### PR TITLE
Add chat image attachments

### DIFF
--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -2,6 +2,7 @@
 import { useRouter } from '#imports'
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import MessageContent from './MessageContent.vue'
+import { useChatAttachments, type DraftAttachment } from '../composables/useChatAttachments'
 import { useChatSession, type SubagentPanelState } from '../composables/useChatSession'
 import { useProjects } from '../composables/useProjects'
 import { useRpc } from '../composables/useRpc'
@@ -19,6 +20,7 @@ import {
   type ItemData,
   type McpToolCallItem
 } from '~~/shared/codex-chat'
+import { buildTurnStartInput } from '~~/shared/chat-attachments'
 import {
   notificationThreadId,
   notificationTurnId,
@@ -50,6 +52,25 @@ const {
   onCompositionEnd,
   shouldSubmit
 } = useChatSubmitGuard()
+const {
+  attachments,
+  isDragging,
+  isUploading,
+  error: attachmentError,
+  fileInput,
+  removeAttachment,
+  replaceAttachments,
+  clearAttachments,
+  discardSnapshot,
+  openFilePicker,
+  onFileInputChange,
+  onPaste,
+  onDragEnter,
+  onDragLeave,
+  onDragOver,
+  onDrop,
+  uploadAttachments
+} = useChatAttachments(props.projectId)
 
 const input = ref('')
 const scrollViewport = ref<HTMLElement | null>(null)
@@ -68,8 +89,13 @@ const {
 } = session
 
 const selectedProject = computed(() => getProject(props.projectId))
-const submitError = computed(() => error.value ? new Error(error.value) : undefined)
-const isBusy = computed(() => status.value === 'submitted' || status.value === 'streaming')
+const composerError = computed(() => attachmentError.value ?? error.value)
+const submitError = computed(() => composerError.value ? new Error(composerError.value) : undefined)
+const isBusy = computed(() =>
+  status.value === 'submitted'
+  || status.value === 'streaming'
+  || isUploading.value
+)
 const routeThreadId = computed(() => props.threadId ?? null)
 const projectTitle = computed(() => selectedProject.value?.projectId ?? props.projectId)
 const showWelcomeState = computed(() =>
@@ -116,6 +142,41 @@ const currentLiveStream = () =>
 const clearLiveStream = () => {
   session.liveStream?.unsubscribe?.()
   session.liveStream = null
+}
+
+const buildOptimisticMessage = (text: string, submittedAttachments: DraftAttachment[]): ChatMessage => ({
+  id: `local-user-${Date.now()}`,
+  role: 'user',
+  parts: [
+    ...(text.trim()
+      ? [{
+          type: 'text' as const,
+          text,
+          state: 'done' as const
+        }]
+      : []),
+    ...submittedAttachments.map((attachment) => ({
+      type: 'attachment' as const,
+      attachment: {
+        kind: 'image' as const,
+        name: attachment.name,
+        mediaType: attachment.mediaType,
+        url: attachment.previewUrl
+      }
+    }))
+  ]
+})
+
+const formatAttachmentSize = (size: number) => {
+  if (size >= 1024 * 1024) {
+    return `${(size / (1024 * 1024)).toFixed(1)} MB`
+  }
+
+  if (size >= 1024) {
+    return `${Math.round(size / 1024)} KB`
+  }
+
+  return `${size} B`
 }
 
 const stripOptimisticDraftMessages = () => {
@@ -1150,34 +1211,25 @@ const applyNotification = (notification: CodexRpcNotification) => {
 
 const sendMessage = async () => {
   const text = input.value.trim()
-  if (!text) {
+  const submittedAttachments = attachments.value.slice()
+
+  if (!text && submittedAttachments.length === 0) {
     return
   }
 
   pinnedToBottom.value = true
   error.value = null
+  attachmentError.value = null
   status.value = 'submitted'
   input.value = ''
-  const shouldRenderOptimisticDraft = !routeThreadId.value
-
-  if (shouldRenderOptimisticDraft) {
-    const optimisticMessage: ChatMessage = {
-      id: `local-user-${Date.now()}`,
-      role: 'user',
-      parts: [{
-        type: 'text',
-        text,
-        state: 'done'
-      }]
-    }
-
-    messages.value = [...messages.value, optimisticMessage]
-  }
+  clearAttachments({ revoke: false })
+  messages.value = [...messages.value, buildOptimisticMessage(text, submittedAttachments)]
   let unsubscribe: (() => void) | null = null
 
   try {
     await ensureProjectRuntime()
     const { threadId, created } = await ensureThread()
+    const uploadedAttachments = await uploadAttachments(threadId, submittedAttachments)
     const client = getClient(props.projectId)
     const buffered: CodexRpcNotification[] = []
     let currentTurnId: string | null = null
@@ -1277,11 +1329,7 @@ const sendMessage = async () => {
 
     const turnStart = await client.request<TurnStartResponse>('turn/start', {
       threadId,
-      input: [{
-        type: 'text',
-        text,
-        text_elements: []
-      }],
+      input: buildTurnStartInput(text, uploadedAttachments),
       cwd: selectedProject.value?.projectPath ?? null,
       approvalPolicy: 'never'
     })
@@ -1296,6 +1344,7 @@ const sendMessage = async () => {
     }
 
     await completion
+    discardSnapshot(submittedAttachments)
     status.value = 'ready'
 
     if (routeThreadId.value) {
@@ -1307,6 +1356,9 @@ const sendMessage = async () => {
     if (session.liveStream?.unsubscribe === unsubscribe) {
       session.liveStream = null
     }
+    stripOptimisticDraftMessages()
+    replaceAttachments(submittedAttachments)
+    input.value = text
     error.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
     status.value = 'error'
   }
@@ -1461,7 +1513,10 @@ watch(status, (nextStatus, previousStatus) => {
         compact
       >
         <template #content="{ message }">
-          <MessageContent :message="message as ChatMessage" />
+          <MessageContent
+            :message="message as ChatMessage"
+            :project-id="projectId"
+          />
         </template>
       </UChatMessages>
     </div>
@@ -1469,30 +1524,108 @@ watch(status, (nextStatus, previousStatus) => {
     <div class="sticky bottom-0 shrink-0 border-t border-default bg-default/95 px-4 py-3 backdrop-blur md:px-6">
       <div class="mx-auto w-full max-w-5xl">
         <TunnelNotice class="mb-3" />
-      <UAlert
-        v-if="error"
-        color="error"
-        variant="soft"
-        icon="i-lucide-circle-alert"
-        :title="error"
-        class="mb-3"
-      />
-
-      <UChatPrompt
-        v-model="input"
-        placeholder="Describe the change you want Codex to make"
-        :error="submitError"
-        :disabled="isBusy"
-        autoresize
-        @submit.prevent="sendMessage"
-        @keydown.enter="onPromptEnter"
-        @compositionstart="onCompositionStart"
-        @compositionend="onCompositionEnd"
-      >
-        <UChatPromptSubmit
-          :status="status"
+        <UAlert
+          v-if="composerError"
+          color="error"
+          variant="soft"
+          icon="i-lucide-circle-alert"
+          :title="composerError"
+          class="mb-3"
         />
-      </UChatPrompt>
+
+        <div
+          class="relative"
+          @dragenter="onDragEnter"
+          @dragleave="onDragLeave"
+          @dragover="onDragOver"
+          @drop="onDrop"
+        >
+          <div
+            v-if="isDragging"
+            class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-3xl border border-dashed border-primary/50 bg-primary/10 text-sm font-medium text-primary backdrop-blur-sm"
+          >
+            Drop images to attach them
+          </div>
+
+          <UChatPrompt
+            v-model="input"
+            placeholder="Describe the change you want Codex to make"
+            :error="submitError"
+            :disabled="isBusy"
+            autoresize
+            @submit.prevent="sendMessage"
+            @keydown.enter="onPromptEnter"
+            @compositionstart="onCompositionStart"
+            @compositionend="onCompositionEnd"
+            @paste="onPaste"
+          >
+            <UChatPromptSubmit
+              :status="status"
+            />
+
+            <template #footer>
+              <div class="flex flex-wrap items-center gap-2 pt-1">
+                <input
+                  ref="fileInput"
+                  type="file"
+                  accept="image/*"
+                  class="hidden"
+                  :disabled="isBusy"
+                  @change="onFileInputChange"
+                >
+                <UButton
+                  type="button"
+                  color="neutral"
+                  variant="soft"
+                  size="sm"
+                  icon="i-lucide-paperclip"
+                  :disabled="isBusy"
+                  @click="openFilePicker"
+                >
+                  Attach image
+                </UButton>
+                <span class="text-xs text-muted">
+                  Drag and drop or paste an image
+                </span>
+              </div>
+
+              <div
+                v-if="attachments.length"
+                class="mt-3 flex flex-wrap gap-2"
+              >
+                <div
+                  v-for="attachment in attachments"
+                  :key="attachment.id"
+                  class="flex max-w-full items-center gap-3 rounded-2xl border border-default bg-elevated/35 px-3 py-2"
+                >
+                  <img
+                    :src="attachment.previewUrl"
+                    :alt="attachment.name"
+                    class="size-10 rounded-xl object-cover"
+                  >
+                  <div class="min-w-0">
+                    <div class="truncate text-sm font-medium text-highlighted">
+                      {{ attachment.name }}
+                    </div>
+                    <div class="text-xs text-muted">
+                      {{ formatAttachmentSize(attachment.size) }}
+                    </div>
+                  </div>
+                  <UButton
+                    type="button"
+                    color="neutral"
+                    variant="ghost"
+                    size="xs"
+                    icon="i-lucide-x"
+                    :disabled="isBusy"
+                    :aria-label="`Remove ${attachment.name}`"
+                    @click="removeAttachment(attachment.id)"
+                  />
+                </div>
+              </div>
+            </template>
+          </UChatPrompt>
+        </div>
       </div>
     </div>
   </section>

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -144,8 +144,13 @@ const clearLiveStream = () => {
   session.liveStream = null
 }
 
+const createOptimisticMessageId = () =>
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? `local-user-${crypto.randomUUID()}`
+    : `local-user-${Date.now()}-${Math.random().toString(16).slice(2)}`
+
 const buildOptimisticMessage = (text: string, submittedAttachments: DraftAttachment[]): ChatMessage => ({
-  id: `local-user-${Date.now()}`,
+  id: createOptimisticMessageId(),
   role: 'user',
   parts: [
     ...(text.trim()

--- a/packages/client/app/components/MessageContent.vue
+++ b/packages/client/app/components/MessageContent.vue
@@ -4,6 +4,7 @@ import type { ChatMessage, ChatPart } from '~~/shared/codex-chat'
 
 defineProps<{
   message?: ChatMessage | null
+  projectId?: string
 }>()
 
 const partKey = (messageId: string | undefined, part: ChatPart, index: number) => {
@@ -21,6 +22,7 @@ const partKey = (messageId: string | undefined, part: ChatPart, index: number) =
       v-for="(part, index) in message?.parts ?? []"
       :key="partKey(message?.id, part, index)"
       :message="message"
+      :project-id="projectId"
       :part="part"
     />
   </div>

--- a/packages/client/app/components/MessagePartRenderer.ts
+++ b/packages/client/app/components/MessagePartRenderer.ts
@@ -1,6 +1,7 @@
 import { defineComponent, h, type PropType } from 'vue'
 import { UChatReasoning } from '#components'
 import { EVENT_PART, ITEM_PART, type ChatMessage, type ChatPart } from '~~/shared/codex-chat'
+import MessagePartAttachment from './message-part/Attachment.vue'
 import MessagePartEvent from './message-part/Event.vue'
 import MessagePartItem from './message-part/Item'
 import MessagePartText from './message-part/Text.vue'
@@ -11,6 +12,10 @@ export default defineComponent({
     message: {
       type: Object as PropType<ChatMessage | null>,
       default: null
+    },
+    projectId: {
+      type: String as PropType<string | undefined>,
+      default: undefined
     },
     part: {
       type: Object as PropType<ChatPart | null>,
@@ -36,6 +41,11 @@ export default defineComponent({
             streaming: props.part.state === 'streaming',
             defaultOpen: props.part.state === 'streaming',
             autoCloseDelay: 600
+          })
+        case 'attachment':
+          return h(MessagePartAttachment, {
+            projectId: props.projectId,
+            part: props.part
           })
         case EVENT_PART:
           return h(MessagePartEvent, {

--- a/packages/client/app/components/message-part/Attachment.vue
+++ b/packages/client/app/components/message-part/Attachment.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRuntimeConfig } from '#imports'
+import { resolveAttachmentPreviewUrl } from '~~/shared/chat-attachments'
+
+const props = defineProps<{
+  projectId?: string
+  part?: {
+    type: 'attachment'
+    attachment: {
+      kind: 'image'
+      name: string
+      mediaType: string
+      url?: string | null
+      localPath?: string | null
+    }
+  } | null
+}>()
+
+const runtimeConfig = useRuntimeConfig()
+
+const previewUrl = computed(() => {
+  const attachment = props.part?.attachment
+  if (!attachment) {
+    return null
+  }
+
+  if (attachment.url) {
+    return attachment.url
+  }
+
+  if (!attachment.localPath || !props.projectId) {
+    return null
+  }
+
+  return resolveAttachmentPreviewUrl({
+    projectId: props.projectId,
+    path: attachment.localPath,
+    mediaType: attachment.mediaType,
+    configuredBase: String(runtimeConfig.public.serverBase ?? '')
+  })
+})
+</script>
+
+<template>
+  <div class="overflow-hidden rounded-2xl border border-default bg-elevated/30">
+    <img
+      v-if="previewUrl"
+      :src="previewUrl"
+      :alt="part?.attachment.name"
+      class="max-h-80 w-full object-cover"
+      loading="lazy"
+    >
+    <div class="flex items-center gap-3 px-3 py-2 text-sm text-toned">
+      <UIcon
+        name="i-lucide-image"
+        class="size-4 text-primary"
+      />
+      <span class="truncate">{{ part?.attachment.name }}</span>
+    </div>
+  </div>
+</template>

--- a/packages/client/app/components/message-part/Attachment.vue
+++ b/packages/client/app/components/message-part/Attachment.vue
@@ -36,7 +36,6 @@ const previewUrl = computed(() => {
   return resolveAttachmentPreviewUrl({
     projectId: props.projectId,
     path: attachment.localPath,
-    mediaType: attachment.mediaType,
     configuredBase: String(runtimeConfig.public.serverBase ?? '')
   })
 })

--- a/packages/client/app/composables/useChatAttachments.ts
+++ b/packages/client/app/composables/useChatAttachments.ts
@@ -2,13 +2,10 @@ import { ref } from 'vue'
 import { useRuntimeConfig } from '#imports'
 import { $fetch } from 'ofetch'
 import {
-  resolveApiUrl
-} from '~~/shared/network'
-import {
+  resolveAttachmentUploadUrl,
   type ProjectAttachmentUploadResponse,
   validateAttachmentSelection
 } from '~~/shared/chat-attachments'
-import { encodeProjectIdSegment } from '~~/shared/codori'
 
 export type DraftAttachment = {
   id: string
@@ -172,10 +169,10 @@ export const useChatAttachments = (projectId: string) => {
     isUploading.value = true
     try {
       const response = await $fetch<ProjectAttachmentUploadResponse>(
-        resolveApiUrl(
-          `/projects/${encodeProjectIdSegment(projectId)}/attachments`,
-          String(runtimeConfig.public.serverBase ?? '')
-        ),
+        resolveAttachmentUploadUrl({
+          projectId,
+          configuredBase: String(runtimeConfig.public.serverBase ?? '')
+        }),
         {
           method: 'POST',
           body: formData

--- a/packages/client/app/composables/useChatAttachments.ts
+++ b/packages/client/app/composables/useChatAttachments.ts
@@ -1,0 +1,211 @@
+import { ref } from 'vue'
+import { useRuntimeConfig } from '#imports'
+import { $fetch } from 'ofetch'
+import {
+  resolveApiUrl
+} from '~~/shared/network'
+import {
+  type ProjectAttachmentUploadResponse,
+  validateAttachmentSelection
+} from '~~/shared/chat-attachments'
+import { encodeProjectIdSegment } from '~~/shared/codori'
+
+export type DraftAttachment = {
+  id: string
+  file: File
+  name: string
+  size: number
+  mediaType: string
+  previewUrl: string
+}
+
+const createAttachmentId = () =>
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`
+
+export const useChatAttachments = (projectId: string) => {
+  const runtimeConfig = useRuntimeConfig()
+  const attachments = ref<DraftAttachment[]>([])
+  const isDragging = ref(false)
+  const isUploading = ref(false)
+  const error = ref<string | null>(null)
+  const fileInput = ref<HTMLInputElement | null>(null)
+  const dragDepth = ref(0)
+
+  const revokePreviewUrl = (attachment: Pick<DraftAttachment, 'previewUrl'>) => {
+    if (import.meta.client) {
+      URL.revokeObjectURL(attachment.previewUrl)
+    }
+  }
+
+  const addFiles = (fileList?: FileList | File[] | null) => {
+    const files = Array.from(fileList ?? [])
+    if (!files.length) {
+      return
+    }
+
+    const { accepted, issues } = validateAttachmentSelection(files, attachments.value.length)
+    error.value = issues[0]?.message ?? null
+
+    if (!accepted.length) {
+      return
+    }
+
+    attachments.value = [
+      ...attachments.value,
+      ...accepted.map(file => ({
+        id: createAttachmentId(),
+        file,
+        name: file.name,
+        size: file.size,
+        mediaType: file.type || 'application/octet-stream',
+        previewUrl: URL.createObjectURL(file)
+      }))
+    ]
+  }
+
+  const removeAttachment = (id: string) => {
+    const existing = attachments.value.find(attachment => attachment.id === id)
+    if (existing) {
+      revokePreviewUrl(existing)
+    }
+    attachments.value = attachments.value.filter(attachment => attachment.id !== id)
+    if (!attachments.value.length) {
+      error.value = null
+    }
+  }
+
+  const replaceAttachments = (next: DraftAttachment[]) => {
+    attachments.value = next
+  }
+
+  const clearAttachments = (options: { revoke?: boolean } = {}) => {
+    if (options.revoke !== false) {
+      for (const attachment of attachments.value) {
+        revokePreviewUrl(attachment)
+      }
+    }
+
+    attachments.value = []
+    error.value = null
+  }
+
+  const discardSnapshot = (snapshot: DraftAttachment[]) => {
+    for (const attachment of snapshot) {
+      revokePreviewUrl(attachment)
+    }
+  }
+
+  const openFilePicker = () => {
+    fileInput.value?.click()
+  }
+
+  const onFileInputChange = (event: Event) => {
+    const target = event.target as HTMLInputElement | null
+    addFiles(target?.files ?? null)
+    if (target) {
+      target.value = ''
+    }
+  }
+
+  const onPaste = (event: ClipboardEvent) => {
+    const files = Array.from(event.clipboardData?.items ?? [])
+      .filter(item => item.kind === 'file')
+      .map(item => item.getAsFile())
+      .filter((file): file is File => Boolean(file))
+
+    if (!files.length) {
+      return
+    }
+
+    event.preventDefault()
+    addFiles(files)
+  }
+
+  const onDragEnter = (event: DragEvent) => {
+    if (!event.dataTransfer?.types.includes('Files')) {
+      return
+    }
+
+    event.preventDefault()
+    dragDepth.value += 1
+    isDragging.value = true
+  }
+
+  const onDragOver = (event: DragEvent) => {
+    if (!event.dataTransfer?.types.includes('Files')) {
+      return
+    }
+
+    event.preventDefault()
+  }
+
+  const onDragLeave = () => {
+    dragDepth.value = Math.max(0, dragDepth.value - 1)
+    if (dragDepth.value === 0) {
+      isDragging.value = false
+    }
+  }
+
+  const onDrop = (event: DragEvent) => {
+    event.preventDefault()
+    addFiles(event.dataTransfer?.files ?? null)
+    dragDepth.value = 0
+    isDragging.value = false
+  }
+
+  const uploadAttachments = async (
+    threadId: string,
+    selectedAttachments: DraftAttachment[]
+  ) => {
+    if (!selectedAttachments.length) {
+      return []
+    }
+
+    const formData = new FormData()
+    formData.append('threadId', threadId)
+    for (const attachment of selectedAttachments) {
+      formData.append('file', attachment.file, attachment.name)
+    }
+
+    isUploading.value = true
+    try {
+      const response = await $fetch<ProjectAttachmentUploadResponse>(
+        resolveApiUrl(
+          `/projects/${encodeProjectIdSegment(projectId)}/attachments`,
+          String(runtimeConfig.public.serverBase ?? '')
+        ),
+        {
+          method: 'POST',
+          body: formData
+        }
+      )
+
+      return response.files
+    } finally {
+      isUploading.value = false
+    }
+  }
+
+  return {
+    attachments,
+    isDragging,
+    isUploading,
+    error,
+    fileInput,
+    addFiles,
+    removeAttachment,
+    replaceAttachments,
+    clearAttachments,
+    discardSnapshot,
+    openFilePicker,
+    onFileInputChange,
+    onPaste,
+    onDragEnter,
+    onDragLeave,
+    onDragOver,
+    onDrop,
+    uploadAttachments
+  }
+}

--- a/packages/client/server/api/codori/projects/[projectId]/attachments.post.ts
+++ b/packages/client/server/api/codori/projects/[projectId]/attachments.post.ts
@@ -1,0 +1,53 @@
+import {
+  createError,
+  defineEventHandler,
+  getRequestHeader,
+  getRouterParam,
+  setResponseStatus
+} from 'h3'
+import { encodeProjectIdSegment } from '~~/shared/codori'
+import { proxyServerFetch } from '../../../../utils/server-proxy'
+
+export default defineEventHandler(async (event) => {
+  const projectId = getRouterParam(event, 'projectId')
+  if (!projectId) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Missing project id.'
+    })
+  }
+
+  const contentType = getRequestHeader(event, 'content-type')
+  if (!contentType) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Missing content type.'
+    })
+  }
+
+  const response = await proxyServerFetch(
+    event,
+    `/api/projects/${encodeProjectIdSegment(projectId)}/attachments`,
+    {
+      method: 'POST',
+      headers: {
+        'content-type': contentType
+      },
+      body: event.node.req as unknown as BodyInit
+    }
+  )
+
+  const body = await response.json()
+  setResponseStatus(event, response.status)
+
+  if (!response.ok) {
+    const errorBody = body as { error?: { message?: string } }
+    throw createError({
+      statusCode: response.status,
+      statusMessage: errorBody.error?.message ?? 'Attachment upload failed.',
+      data: body
+    })
+  }
+
+  return body
+})

--- a/packages/client/server/api/codori/projects/[projectId]/attachments/file.get.ts
+++ b/packages/client/server/api/codori/projects/[projectId]/attachments/file.get.ts
@@ -1,0 +1,62 @@
+import {
+  createError,
+  defineEventHandler,
+  getQuery,
+  getRouterParam
+} from 'h3'
+import { encodeProjectIdSegment } from '~~/shared/codori'
+import { proxyServerFetch } from '../../../../../utils/server-proxy'
+
+export default defineEventHandler(async (event) => {
+  const projectId = getRouterParam(event, 'projectId')
+  if (!projectId) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Missing project id.'
+    })
+  }
+
+  const queryValue = getQuery(event).path
+  const path = typeof queryValue === 'string'
+    ? queryValue
+    : ''
+
+  if (!path) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Missing attachment path.'
+    })
+  }
+
+  const query = new URLSearchParams()
+  query.set('path', path)
+  const response = await proxyServerFetch(
+    event,
+    `/api/projects/${encodeProjectIdSegment(projectId)}/attachments/file?${query.toString()}`
+  )
+
+  if (!response.ok) {
+    let statusMessage = 'Attachment preview failed.'
+    try {
+      const body = await response.json() as { error?: { message?: string } }
+      statusMessage = body.error?.message ?? statusMessage
+    } catch {
+      // Ignore parse failures and fall back to the default message.
+    }
+
+    throw createError({
+      statusCode: response.status,
+      statusMessage
+    })
+  }
+
+  const headers = new Headers()
+  for (const [key, value] of response.headers.entries()) {
+    headers.set(key, value)
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    headers
+  })
+})

--- a/packages/client/server/utils/server-proxy.ts
+++ b/packages/client/server/utils/server-proxy.ts
@@ -23,3 +23,26 @@ export const proxyServerRequest = async <T>(
     body: options.body as BodyInit | Record<string, unknown> | undefined
   })
 }
+
+export const proxyServerFetch = async (
+  event: H3Event,
+  path: string,
+  options: {
+    method?: 'GET' | 'POST'
+    headers?: HeadersInit
+    body?: BodyInit | null
+  } = {}
+) => {
+  const baseURL = getServerBase(event)
+  const requestInit: RequestInit & { duplex?: 'half' } = {
+    method: options.method,
+    headers: options.headers,
+    body: options.body ?? null
+  }
+
+  if (options.body) {
+    requestInit.duplex = 'half'
+  }
+
+  return await fetch(`${baseURL}${path}`, requestInit)
+}

--- a/packages/client/shared/chat-attachments.ts
+++ b/packages/client/shared/chat-attachments.ts
@@ -1,6 +1,6 @@
 import type { CodexUserInput } from './codex-rpc'
 import { encodeProjectIdSegment } from './codori'
-import { resolveApiUrl } from './network'
+import { resolveApiUrl, shouldUseServerProxy } from './network'
 
 export const MAX_ATTACHMENTS_PER_MESSAGE = 8
 export const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024
@@ -109,9 +109,27 @@ export const resolveAttachmentPreviewUrl = (input: {
   const query = new URLSearchParams({
     path: input.path
   })
+  const requestPath = `/projects/${encodeProjectIdSegment(input.projectId)}/attachments/file?${query.toString()}`
+
+  if (shouldUseServerProxy(input.configuredBase)) {
+    return `/api/codori${requestPath}`
+  }
 
   return resolveApiUrl(
-    `/projects/${encodeProjectIdSegment(input.projectId)}/attachments/file?${query.toString()}`,
+    requestPath,
     input.configuredBase
   )
+}
+
+export const resolveAttachmentUploadUrl = (input: {
+  projectId: string
+  configuredBase?: string | null
+}) => {
+  const requestPath = `/projects/${encodeProjectIdSegment(input.projectId)}/attachments`
+
+  if (shouldUseServerProxy(input.configuredBase)) {
+    return `/api/codori${requestPath}`
+  }
+
+  return resolveApiUrl(requestPath, input.configuredBase)
 }

--- a/packages/client/shared/chat-attachments.ts
+++ b/packages/client/shared/chat-attachments.ts
@@ -104,16 +104,11 @@ export const buildTurnStartInput = (
 export const resolveAttachmentPreviewUrl = (input: {
   projectId: string
   path: string
-  mediaType?: string | null
   configuredBase?: string | null
 }) => {
   const query = new URLSearchParams({
     path: input.path
   })
-
-  if (input.mediaType) {
-    query.set('mediaType', input.mediaType)
-  }
 
   return resolveApiUrl(
     `/projects/${encodeProjectIdSegment(input.projectId)}/attachments/file?${query.toString()}`,

--- a/packages/client/shared/chat-attachments.ts
+++ b/packages/client/shared/chat-attachments.ts
@@ -1,0 +1,122 @@
+import type { CodexUserInput } from './codex-rpc'
+import { encodeProjectIdSegment } from './codori'
+import { resolveApiUrl } from './network'
+
+export const MAX_ATTACHMENTS_PER_MESSAGE = 8
+export const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024
+
+export type FileLike = {
+  name: string
+  size: number
+  type: string
+}
+
+export type AttachmentValidationIssue = {
+  code: 'tooMany' | 'unsupportedType' | 'tooLarge'
+  fileName: string
+  message: string
+}
+
+export type PersistedProjectAttachment = {
+  filename: string
+  mediaType: string | null
+  path: string
+}
+
+export type ProjectAttachmentUploadResponse = {
+  threadId: string
+  files: PersistedProjectAttachment[]
+}
+
+export const isSupportedAttachmentType = (mediaType: string) =>
+  mediaType.toLowerCase().startsWith('image/')
+
+export const validateAttachmentSelection = <T extends FileLike>(
+  files: T[],
+  existingCount: number
+) => {
+  const issues: AttachmentValidationIssue[] = []
+  const accepted: T[] = []
+
+  for (const file of files) {
+    if (existingCount + accepted.length >= MAX_ATTACHMENTS_PER_MESSAGE) {
+      issues.push({
+        code: 'tooMany',
+        fileName: file.name,
+        message: `You can attach up to ${MAX_ATTACHMENTS_PER_MESSAGE} images per message.`
+      })
+      continue
+    }
+
+    const mediaType = file.type || 'application/octet-stream'
+    if (!isSupportedAttachmentType(mediaType)) {
+      issues.push({
+        code: 'unsupportedType',
+        fileName: file.name,
+        message: 'Only image attachments are currently supported.'
+      })
+      continue
+    }
+
+    if (file.size > MAX_ATTACHMENT_BYTES) {
+      issues.push({
+        code: 'tooLarge',
+        fileName: file.name,
+        message: `Each image must be ${Math.floor(MAX_ATTACHMENT_BYTES / (1024 * 1024))} MB or smaller.`
+      })
+      continue
+    }
+
+    accepted.push(file)
+  }
+
+  return {
+    accepted,
+    issues
+  }
+}
+
+export const buildTurnStartInput = (
+  text: string,
+  attachments: Array<{ path: string }>
+): CodexUserInput[] => {
+  const input: CodexUserInput[] = []
+  const trimmedText = text.trim()
+
+  if (trimmedText) {
+    input.push({
+      type: 'text',
+      text: trimmedText,
+      text_elements: []
+    })
+  }
+
+  for (const attachment of attachments) {
+    input.push({
+      type: 'localImage',
+      path: attachment.path
+    })
+  }
+
+  return input
+}
+
+export const resolveAttachmentPreviewUrl = (input: {
+  projectId: string
+  path: string
+  mediaType?: string | null
+  configuredBase?: string | null
+}) => {
+  const query = new URLSearchParams({
+    path: input.path
+  })
+
+  if (input.mediaType) {
+    query.set('mediaType', input.mediaType)
+  }
+
+  return resolveApiUrl(
+    `/projects/${encodeProjectIdSegment(input.projectId)}/attachments/file?${query.toString()}`,
+    input.configuredBase
+  )
+}

--- a/packages/client/shared/codex-chat.ts
+++ b/packages/client/shared/codex-chat.ts
@@ -101,6 +101,16 @@ export type ChatPart =
       state?: 'done' | 'streaming'
     }
   | {
+      type: 'attachment'
+      attachment: {
+        kind: 'image'
+        name: string
+        mediaType: string
+        url?: string | null
+        localPath?: string | null
+      }
+    }
+  | {
       type: 'reasoning'
       summary: string[]
       content: string[]
@@ -125,15 +135,31 @@ export type ChatMessage = {
 export const isSubagentActiveStatus = (status: SubagentAgentStatus) =>
   status === null || status === 'pendingInit' || status === 'running'
 
-const formatUserInput = (input: CodexUserInput) => {
+const streamingState = (pending?: boolean) => pending ? 'streaming' : 'done'
+
+const userInputToParts = (input: CodexUserInput): ChatPart[] => {
   if (input.type === 'text') {
-    return input.text
+    if (!input.text.trim()) {
+      return []
+    }
+
+    return [{
+      type: 'text',
+      text: input.text,
+      state: 'done'
+    }]
   }
 
-  return `[local image] ${input.path}`
+  return [{
+    type: 'attachment',
+    attachment: {
+      kind: 'image',
+      name: input.path.split(/[\\/]/).pop() || 'image',
+      mediaType: 'image/*',
+      localPath: input.path
+    }
+  }]
 }
-
-const streamingState = (pending?: boolean) => pending ? 'streaming' : 'done'
 
 export const itemToMessages = (item: CodexThreadItem): ChatMessage[] => {
   switch (item.type) {
@@ -141,11 +167,7 @@ export const itemToMessages = (item: CodexThreadItem): ChatMessage[] => {
       return [{
         id: item.id,
         role: 'user',
-        parts: [{
-          type: 'text',
-          text: item.content.map(formatUserInput).join('\n').trim(),
-          state: 'done'
-        }]
+        parts: item.content.flatMap(userInputToParts)
       }]
     case 'agentMessage':
       return [{

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import { ITEM_PART, isSubagentActiveStatus, itemToMessages } from '../shared/codex-chat'
 import {
   buildTurnStartInput,
+  resolveAttachmentPreviewUrl,
+  resolveAttachmentUploadUrl,
   validateAttachmentSelection
 } from '../shared/chat-attachments'
 import {
@@ -72,6 +74,32 @@ describe('client package', () => {
       type: 'localImage',
       path: '/tmp/screenshot.png'
     }])
+  })
+
+  it('routes attachment requests through the Nuxt proxy in standalone client mode', () => {
+    expect(resolveAttachmentUploadUrl({
+      projectId: 'team/api',
+      configuredBase: 'https://codori.example.com'
+    })).toBe('/api/codori/projects/team%2Fapi/attachments')
+
+    expect(resolveAttachmentPreviewUrl({
+      projectId: 'team/api',
+      path: '/tmp/screenshot.png',
+      configuredBase: 'https://codori.example.com'
+    })).toBe('/api/codori/projects/team%2Fapi/attachments/file?path=%2Ftmp%2Fscreenshot.png')
+  })
+
+  it('keeps direct attachment requests when bundled with the codori server', () => {
+    expect(resolveAttachmentUploadUrl({
+      projectId: 'team/api',
+      configuredBase: ''
+    })).toBe('http://127.0.0.1:4310/api/projects/team%2Fapi/attachments')
+
+    expect(resolveAttachmentPreviewUrl({
+      projectId: 'team/api',
+      path: '/tmp/screenshot.png',
+      configuredBase: ''
+    })).toBe('http://127.0.0.1:4310/api/projects/team%2Fapi/attachments/file?path=%2Ftmp%2Fscreenshot.png')
   })
 
   it('validates attachment selections before submit', () => {

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { ITEM_PART, isSubagentActiveStatus, itemToMessages } from '../shared/codex-chat'
 import {
+  buildTurnStartInput,
+  validateAttachmentSelection
+} from '../shared/chat-attachments'
+import {
   encodeProjectIdSegment,
   normalizeProjectIdParam,
   projectStatusMeta,
@@ -44,6 +48,85 @@ describe('client package', () => {
         type: 'text',
         text: 'Working on it',
         state: 'done'
+      }]
+    }])
+  })
+
+  it('builds turn input for text with image attachments', () => {
+    expect(buildTurnStartInput('Investigate this UI bug', [
+      { path: '/tmp/screenshot.png' }
+    ])).toEqual([
+      {
+        type: 'text',
+        text: 'Investigate this UI bug',
+        text_elements: []
+      },
+      {
+        type: 'localImage',
+        path: '/tmp/screenshot.png'
+      }
+    ])
+    expect(buildTurnStartInput('', [
+      { path: '/tmp/screenshot.png' }
+    ])).toEqual([{
+      type: 'localImage',
+      path: '/tmp/screenshot.png'
+    }])
+  })
+
+  it('validates attachment selections before submit', () => {
+    const result = validateAttachmentSelection([
+      {
+        name: 'diagram.png',
+        size: 10,
+        type: 'image/png'
+      },
+      {
+        name: 'notes.txt',
+        size: 10,
+        type: 'text/plain'
+      }
+    ], 0)
+
+    expect(result.accepted).toEqual([{
+      name: 'diagram.png',
+      size: 10,
+      type: 'image/png'
+    }])
+    expect(result.issues).toEqual([{
+      code: 'unsupportedType',
+      fileName: 'notes.txt',
+      message: 'Only image attachments are currently supported.'
+    }])
+  })
+
+  it('renders local image user inputs as attachment parts', () => {
+    expect(itemToMessages({
+      type: 'userMessage',
+      id: 'user-1',
+      content: [{
+        type: 'text',
+        text: 'Please inspect this screenshot.',
+        text_elements: []
+      }, {
+        type: 'localImage',
+        path: '/tmp/screenshot.png'
+      }]
+    })).toEqual([{
+      id: 'user-1',
+      role: 'user',
+      parts: [{
+        type: 'text',
+        text: 'Please inspect this screenshot.',
+        state: 'done'
+      }, {
+        type: 'attachment',
+        attachment: {
+          kind: 'image',
+          name: 'screenshot.png',
+          mediaType: 'image/*',
+          localPath: '/tmp/screenshot.png'
+        }
       }]
     }])
   })

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -41,6 +41,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@fastify/multipart": "^10.0.0",
     "@fastify/static": "^9.1.0",
     "@fastify/websocket": "^11.2.0",
     "fastify": "^5.6.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -45,6 +45,10 @@
     "@fastify/static": "^9.1.0",
     "@fastify/websocket": "^11.2.0",
     "fastify": "^5.6.1",
+    "mime-types": "^3.0.2",
     "ws": "^8.18.3"
+  },
+  "devDependencies": {
+    "@types/mime-types": "^3.0.1"
   }
 }

--- a/packages/server/src/attachment-store.ts
+++ b/packages/server/src/attachment-store.ts
@@ -1,6 +1,5 @@
 import { createHash } from 'node:crypto'
-import { createWriteStream } from 'node:fs'
-import { access, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { open, readFile, writeFile, mkdir } from 'node:fs/promises'
 import os from 'node:os'
 import { pipeline } from 'node:stream/promises'
 import { basename, extname, isAbsolute, join, relative, resolve } from 'node:path'
@@ -24,27 +23,10 @@ const sanitizeFilename = (value: string) => {
   return normalized || 'attachment'
 }
 
-const pathExists = async (value: string) => {
-  try {
-    await access(value)
-    return true
-  } catch {
-    return false
-  }
-}
-
-const ensureUniqueFilePath = async (directory: string, filename: string) => {
+const createFileNameCandidate = (directory: string, filename: string, index: number) => {
   const extension = extname(filename)
   const base = extension ? filename.slice(0, -extension.length) : filename
-  let candidate = join(directory, filename)
-  let index = 1
-
-  while (await pathExists(candidate)) {
-    candidate = join(directory, `${base}-${index}${extension}`)
-    index += 1
-  }
-
-  return candidate
+  return join(directory, index === 0 ? filename : `${base}-${index}${extension}`)
 }
 
 const attachmentMetadataPath = (filePath: string) => `${filePath}.metadata.json`
@@ -106,7 +88,26 @@ export const createThreadAttachmentTarget = async (input: {
   const directory = resolveThreadAttachmentsDir(input.projectPath, input.threadId, input.rootDir)
   await mkdir(directory, { recursive: true })
   const filename = sanitizeFilename(input.filename)
-  return await ensureUniqueFilePath(directory, filename)
+
+  for (let index = 0; index < 10_000; index += 1) {
+    const candidate = createFileNameCandidate(directory, filename, index)
+
+    try {
+      const handle = await open(candidate, 'wx')
+      return {
+        filePath: candidate,
+        handle
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+        continue
+      }
+
+      throw error
+    }
+  }
+
+  throw new Error(`Failed to allocate a unique attachment path for ${filename}.`)
 }
 
 export const persistThreadAttachmentStream = async (input: {
@@ -117,15 +118,20 @@ export const persistThreadAttachmentStream = async (input: {
   stream: NodeJS.ReadableStream
   rootDir?: string | null
 }): Promise<PersistedAttachment> => {
-  const filePath = await createThreadAttachmentTarget(input)
-  await pipeline(input.stream, createWriteStream(filePath))
-  await writeAttachmentMetadata(filePath, {
-    mediaType: input.mediaType
-  })
+  const target = await createThreadAttachmentTarget(input)
 
-  return {
-    filename: basename(filePath),
-    mediaType: input.mediaType,
-    path: filePath
+  try {
+    await pipeline(input.stream, target.handle.createWriteStream())
+    await writeAttachmentMetadata(target.filePath, {
+      mediaType: input.mediaType
+    })
+
+    return {
+      filename: basename(target.filePath),
+      mediaType: input.mediaType,
+      path: target.filePath
+    }
+  } finally {
+    await target.handle.close().catch(() => {})
   }
 }

--- a/packages/server/src/attachment-store.ts
+++ b/packages/server/src/attachment-store.ts
@@ -1,0 +1,91 @@
+import { createHash } from 'node:crypto'
+import { access, mkdir, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import { basename, extname, isAbsolute, join, relative, resolve } from 'node:path'
+import { resolveCodoriHome } from './config.js'
+
+export type PersistedAttachment = {
+  filename: string
+  mediaType: string | null
+  path: string
+}
+
+type AttachmentFileInput = {
+  filename: string
+  mediaType: string | null
+  data: Buffer
+}
+
+const hashSegment = (value: string) =>
+  createHash('sha256').update(value).digest('hex').slice(0, 16)
+
+const sanitizeFilename = (value: string) => {
+  const normalized = basename(value).trim()
+  return normalized || 'attachment'
+}
+
+const pathExists = async (value: string) => {
+  try {
+    await access(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const ensureUniqueFilePath = async (directory: string, filename: string) => {
+  const extension = extname(filename)
+  const base = extension ? filename.slice(0, -extension.length) : filename
+  let candidate = join(directory, filename)
+  let index = 1
+
+  while (await pathExists(candidate)) {
+    candidate = join(directory, `${base}-${index}${extension}`)
+    index += 1
+  }
+
+  return candidate
+}
+
+export const resolveAttachmentsRootDir = (rootDir?: string | null) =>
+  resolve(rootDir ?? join(resolveCodoriHome(os.homedir()), 'attachments'))
+
+export const resolveProjectAttachmentsDir = (
+  projectPath: string,
+  rootDir?: string | null
+) => join(resolveAttachmentsRootDir(rootDir), hashSegment(projectPath))
+
+export const resolveThreadAttachmentsDir = (
+  projectPath: string,
+  threadId: string,
+  rootDir?: string | null
+) => join(resolveProjectAttachmentsDir(projectPath, rootDir), hashSegment(threadId))
+
+export const isPathInsideDirectory = (targetPath: string, directory: string) => {
+  const relativePath = relative(directory, targetPath)
+  return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath))
+}
+
+export const persistThreadAttachments = async (input: {
+  projectPath: string
+  threadId: string
+  files: AttachmentFileInput[]
+  rootDir?: string | null
+}): Promise<PersistedAttachment[]> => {
+  const directory = resolveThreadAttachmentsDir(input.projectPath, input.threadId, input.rootDir)
+  await mkdir(directory, { recursive: true })
+
+  const persisted: PersistedAttachment[] = []
+  for (const file of input.files) {
+    const filename = sanitizeFilename(file.filename)
+    const filePath = await ensureUniqueFilePath(directory, filename)
+    await writeFile(filePath, file.data)
+    persisted.push({
+      filename: basename(filePath),
+      mediaType: file.mediaType,
+      path: filePath
+    })
+  }
+
+  return persisted
+}

--- a/packages/server/src/attachment-store.ts
+++ b/packages/server/src/attachment-store.ts
@@ -1,6 +1,8 @@
 import { createHash } from 'node:crypto'
-import { access, mkdir, writeFile } from 'node:fs/promises'
+import { createWriteStream } from 'node:fs'
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises'
 import os from 'node:os'
+import { pipeline } from 'node:stream/promises'
 import { basename, extname, isAbsolute, join, relative, resolve } from 'node:path'
 import { resolveCodoriHome } from './config.js'
 
@@ -10,10 +12,8 @@ export type PersistedAttachment = {
   path: string
 }
 
-type AttachmentFileInput = {
-  filename: string
+type AttachmentMetadata = {
   mediaType: string | null
-  data: Buffer
 }
 
 const hashSegment = (value: string) =>
@@ -47,6 +47,8 @@ const ensureUniqueFilePath = async (directory: string, filename: string) => {
   return candidate
 }
 
+const attachmentMetadataPath = (filePath: string) => `${filePath}.metadata.json`
+
 export const resolveAttachmentsRootDir = (rootDir?: string | null) =>
   resolve(rootDir ?? join(resolveCodoriHome(os.homedir()), 'attachments'))
 
@@ -66,26 +68,64 @@ export const isPathInsideDirectory = (targetPath: string, directory: string) => 
   return relativePath === '' || (!relativePath.startsWith('..') && !isAbsolute(relativePath))
 }
 
-export const persistThreadAttachments = async (input: {
+export const writeAttachmentMetadata = async (filePath: string, metadata: AttachmentMetadata) => {
+  await writeFile(
+    attachmentMetadataPath(filePath),
+    `${JSON.stringify(metadata, null, 2)}\n`,
+    'utf8'
+  )
+}
+
+export const readAttachmentMetadata = async (filePath: string): Promise<AttachmentMetadata | null> => {
+  try {
+    const source = await readFile(attachmentMetadataPath(filePath), 'utf8')
+    const parsed: unknown = JSON.parse(source)
+    if (
+      typeof parsed === 'object'
+      && parsed !== null
+      && 'mediaType' in parsed
+      && (typeof parsed.mediaType === 'string' || parsed.mediaType === null)
+    ) {
+      return {
+        mediaType: parsed.mediaType
+      }
+    }
+
+    return null
+  } catch {
+    return null
+  }
+}
+
+export const createThreadAttachmentTarget = async (input: {
   projectPath: string
   threadId: string
-  files: AttachmentFileInput[]
+  filename: string
   rootDir?: string | null
-}): Promise<PersistedAttachment[]> => {
+}) => {
   const directory = resolveThreadAttachmentsDir(input.projectPath, input.threadId, input.rootDir)
   await mkdir(directory, { recursive: true })
+  const filename = sanitizeFilename(input.filename)
+  return await ensureUniqueFilePath(directory, filename)
+}
 
-  const persisted: PersistedAttachment[] = []
-  for (const file of input.files) {
-    const filename = sanitizeFilename(file.filename)
-    const filePath = await ensureUniqueFilePath(directory, filename)
-    await writeFile(filePath, file.data)
-    persisted.push({
-      filename: basename(filePath),
-      mediaType: file.mediaType,
-      path: filePath
-    })
+export const persistThreadAttachmentStream = async (input: {
+  projectPath: string
+  threadId: string
+  filename: string
+  mediaType: string | null
+  stream: NodeJS.ReadableStream
+  rootDir?: string | null
+}): Promise<PersistedAttachment> => {
+  const filePath = await createThreadAttachmentTarget(input)
+  await pipeline(input.stream, createWriteStream(filePath))
+  await writeAttachmentMetadata(filePath, {
+    mediaType: input.mediaType
+  })
+
+  return {
+    filename: basename(filePath),
+    mediaType: input.mediaType,
+    path: filePath
   }
-
-  return persisted
 }

--- a/packages/server/src/http-server.ts
+++ b/packages/server/src/http-server.ts
@@ -114,6 +114,10 @@ const normalizeImageMediaType = (input: { filename: string, declaredMediaType: s
     return declared
   }
 
+  if (declared) {
+    return null
+  }
+
   const inferred = lookupMimeType(input.filename)
   if (typeof inferred === 'string' && inferred.toLowerCase().startsWith('image/')) {
     return inferred.toLowerCase()

--- a/packages/server/src/http-server.ts
+++ b/packages/server/src/http-server.ts
@@ -11,10 +11,13 @@ import Fastify, {
   type FastifyReply,
   type FastifyRequest
 } from 'fastify'
+import { lookup as lookupMimeType } from 'mime-types'
 import WebSocket from 'ws'
 import {
   isPathInsideDirectory,
-  persistThreadAttachments,
+  persistThreadAttachmentStream,
+  type PersistedAttachment,
+  readAttachmentMetadata,
   resolveProjectAttachmentsDir
 } from './attachment-store.js'
 import { CodoriError } from './errors.js'
@@ -72,6 +75,9 @@ const toRequestPath = (url: string) => url.split('?')[0]?.split('#')[0] ?? url
 const isAssetRequest = (pathname: string) =>
   /\.[a-z0-9]+$/i.test(pathname)
 
+const MAX_ATTACHMENTS_PER_MESSAGE = 8
+const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024
+
 const toStatusCode = (error: CodoriError) => {
   switch (error.code) {
     case 'PROJECT_NOT_FOUND':
@@ -95,6 +101,26 @@ const getProjectIdFromRequest = (value: string | undefined) => {
 }
 
 const resolveValue = async <T>(value: MaybePromise<T>) => value
+
+const isStatusCodeCarrier = (error: unknown): error is { statusCode: number, message?: string, code?: string } =>
+  typeof error === 'object'
+  && error !== null
+  && 'statusCode' in error
+  && typeof (error as { statusCode?: unknown }).statusCode === 'number'
+
+const normalizeImageMediaType = (input: { filename: string, declaredMediaType: string | null }) => {
+  const declared = input.declaredMediaType?.trim().toLowerCase() ?? null
+  if (declared?.startsWith('image/')) {
+    return declared
+  }
+
+  const inferred = lookupMimeType(input.filename)
+  if (typeof inferred === 'string' && inferred.toLowerCase().startsWith('image/')) {
+    return inferred.toLowerCase()
+  }
+
+  return null
+}
 
 const wait = async (ms: number) =>
   new Promise<void>((resolvePromise) => {
@@ -147,7 +173,13 @@ export const createHttpServer = async (
     ? resolveBundledClientDir()
     : options.clientBundleDir
 
-  await app.register(multipart)
+  await app.register(multipart, {
+    limits: {
+      files: MAX_ATTACHMENTS_PER_MESSAGE,
+      fields: 4,
+      fileSize: MAX_ATTACHMENT_BYTES
+    }
+  })
   await app.register(websocket)
 
   if (clientBundleDir) {
@@ -168,21 +200,22 @@ export const createHttpServer = async (
       return
     }
 
+    if (isStatusCodeCarrier(error)) {
+      reply.status(error.statusCode).send({
+        error: {
+          code: error.code ?? 'REQUEST_ERROR',
+          message: error.message ?? 'Request failed.'
+        }
+      })
+      return
+    }
+
     reply.status(500).send({
       error: {
         code: 'INTERNAL_ERROR',
         message: error instanceof Error ? error.message : 'Unknown error.'
       }
     })
-  })
-
-  app.addHook('onSend', async (request, reply, payload) => {
-    if (/^\/api\/projects\/[^/]+\/attachments(?:\/file)?(?:$|\?)/.test(request.url)) {
-      reply.header('access-control-allow-origin', '*')
-      reply.header('cross-origin-resource-policy', 'cross-origin')
-    }
-
-    return payload
   })
 
   app.get('/api/projects', async (): Promise<ProjectsResponse> => ({
@@ -222,16 +255,34 @@ export const createHttpServer = async (
     async (request, reply) => {
       const projectId = getProjectIdFromRequest(request.params.projectId)
       const project = await resolveValue(manager.getProjectStatus(projectId))
-      const files: Array<{ filename: string, mediaType: string | null, data: Buffer }> = []
+      const files: PersistedAttachment[] = []
       let threadId: string | null = null
 
       for await (const part of request.parts()) {
         if (part.type === 'file') {
-          files.push({
+          if (!threadId) {
+            throw new CodoriError('MISSING_THREAD_ID', 'Thread id must be provided before file parts.')
+          }
+
+          const mediaType = normalizeImageMediaType({
             filename: part.filename ?? 'attachment',
-            mediaType: part.mimetype || null,
-            data: await part.toBuffer()
+            declaredMediaType: part.mimetype || null
           })
+
+          if (!mediaType) {
+            throw new CodoriError('INVALID_ATTACHMENT', 'Only image attachments are supported.')
+          }
+
+          const attachment = await persistThreadAttachmentStream({
+            projectPath: project.projectPath,
+            threadId,
+            filename: part.filename ?? 'attachment',
+            mediaType,
+            stream: part.file,
+            rootDir: options.attachmentsRootDir
+          })
+
+          files.push(attachment)
           continue
         }
 
@@ -248,17 +299,10 @@ export const createHttpServer = async (
         throw new CodoriError('INVALID_ATTACHMENT', 'No files provided.')
       }
 
-      const persisted = await persistThreadAttachments({
-        projectPath: project.projectPath,
-        threadId,
-        files,
-        rootDir: options.attachmentsRootDir
-      })
-
       reply.header('cache-control', 'no-store')
       return {
         threadId,
-        files: persisted
+        files
       }
     }
   )
@@ -312,11 +356,26 @@ export const createHttpServer = async (
         }
       }
 
-      const mediaType = typeof request.query.mediaType === 'string' && request.query.mediaType.trim().length > 0
-        ? request.query.mediaType.trim()
-        : 'application/octet-stream'
+      const attachmentMetadata = await readAttachmentMetadata(resolvedPath)
+      const inferredMediaType = typeof lookupMimeType(resolvedPath) === 'string'
+        ? String(lookupMimeType(resolvedPath)).toLowerCase()
+        : null
+      const mediaType = attachmentMetadata?.mediaType?.toLowerCase()
+        ?? inferredMediaType
+        ?? null
+
+      if (!mediaType?.startsWith('image/')) {
+        reply.status(415)
+        return {
+          error: {
+            code: 'UNSUPPORTED_MEDIA_TYPE',
+            message: 'Attachment preview is only available for image files.'
+          }
+        }
+      }
 
       reply.header('cache-control', 'private, max-age=3600')
+      reply.header('cross-origin-resource-policy', 'cross-origin')
       reply.header('content-type', mediaType)
       reply.header('content-disposition', `inline; filename="${basename(resolvedPath).replace(/"/g, '')}"`)
 

--- a/packages/server/src/http-server.ts
+++ b/packages/server/src/http-server.ts
@@ -1,7 +1,9 @@
+import { readFile, stat } from 'node:fs/promises'
 import net from 'node:net'
 import { existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { basename, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import multipart from '@fastify/multipart'
 import fastifyStatic from '@fastify/static'
 import websocket from '@fastify/websocket'
 import Fastify, {
@@ -10,6 +12,11 @@ import Fastify, {
   type FastifyRequest
 } from 'fastify'
 import WebSocket from 'ws'
+import {
+  isPathInsideDirectory,
+  persistThreadAttachments,
+  resolveProjectAttachmentsDir
+} from './attachment-store.js'
 import { CodoriError } from './errors.js'
 import { createRuntimeManager } from './process-manager.js'
 import type { ProjectStatusRecord, StartProjectResult } from './types.js'
@@ -39,6 +46,7 @@ type ProjectsResponse = {
 
 export type HttpServerOptions = {
   clientBundleDir?: string | null
+  attachmentsRootDir?: string | null
 }
 
 const isCodoriError = (error: unknown): error is CodoriError =>
@@ -70,6 +78,8 @@ const toStatusCode = (error: CodoriError) => {
       return 404
     case 'INVALID_CONFIG':
     case 'MISSING_PROJECT_ID':
+    case 'MISSING_THREAD_ID':
+    case 'INVALID_ATTACHMENT':
     case 'MISSING_ROOT':
       return 400
     default:
@@ -137,6 +147,7 @@ export const createHttpServer = async (
     ? resolveBundledClientDir()
     : options.clientBundleDir
 
+  await app.register(multipart)
   await app.register(websocket)
 
   if (clientBundleDir) {
@@ -163,6 +174,15 @@ export const createHttpServer = async (
         message: error instanceof Error ? error.message : 'Unknown error.'
       }
     })
+  })
+
+  app.addHook('onSend', async (request, reply, payload) => {
+    if (/^\/api\/projects\/[^/]+\/attachments(?:\/file)?(?:$|\?)/.test(request.url)) {
+      reply.header('access-control-allow-origin', '*')
+      reply.header('cross-origin-resource-policy', 'cross-origin')
+    }
+
+    return payload
   })
 
   app.get('/api/projects', async (): Promise<ProjectsResponse> => ({
@@ -195,6 +215,113 @@ export const createHttpServer = async (
     async (request: FastifyRequest<{ Params: { projectId: string } }>): Promise<ProjectResponse> => ({
       project: await resolveValue(manager.stopProject(getProjectIdFromRequest(request.params.projectId)))
     })
+  )
+
+  app.post<{ Params: { projectId: string } }>(
+    '/api/projects/:projectId/attachments',
+    async (request, reply) => {
+      const projectId = getProjectIdFromRequest(request.params.projectId)
+      const project = await resolveValue(manager.getProjectStatus(projectId))
+      const files: Array<{ filename: string, mediaType: string | null, data: Buffer }> = []
+      let threadId: string | null = null
+
+      for await (const part of request.parts()) {
+        if (part.type === 'file') {
+          files.push({
+            filename: part.filename ?? 'attachment',
+            mediaType: part.mimetype || null,
+            data: await part.toBuffer()
+          })
+          continue
+        }
+
+        if (part.fieldname === 'threadId' && typeof part.value === 'string') {
+          threadId = part.value.trim() || null
+        }
+      }
+
+      if (!threadId) {
+        throw new CodoriError('MISSING_THREAD_ID', 'Missing thread id.')
+      }
+
+      if (!files.length) {
+        throw new CodoriError('INVALID_ATTACHMENT', 'No files provided.')
+      }
+
+      const persisted = await persistThreadAttachments({
+        projectPath: project.projectPath,
+        threadId,
+        files,
+        rootDir: options.attachmentsRootDir
+      })
+
+      reply.header('cache-control', 'no-store')
+      return {
+        threadId,
+        files: persisted
+      }
+    }
+  )
+
+  app.get<{ Params: { projectId: string }, Querystring: { path?: string, mediaType?: string } }>(
+    '/api/projects/:projectId/attachments/file',
+    async (request, reply) => {
+      const projectId = getProjectIdFromRequest(request.params.projectId)
+      const requestedPath = typeof request.query.path === 'string'
+        ? request.query.path.trim()
+        : ''
+
+      if (!requestedPath) {
+        throw new CodoriError('INVALID_ATTACHMENT', 'Missing attachment path.')
+      }
+
+      const project = await resolveValue(manager.getProjectStatus(projectId))
+      const allowedRoot = resolveProjectAttachmentsDir(project.projectPath, options.attachmentsRootDir)
+      const resolvedPath = resolve(requestedPath)
+
+      if (!isPathInsideDirectory(resolvedPath, allowedRoot)) {
+        reply.status(403)
+        return {
+          error: {
+            code: 'FORBIDDEN',
+            message: 'Invalid attachment path.'
+          }
+        }
+      }
+
+      let fileStat
+      try {
+        fileStat = await stat(resolvedPath)
+      } catch {
+        reply.status(404)
+        return {
+          error: {
+            code: 'NOT_FOUND',
+            message: 'Attachment not found.'
+          }
+        }
+      }
+
+      if (!fileStat.isFile()) {
+        reply.status(404)
+        return {
+          error: {
+            code: 'NOT_FOUND',
+            message: 'Attachment not found.'
+          }
+        }
+      }
+
+      const mediaType = typeof request.query.mediaType === 'string' && request.query.mediaType.trim().length > 0
+        ? request.query.mediaType.trim()
+        : 'application/octet-stream'
+
+      reply.header('cache-control', 'private, max-age=3600')
+      reply.header('content-type', mediaType)
+      reply.header('content-disposition', `inline; filename="${basename(resolvedPath).replace(/"/g, '')}"`)
+
+      return await readFile(resolvedPath)
+    }
   )
 
   app.get<{ Params: { projectId: string } }>(

--- a/packages/server/test/attachment-store.test.ts
+++ b/packages/server/test/attachment-store.test.ts
@@ -1,0 +1,46 @@
+import { mkdirSync, mkdtempSync, readFileSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import os from 'node:os'
+import { join } from 'node:path'
+import { Readable } from 'node:stream'
+import { afterEach, describe, expect, it } from 'vitest'
+import { persistThreadAttachmentStream, resolveProjectAttachmentsDir } from '../src/attachment-store.js'
+
+const attachmentRoots: string[] = []
+
+afterEach(async () => {
+  for (const root of attachmentRoots.splice(0, attachmentRoots.length)) {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+describe('attachment-store', () => {
+  it('allocates distinct files for concurrent uploads with the same filename', async () => {
+    const attachmentsRoot = mkdtempSync(join(os.tmpdir(), 'codori-attachments-'))
+    attachmentRoots.push(attachmentsRoot)
+    mkdirSync(resolveProjectAttachmentsDir('/tmp/demo', attachmentsRoot), { recursive: true })
+
+    const [first, second] = await Promise.all([
+      persistThreadAttachmentStream({
+        projectPath: '/tmp/demo',
+        threadId: 'thread-123',
+        filename: 'diagram.png',
+        mediaType: 'image/png',
+        stream: Readable.from(['first']),
+        rootDir: attachmentsRoot
+      }),
+      persistThreadAttachmentStream({
+        projectPath: '/tmp/demo',
+        threadId: 'thread-123',
+        filename: 'diagram.png',
+        mediaType: 'image/png',
+        stream: Readable.from(['second']),
+        rootDir: attachmentsRoot
+      })
+    ])
+
+    expect(first.path).not.toBe(second.path)
+    expect(new Set([first.filename, second.filename]).size).toBe(2)
+    expect([readFileSync(first.path, 'utf8'), readFileSync(second.path, 'utf8')].sort()).toEqual(['first', 'second'])
+  })
+})

--- a/packages/server/test/http-server.test.ts
+++ b/packages/server/test/http-server.test.ts
@@ -348,6 +348,48 @@ describe('createHttpServer', () => {
     })
   })
 
+  it('rejects uploads that declare a non-image mime type even if the filename looks like an image', async () => {
+    const attachmentsRoot = mkdtempSync(join(os.tmpdir(), 'codori-attachments-'))
+    attachmentsRoots.push(attachmentsRoot)
+    const app = await createHttpServer(createManager(), {
+      attachmentsRootDir: attachmentsRoot
+    })
+    startedApps.push(app)
+
+    const boundary = '----codori-test-boundary'
+    const body = [
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="threadId"',
+      '',
+      'thread-123',
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="file"; filename="diagram.png"',
+      'Content-Type: text/html',
+      '',
+      '<script>alert(1)</script>',
+      `--${boundary}--`,
+      ''
+    ].join('\r\n')
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/projects/demo/attachments',
+      headers: {
+        'content-type': `multipart/form-data; boundary=${boundary}`
+      },
+      payload: body
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toEqual({
+      error: {
+        code: 'INVALID_ATTACHMENT',
+        message: 'Only image attachments are supported.',
+        details: null
+      }
+    })
+  })
+
   it('rejects attachment preview paths outside the project attachment root', async () => {
     const attachmentsRoot = mkdtempSync(join(os.tmpdir(), 'codori-attachments-'))
     attachmentsRoots.push(attachmentsRoot)

--- a/packages/server/test/http-server.test.ts
+++ b/packages/server/test/http-server.test.ts
@@ -1,15 +1,18 @@
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
 import { createServer as createNetServer } from 'node:net'
 import os from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import WebSocket, { WebSocketServer } from 'ws'
+import { resolveProjectAttachmentsDir } from '../src/attachment-store.js'
 import { createHttpServer, type RuntimeManagerLike } from '../src/http-server.js'
 import type { ProjectStatusRecord, StartProjectResult } from '../src/types.js'
 
 const startedApps: Array<Awaited<ReturnType<typeof createHttpServer>>> = []
 const startedSocketServers: WebSocketServer[] = []
 const occupiedTcpServers: Array<ReturnType<typeof createNetServer>> = []
+const attachmentsRoots: string[] = []
 
 afterEach(async () => {
   for (const app of startedApps.splice(0, startedApps.length)) {
@@ -38,6 +41,10 @@ afterEach(async () => {
         resolvePromise()
       })
     })
+  }
+
+  for (const root of attachmentsRoots.splice(0, attachmentsRoots.length)) {
+    await rm(root, { recursive: true, force: true })
   }
 })
 
@@ -242,6 +249,82 @@ describe('createHttpServer', () => {
         }
       })
       client.once('error', reject)
+    })
+  })
+
+  it('persists uploaded attachments and serves previews', async () => {
+    const attachmentsRoot = mkdtempSync(join(os.tmpdir(), 'codori-attachments-'))
+    attachmentsRoots.push(attachmentsRoot)
+    const app = await createHttpServer(createManager(), {
+      attachmentsRootDir: attachmentsRoot
+    })
+    startedApps.push(app)
+
+    const boundary = '----codori-test-boundary'
+    const body = [
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="threadId"',
+      '',
+      'thread-123',
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="file"; filename="diagram.png"',
+      'Content-Type: image/png',
+      '',
+      'PNGDATA',
+      `--${boundary}--`,
+      ''
+    ].join('\r\n')
+
+    const uploadResponse = await app.inject({
+      method: 'POST',
+      url: '/api/projects/demo/attachments',
+      headers: {
+        'content-type': `multipart/form-data; boundary=${boundary}`
+      },
+      payload: body
+    })
+
+    expect(uploadResponse.statusCode).toBe(200)
+    const uploadJson = uploadResponse.json() as {
+      threadId: string
+      files: Array<{ filename: string, mediaType: string | null, path: string }>
+    }
+    expect(uploadJson.threadId).toBe('thread-123')
+    expect(uploadJson.files).toHaveLength(1)
+    expect(uploadJson.files[0]?.filename).toBe('diagram.png')
+    expect(uploadJson.files[0]?.mediaType).toBe('image/png')
+    expect(readFileSync(uploadJson.files[0]!.path, 'utf8')).toBe('PNGDATA')
+    expect(uploadJson.files[0]!.path.startsWith(resolveProjectAttachmentsDir('/tmp/demo', attachmentsRoot))).toBe(true)
+
+    const fileResponse = await app.inject({
+      method: 'GET',
+      url: `/api/projects/demo/attachments/file?path=${encodeURIComponent(uploadJson.files[0]!.path)}&mediaType=image%2Fpng`
+    })
+
+    expect(fileResponse.statusCode).toBe(200)
+    expect(fileResponse.headers['content-type']).toContain('image/png')
+    expect(fileResponse.body).toBe('PNGDATA')
+  })
+
+  it('rejects attachment preview paths outside the project attachment root', async () => {
+    const attachmentsRoot = mkdtempSync(join(os.tmpdir(), 'codori-attachments-'))
+    attachmentsRoots.push(attachmentsRoot)
+    const app = await createHttpServer(createManager(), {
+      attachmentsRootDir: attachmentsRoot
+    })
+    startedApps.push(app)
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/projects/demo/attachments/file?path=${encodeURIComponent('/tmp/not-allowed.png')}&mediaType=image%2Fpng`
+    })
+
+    expect(response.statusCode).toBe(403)
+    expect(response.json()).toEqual({
+      error: {
+        code: 'FORBIDDEN',
+        message: 'Invalid attachment path.'
+      }
     })
   })
 })

--- a/packages/server/test/http-server.test.ts
+++ b/packages/server/test/http-server.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
 import { createServer as createNetServer } from 'node:net'
 import os from 'node:os'
@@ -298,12 +298,54 @@ describe('createHttpServer', () => {
 
     const fileResponse = await app.inject({
       method: 'GET',
-      url: `/api/projects/demo/attachments/file?path=${encodeURIComponent(uploadJson.files[0]!.path)}&mediaType=image%2Fpng`
+      url: `/api/projects/demo/attachments/file?path=${encodeURIComponent(uploadJson.files[0]!.path)}`
     })
 
     expect(fileResponse.statusCode).toBe(200)
     expect(fileResponse.headers['content-type']).toContain('image/png')
     expect(fileResponse.body).toBe('PNGDATA')
+  })
+
+  it('rejects non-image attachments before persisting', async () => {
+    const attachmentsRoot = mkdtempSync(join(os.tmpdir(), 'codori-attachments-'))
+    attachmentsRoots.push(attachmentsRoot)
+    const app = await createHttpServer(createManager(), {
+      attachmentsRootDir: attachmentsRoot
+    })
+    startedApps.push(app)
+
+    const boundary = '----codori-test-boundary'
+    const body = [
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="threadId"',
+      '',
+      'thread-123',
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="file"; filename="payload.html"',
+      'Content-Type: text/html',
+      '',
+      '<script>alert(1)</script>',
+      `--${boundary}--`,
+      ''
+    ].join('\r\n')
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/projects/demo/attachments',
+      headers: {
+        'content-type': `multipart/form-data; boundary=${boundary}`
+      },
+      payload: body
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toEqual({
+      error: {
+        code: 'INVALID_ATTACHMENT',
+        message: 'Only image attachments are supported.',
+        details: null
+      }
+    })
   })
 
   it('rejects attachment preview paths outside the project attachment root', async () => {
@@ -324,6 +366,33 @@ describe('createHttpServer', () => {
       error: {
         code: 'FORBIDDEN',
         message: 'Invalid attachment path.'
+      }
+    })
+  })
+
+  it('rejects inline previews for non-image files even when stored under the attachment root', async () => {
+    const attachmentsRoot = mkdtempSync(join(os.tmpdir(), 'codori-attachments-'))
+    attachmentsRoots.push(attachmentsRoot)
+    const projectRoot = resolveProjectAttachmentsDir('/tmp/demo', attachmentsRoot)
+    const filePath = join(projectRoot, 'thread', 'payload.html')
+    mkdirSync(join(projectRoot, 'thread'), { recursive: true })
+    writeFileSync(filePath, '<script>alert(1)</script>', { encoding: 'utf8', flag: 'w' })
+
+    const app = await createHttpServer(createManager(), {
+      attachmentsRootDir: attachmentsRoot
+    })
+    startedApps.push(app)
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/projects/demo/attachments/file?path=${encodeURIComponent(filePath)}`
+    })
+
+    expect(response.statusCode).toBe(415)
+    expect(response.json()).toEqual({
+      error: {
+        code: 'UNSUPPORTED_MEDIA_TYPE',
+        message: 'Attachment preview is only available for image files.'
       }
     })
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,16 @@ importers:
       fastify:
         specifier: ^5.6.1
         version: 5.8.4
+      mime-types:
+        specifier: ^3.0.2
+        version: 3.0.2
       ws:
         specifier: ^8.18.3
         version: 8.20.0
+    devDependencies:
+      '@types/mime-types':
+        specifier: ^3.0.1
+        version: 3.0.1
 
 packages:
 
@@ -1880,6 +1887,9 @@ packages:
 
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
+  '@types/mime-types@3.0.1':
+    resolution: {integrity: sha512-xRMsfuQbnRq1Ef+C+RKaENOxXX87Ygl38W1vDfPHRku02TgQr+Qd8iivLtAMcR0KF5/29xlnFihkTlbqFrGOVQ==}
 
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
@@ -7062,6 +7072,8 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/mdurl@2.0.0': {}
+
+  '@types/mime-types@3.0.1': {}
 
   '@types/node@24.12.2':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
 
   packages/server:
     dependencies:
+      '@fastify/multipart':
+        specifier: ^10.0.0
+        version: 10.0.0
       '@fastify/static':
         specifier: ^9.1.0
         version: 9.1.0
@@ -480,6 +483,12 @@ packages:
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
+  '@fastify/busboy@3.2.0':
+    resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
+
+  '@fastify/deepmerge@3.2.1':
+    resolution: {integrity: sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==}
+
   '@fastify/error@4.2.0':
     resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
 
@@ -491,6 +500,9 @@ packages:
 
   '@fastify/merge-json-schemas@0.2.1':
     resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/multipart@10.0.0':
+    resolution: {integrity: sha512-pUx3Z1QStY7E7kwvDTIvB6P+rF5lzP+iqPgZyJyG3yBJVPvQaZxzDHYbQD89rbY0ciXrMOyGi8ezHDVexLvJDA==}
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
@@ -5544,6 +5556,10 @@ snapshots:
       ajv-formats: 3.0.1(ajv@8.18.0)
       fast-uri: 3.1.0
 
+  '@fastify/busboy@3.2.0': {}
+
+  '@fastify/deepmerge@3.2.1': {}
+
   '@fastify/error@4.2.0': {}
 
   '@fastify/fast-json-stringify-compiler@5.0.3':
@@ -5555,6 +5571,14 @@ snapshots:
   '@fastify/merge-json-schemas@0.2.1':
     dependencies:
       dequal: 2.0.3
+
+  '@fastify/multipart@10.0.0':
+    dependencies:
+      '@fastify/busboy': 3.2.0
+      '@fastify/deepmerge': 3.2.1
+      '@fastify/error': 4.2.0
+      fastify-plugin: 5.1.0
+      secure-json-parse: 4.1.0
 
   '@fastify/proxy-addr@5.1.0':
     dependencies:


### PR DESCRIPTION
## Summary
- add first-class image attachments to the chat composer with file picker, drag-and-drop, and clipboard paste support
- upload attached images through the codori server and convert them into Codex `localImage` inputs for `turn/start`
- route attachment upload and preview requests through Nuxt proxy endpoints when the client runs standalone with `serverBase`, while keeping direct bundled-server requests unchanged
- render attached images consistently in optimistic user messages and server-confirmed user messages

## Why
Codori's chat composer was effectively text-only, which blocked screenshot-driven workflows and did not satisfy issue #2's expected attachment behavior.

## Impact
- users can submit image-only prompts or text plus images from the web composer
- standalone `@codori/client` deployments can upload and preview attachments without cross-origin fetch failures
- bundled `@codori/server` deployments keep the simpler direct attachment flow
- invalid attachments are rejected with clear client-side validation messages
- server-side attachment handling is constrained to per-project attachment roots with preview path validation

## Validation
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint` (existing unrelated warning remains in `packages/client/app/components/ProjectStatusDot.vue`)

Closes #2
