### PR TITLE
Support active turn steering and stop controls

### DIFF
--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -6,6 +6,7 @@ import {
   reconcileOptimisticUserMessage,
   removeChatMessage,
   removePendingUserMessageId,
+  resolvePromptSubmitStatus,
   resolveTurnSubmissionMethod,
   shouldIgnoreNotificationAfterInterrupt
 } from '../utils/chat-turn-engagement'
@@ -98,14 +99,25 @@ const {
 const selectedProject = computed(() => getProject(props.projectId))
 const composerError = computed(() => attachmentError.value ?? error.value)
 const submitError = computed(() => composerError.value ? new Error(composerError.value) : undefined)
+const interruptRequested = ref(false)
 const isBusy = computed(() =>
   status.value === 'submitted'
   || status.value === 'streaming'
   || isUploading.value
 )
+const hasDraftContent = computed(() =>
+  input.value.trim().length > 0
+  || attachments.value.length > 0
+)
 const isComposerDisabled = computed(() =>
   isUploading.value
-  || currentLiveStream()?.interruptRequested === true
+  || interruptRequested.value
+)
+const promptSubmitStatus = computed(() =>
+  resolvePromptSubmitStatus({
+    status: status.value,
+    hasDraftContent: hasDraftContent.value
+  })
 )
 const routeThreadId = computed(() => props.threadId ?? null)
 const projectTitle = computed(() => selectedProject.value?.projectId ?? props.projectId)
@@ -176,6 +188,19 @@ const createLiveStreamState = (
   unsubscribe: null
 })
 
+const setSessionLiveStream = (liveStream: LiveStream | null) => {
+  session.liveStream = liveStream
+  interruptRequested.value = liveStream?.interruptRequested === true
+}
+
+const setLiveStreamInterruptRequested = (liveStream: LiveStream, nextValue: boolean) => {
+  liveStream.interruptRequested = nextValue
+
+  if (session.liveStream === liveStream) {
+    interruptRequested.value = nextValue
+  }
+}
+
 const setLiveStreamTurnId = (liveStream: LiveStream, turnId: string | null) => {
   liveStream.turnId = turnId
 
@@ -203,12 +228,13 @@ const waitForLiveStreamTurnId = async (liveStream: LiveStream) => {
 const clearLiveStream = (reason?: Error) => {
   const liveStream = session.liveStream
   if (!liveStream) {
+    interruptRequested.value = false
     return null
   }
 
   liveStream.unsubscribe?.()
   rejectLiveStreamTurnWaiters(liveStream, reason ?? new Error('The active turn is no longer available.'))
-  session.liveStream = null
+  setSessionLiveStream(null)
   return liveStream
 }
 
@@ -256,7 +282,7 @@ const ensurePendingLiveStream = async () => {
       applyNotification(notification)
     })
 
-    session.liveStream = liveStream
+    setSessionLiveStream(liveStream)
 
     if (created && !routeThreadId.value) {
       pendingThreadId.value = threadId
@@ -515,9 +541,13 @@ const hydrateThread = async (threadId: string) => {
     const client = getClient(props.projectId)
     activeThreadId.value = threadId
 
-    const existingLiveStream = currentLiveStream()
+    const existingLiveStream = session.liveStream
 
-    if (!existingLiveStream) {
+    if (existingLiveStream && existingLiveStream.threadId !== threadId) {
+      clearLiveStream()
+    }
+
+    if (!session.liveStream) {
       const nextLiveStream = createLiveStreamState(threadId)
 
       nextLiveStream.unsubscribe = client.subscribe((notification) => {
@@ -546,7 +576,7 @@ const hydrateThread = async (threadId: string) => {
         applyNotification(notification)
       })
 
-      session.liveStream = nextLiveStream
+      setSessionLiveStream(nextLiveStream)
     }
 
     await client.request<ThreadResumeResponse>('thread/resume', {
@@ -1221,7 +1251,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
     case 'turn/started': {
       if (liveStream) {
         setLiveStreamTurnId(liveStream, notificationTurnId(notification))
-        liveStream.interruptRequested = false
+        setLiveStreamInterruptRequested(liveStream, false)
       }
       messages.value = upsertStreamingMessage(
         messages.value,
@@ -1529,13 +1559,15 @@ const stopActiveTurn = async () => {
     return
   }
 
+  let liveStream: LiveStream | null = null
+
   try {
-    const liveStream = await ensurePendingLiveStream()
+    liveStream = await ensurePendingLiveStream()
     if (liveStream.interruptRequested) {
       return
     }
 
-    liveStream.interruptRequested = true
+    setLiveStreamInterruptRequested(liveStream, true)
     error.value = null
     const client = getClient(props.projectId)
     const turnId = await waitForLiveStreamTurnId(liveStream)
@@ -1545,9 +1577,8 @@ const stopActiveTurn = async () => {
     })
     liveStream.interruptAcknowledged = true
   } catch (caughtError) {
-    const liveStream = currentLiveStream()
     if (liveStream) {
-      liveStream.interruptRequested = false
+      setLiveStreamInterruptRequested(liveStream, false)
     }
     error.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
   }
@@ -1749,7 +1780,7 @@ watch(status, (nextStatus, previousStatus) => {
             @paste="onPaste"
           >
             <UChatPromptSubmit
-              :status="status"
+              :status="promptSubmitStatus"
               @stop="stopActiveTurn"
             />
 

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -2,8 +2,15 @@
 import { useRouter } from '#imports'
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import MessageContent from './MessageContent.vue'
+import {
+  reconcileOptimisticUserMessage,
+  removeChatMessage,
+  removePendingUserMessageId,
+  resolveTurnSubmissionMethod,
+  shouldIgnoreNotificationAfterInterrupt
+} from '../utils/chat-turn-engagement'
 import { useChatAttachments, type DraftAttachment } from '../composables/useChatAttachments'
-import { useChatSession, type SubagentPanelState } from '../composables/useChatSession'
+import { useChatSession, type LiveStream, type SubagentPanelState } from '../composables/useChatSession'
 import { useProjects } from '../composables/useProjects'
 import { useRpc } from '../composables/useRpc'
 import { useChatSubmitGuard } from '../composables/useChatSubmitGuard'
@@ -96,6 +103,10 @@ const isBusy = computed(() =>
   || status.value === 'streaming'
   || isUploading.value
 )
+const isComposerDisabled = computed(() =>
+  isUploading.value
+  || currentLiveStream()?.interruptRequested === true
+)
 const routeThreadId = computed(() => props.threadId ?? null)
 const projectTitle = computed(() => selectedProject.value?.projectId ?? props.projectId)
 const showWelcomeState = computed(() =>
@@ -125,6 +136,7 @@ const starterPrompts = computed(() => {
 })
 
 const subagentBootstrapPromises = new Map<string, Promise<void>>()
+const optimisticAttachmentSnapshots = new Map<string, DraftAttachment[]>()
 
 const isActiveTurnStatus = (value: string | null | undefined) => {
   if (!value) {
@@ -139,9 +151,129 @@ const currentLiveStream = () =>
     ? session.liveStream
     : null
 
-const clearLiveStream = () => {
-  session.liveStream?.unsubscribe?.()
+const hasActiveTurnEngagement = () =>
+  Boolean(currentLiveStream() || session.pendingLiveStream)
+
+const rejectLiveStreamTurnWaiters = (liveStream: LiveStream, error: Error) => {
+  const waiters = liveStream.turnIdWaiters.splice(0, liveStream.turnIdWaiters.length)
+  for (const waiter of waiters) {
+    waiter.reject(error)
+  }
+}
+
+const createLiveStreamState = (
+  threadId: string,
+  bufferedNotifications: CodexRpcNotification[] = []
+): LiveStream => ({
+  threadId,
+  turnId: null,
+  bufferedNotifications,
+  observedSubagentThreadIds: new Set<string>(),
+  pendingUserMessageIds: [],
+  turnIdWaiters: [],
+  interruptRequested: false,
+  interruptAcknowledged: false,
+  unsubscribe: null
+})
+
+const setLiveStreamTurnId = (liveStream: LiveStream, turnId: string | null) => {
+  liveStream.turnId = turnId
+
+  if (!turnId) {
+    return
+  }
+
+  liveStream.interruptAcknowledged = false
+  const waiters = liveStream.turnIdWaiters.splice(0, liveStream.turnIdWaiters.length)
+  for (const waiter of waiters) {
+    waiter.resolve(turnId)
+  }
+}
+
+const waitForLiveStreamTurnId = async (liveStream: LiveStream) => {
+  if (liveStream.turnId) {
+    return liveStream.turnId
+  }
+
+  return await new Promise<string>((resolve, reject) => {
+    liveStream.turnIdWaiters.push({ resolve, reject })
+  })
+}
+
+const clearLiveStream = (reason?: Error) => {
+  const liveStream = session.liveStream
+  if (!liveStream) {
+    return null
+  }
+
+  liveStream.unsubscribe?.()
+  rejectLiveStreamTurnWaiters(liveStream, reason ?? new Error('The active turn is no longer available.'))
   session.liveStream = null
+  return liveStream
+}
+
+const ensurePendingLiveStream = async () => {
+  const existingLiveStream = currentLiveStream()
+  if (existingLiveStream) {
+    return existingLiveStream
+  }
+
+  if (session.pendingLiveStream) {
+    return await session.pendingLiveStream
+  }
+
+  const pendingLiveStream = (async () => {
+    await ensureProjectRuntime()
+    const { threadId, created } = await ensureThread()
+    const client = getClient(props.projectId)
+    const buffered: CodexRpcNotification[] = []
+    clearLiveStream()
+
+    const liveStream = createLiveStreamState(threadId, buffered)
+    liveStream.unsubscribe = client.subscribe((notification) => {
+      const targetThreadId = notificationThreadId(notification)
+      if (!targetThreadId) {
+        return
+      }
+
+      if (targetThreadId !== threadId) {
+        if (liveStream.observedSubagentThreadIds.has(targetThreadId)) {
+          applySubagentNotification(targetThreadId, notification)
+        }
+        return
+      }
+
+      if (!liveStream.turnId) {
+        buffered.push(notification)
+        return
+      }
+
+      const turnId = notificationTurnId(notification)
+      if (turnId && turnId !== liveStream.turnId) {
+        return
+      }
+
+      applyNotification(notification)
+    })
+
+    session.liveStream = liveStream
+
+    if (created && !routeThreadId.value) {
+      pendingThreadId.value = threadId
+    }
+
+    return liveStream
+  })()
+
+  session.pendingLiveStream = pendingLiveStream
+
+  try {
+    return await pendingLiveStream
+  } finally {
+    if (session.pendingLiveStream === pendingLiveStream) {
+      session.pendingLiveStream = null
+    }
+  }
 }
 
 const createOptimisticMessageId = () =>
@@ -172,6 +304,14 @@ const buildOptimisticMessage = (text: string, submittedAttachments: DraftAttachm
   ]
 })
 
+const rememberOptimisticAttachments = (messageId: string, submittedAttachments: DraftAttachment[]) => {
+  if (submittedAttachments.length === 0) {
+    return
+  }
+
+  optimisticAttachmentSnapshots.set(messageId, submittedAttachments)
+}
+
 const formatAttachmentSize = (size: number) => {
   if (size >= 1024 * 1024) {
     return `${(size / (1024 * 1024)).toFixed(1)} MB`
@@ -184,8 +324,62 @@ const formatAttachmentSize = (size: number) => {
   return `${size} B`
 }
 
-const stripOptimisticDraftMessages = () => {
-  messages.value = messages.value.filter(message => !message.id.startsWith('local-user-'))
+const removeOptimisticMessage = (messageId: string) => {
+  messages.value = removeChatMessage(messages.value, messageId)
+  optimisticAttachmentSnapshots.delete(messageId)
+}
+
+const restoreDraftIfPristine = (text: string, submittedAttachments: DraftAttachment[]) => {
+  if (!input.value.trim()) {
+    input.value = text
+  }
+
+  if (attachments.value.length === 0 && submittedAttachments.length > 0) {
+    replaceAttachments(submittedAttachments)
+  }
+}
+
+const untrackPendingUserMessage = (messageId: string) => {
+  const liveStream = currentLiveStream()
+  if (!liveStream) {
+    return
+  }
+
+  liveStream.pendingUserMessageIds = removePendingUserMessageId(liveStream.pendingUserMessageIds, messageId)
+}
+
+const reconcilePendingUserMessage = (confirmedMessage: ChatMessage) => {
+  const liveStream = currentLiveStream()
+  const optimisticMessageId = liveStream?.pendingUserMessageIds.shift() ?? null
+  if (!optimisticMessageId) {
+    messages.value = upsertStreamingMessage(messages.value, confirmedMessage)
+    return
+  }
+
+  const pendingAttachments = optimisticAttachmentSnapshots.get(optimisticMessageId)
+  if (pendingAttachments) {
+    discardSnapshot(pendingAttachments)
+    optimisticAttachmentSnapshots.delete(optimisticMessageId)
+  }
+
+  messages.value = reconcileOptimisticUserMessage(messages.value, optimisticMessageId, confirmedMessage)
+}
+
+const clearPendingOptimisticMessages = (liveStream: LiveStream | null, options?: { discardSnapshots?: boolean }) => {
+  if (!liveStream) {
+    return
+  }
+
+  for (const messageId of liveStream.pendingUserMessageIds) {
+    messages.value = removeChatMessage(messages.value, messageId)
+    const pendingAttachments = optimisticAttachmentSnapshots.get(messageId)
+    if (options?.discardSnapshots && pendingAttachments) {
+      discardSnapshot(pendingAttachments)
+    }
+    optimisticAttachmentSnapshots.delete(messageId)
+  }
+
+  liveStream.pendingUserMessageIds = []
 }
 
 const resolveThreadTitle = (thread: { name: string | null, preview: string, id: string }) => {
@@ -324,13 +518,7 @@ const hydrateThread = async (threadId: string) => {
     const existingLiveStream = currentLiveStream()
 
     if (!existingLiveStream) {
-      const nextLiveStream = {
-        threadId,
-        turnId: null,
-        bufferedNotifications: [] as CodexRpcNotification[],
-        observedSubagentThreadIds: new Set<string>(),
-        unsubscribe: null as (() => void) | null
-      }
+      const nextLiveStream = createLiveStreamState(threadId)
 
       nextLiveStream.unsubscribe = client.subscribe((notification) => {
         const targetThreadId = notificationThreadId(notification)
@@ -393,7 +581,7 @@ const hydrateThread = async (threadId: string) => {
       return
     }
 
-    session.liveStream.turnId = activeTurn.id
+    setLiveStreamTurnId(session.liveStream, activeTurn.id)
     status.value = 'streaming'
 
     const pendingNotifications = session.liveStream.bufferedNotifications.splice(0, session.liveStream.bufferedNotifications.length)
@@ -414,6 +602,7 @@ const hydrateThread = async (threadId: string) => {
 
 const resetDraftThread = () => {
   clearLiveStream()
+  session.pendingLiveStream = null
   activeThreadId.value = null
   threadTitle.value = null
   pendingThreadId.value = null
@@ -1013,6 +1202,11 @@ const applySubagentNotification = (threadId: string, notification: CodexRpcNotif
 }
 
 const applyNotification = (notification: CodexRpcNotification) => {
+  const liveStream = currentLiveStream()
+  if (liveStream?.interruptAcknowledged && shouldIgnoreNotificationAfterInterrupt(notification.method)) {
+    return
+  }
+
   switch (notification.method) {
     case 'thread/started': {
       const nextThreadId = notificationThreadId(notification)
@@ -1025,6 +1219,10 @@ const applyNotification = (notification: CodexRpcNotification) => {
       return
     }
     case 'turn/started': {
+      if (liveStream) {
+        setLiveStreamTurnId(liveStream, notificationTurnId(notification))
+        liveStream.interruptRequested = false
+      }
       messages.value = upsertStreamingMessage(
         messages.value,
         eventToMessage(`event-turn-started-${notificationTurnId(notification) ?? Date.now()}`, {
@@ -1048,14 +1246,17 @@ const applyNotification = (notification: CodexRpcNotification) => {
       if (params.item.type === 'collabAgentToolCall') {
         applySubagentActivityItem(params.item)
       }
-      if (params.item.type === 'userMessage') {
-        stripOptimisticDraftMessages()
-      }
       for (const nextMessage of itemToMessages(params.item)) {
-        messages.value = upsertStreamingMessage(messages.value, {
+        const confirmedMessage = {
           ...nextMessage,
           pending: false
-        })
+        }
+        if (params.item.type === 'userMessage') {
+          reconcilePendingUserMessage(confirmedMessage)
+          continue
+        }
+
+        messages.value = upsertStreamingMessage(messages.value, confirmedMessage)
       }
       return
     }
@@ -1186,11 +1387,22 @@ const applyNotification = (notification: CodexRpcNotification) => {
       status.value = 'streaming'
       return
     }
+    case 'error': {
+      const params = notification.params as { error?: { message?: string } }
+      const messageText = params.error?.message ?? 'The stream failed.'
+      pushEventMessage('stream.error', messageText)
+      clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
+      clearLiveStream(new Error(messageText))
+      error.value = messageText
+      status.value = 'error'
+      return
+    }
     case 'turn/failed': {
       const params = notification.params as { error?: { message?: string } }
       const messageText = params.error?.message ?? 'The turn failed.'
       pushEventMessage('turn.failed', messageText)
-      clearLiveStream()
+      clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
+      clearLiveStream(new Error(messageText))
       error.value = messageText
       status.value = 'error'
       return
@@ -1199,12 +1411,15 @@ const applyNotification = (notification: CodexRpcNotification) => {
       const params = notification.params as { message?: string }
       const messageText = params.message ?? 'The stream failed.'
       pushEventMessage('stream.error', messageText)
-      clearLiveStream()
+      clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
+      clearLiveStream(new Error(messageText))
       error.value = messageText
       status.value = 'error'
       return
     }
     case 'turn/completed': {
+      clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
+      error.value = null
       status.value = 'ready'
       clearLiveStream()
       return
@@ -1225,112 +1440,40 @@ const sendMessage = async () => {
   pinnedToBottom.value = true
   error.value = null
   attachmentError.value = null
-  status.value = 'submitted'
+  const submissionMethod = resolveTurnSubmissionMethod(hasActiveTurnEngagement())
+  if (submissionMethod === 'turn/start') {
+    status.value = 'submitted'
+  }
   input.value = ''
   clearAttachments({ revoke: false })
-  messages.value = [...messages.value, buildOptimisticMessage(text, submittedAttachments)]
-  let unsubscribe: (() => void) | null = null
+  const optimisticMessage = buildOptimisticMessage(text, submittedAttachments)
+  const optimisticMessageId = optimisticMessage.id
+  rememberOptimisticAttachments(optimisticMessageId, submittedAttachments)
+  messages.value = [...messages.value, optimisticMessage]
+  let startedLiveStream: LiveStream | null = null
 
   try {
-    await ensureProjectRuntime()
-    const { threadId, created } = await ensureThread()
-    const uploadedAttachments = await uploadAttachments(threadId, submittedAttachments)
     const client = getClient(props.projectId)
-    const buffered: CodexRpcNotification[] = []
-    let currentTurnId: string | null = null
-    let completionResolved = false
-    let resolveCompletion: (() => void) | null = null
-    let rejectCompletion: ((error: Error) => void) | null = null
 
-    const settleNotification = (notification: CodexRpcNotification) => {
-      if (notificationThreadId(notification) !== threadId) {
-        return false
-      }
+    if (submissionMethod === 'turn/steer') {
+      const liveStream = await ensurePendingLiveStream()
+      const uploadedAttachments = await uploadAttachments(liveStream.threadId, submittedAttachments)
+      liveStream.pendingUserMessageIds.push(optimisticMessageId)
+      const turnId = await waitForLiveStreamTurnId(liveStream)
 
-      const turnId = notificationTurnId(notification)
-      if (currentTurnId && turnId && turnId !== currentTurnId) {
-        return false
-      }
-
-      if (notification.method === 'error') {
-        completionResolved = true
-        unsubscribe?.()
-        if (session.liveStream?.unsubscribe === unsubscribe) {
-          session.liveStream = null
-        }
-        const params = notification.params as { error?: { message?: string } }
-        const messageText = params.error?.message ?? 'Turn failed.'
-        pushEventMessage('stream.error', messageText)
-        rejectCompletion?.(new Error(messageText))
-        return true
-      }
-
-      applyNotification(notification)
-
-      if (notification.method === 'turn/completed') {
-        completionResolved = true
-        unsubscribe?.()
-        if (session.liveStream?.unsubscribe === unsubscribe) {
-          session.liveStream = null
-        }
-        resolveCompletion?.()
-        return true
-      }
-
-      if (notification.method === 'turn/failed' || notification.method === 'stream/error') {
-        completionResolved = true
-        unsubscribe?.()
-        if (session.liveStream?.unsubscribe === unsubscribe) {
-          session.liveStream = null
-        }
-        rejectCompletion?.(new Error(error.value ?? 'Turn failed.'))
-        return true
-      }
-
-      return false
+      await client.request<TurnStartResponse>('turn/steer', {
+        threadId: liveStream.threadId,
+        expectedTurnId: turnId,
+        input: buildTurnStartInput(text, uploadedAttachments)
+      })
+      return
     }
 
-    clearLiveStream()
-
-    const completion = new Promise<void>((resolve, reject) => {
-      resolveCompletion = resolve
-      rejectCompletion = (caughtError: Error) => reject(caughtError)
-    })
-
-    const liveStream = {
-      threadId,
-      turnId: null as string | null,
-      bufferedNotifications: buffered,
-      observedSubagentThreadIds: new Set<string>(),
-      unsubscribe: null as (() => void) | null
-    }
-
-    unsubscribe = client.subscribe((notification) => {
-      const targetThreadId = notificationThreadId(notification)
-      if (!targetThreadId) {
-        return
-      }
-
-      if (targetThreadId !== threadId) {
-        if (liveStream.observedSubagentThreadIds.has(targetThreadId)) {
-          applySubagentNotification(targetThreadId, notification)
-        }
-        return
-      }
-
-      if (!currentTurnId) {
-        buffered.push(notification)
-        return
-      }
-
-      settleNotification(notification)
-    })
-    liveStream.unsubscribe = unsubscribe
-    session.liveStream = liveStream
-
-    if (created && !routeThreadId.value) {
-      pendingThreadId.value = threadId
-    }
+    const liveStream = await ensurePendingLiveStream()
+    startedLiveStream = liveStream
+    const threadId = liveStream.threadId
+    const uploadedAttachments = await uploadAttachments(threadId, submittedAttachments)
+    liveStream.pendingUserMessageIds.push(optimisticMessageId)
 
     const turnStart = await client.request<TurnStartResponse>('turn/start', {
       threadId,
@@ -1339,33 +1482,64 @@ const sendMessage = async () => {
       approvalPolicy: 'never'
     })
 
-    currentTurnId = turnStart.turn.id
-    liveStream.turnId = turnStart.turn.id
+    setLiveStreamTurnId(liveStream, turnStart.turn.id)
 
-    for (const notification of buffered.splice(0, buffered.length)) {
-      if (settleNotification(notification) && completionResolved) {
-        break
+    for (const notification of liveStream.bufferedNotifications.splice(0, liveStream.bufferedNotifications.length)) {
+      const turnId = notificationTurnId(notification)
+      if (turnId && turnId !== liveStream.turnId) {
+        continue
       }
-    }
 
-    await completion
-    discardSnapshot(submittedAttachments)
-    status.value = 'ready'
-
-    if (routeThreadId.value) {
-      await hydrateThread(threadId)
-      return
+      applyNotification(notification)
     }
   } catch (caughtError) {
-    unsubscribe?.()
-    if (session.liveStream?.unsubscribe === unsubscribe) {
-      session.liveStream = null
+    const messageText = caughtError instanceof Error ? caughtError.message : String(caughtError)
+
+    untrackPendingUserMessage(optimisticMessageId)
+    removeOptimisticMessage(optimisticMessageId)
+
+    if (submissionMethod === 'turn/start') {
+      if (startedLiveStream && session.liveStream === startedLiveStream) {
+        clearPendingOptimisticMessages(clearLiveStream(new Error(messageText)))
+      }
+      session.pendingLiveStream = null
+      restoreDraftIfPristine(text, submittedAttachments)
+      error.value = messageText
+      status.value = 'error'
+      return
     }
-    stripOptimisticDraftMessages()
-    replaceAttachments(submittedAttachments)
-    input.value = text
+
+    restoreDraftIfPristine(text, submittedAttachments)
+    error.value = messageText
+  }
+}
+
+const stopActiveTurn = async () => {
+  if (!hasActiveTurnEngagement()) {
+    return
+  }
+
+  try {
+    const liveStream = await ensurePendingLiveStream()
+    if (liveStream.interruptRequested) {
+      return
+    }
+
+    liveStream.interruptRequested = true
+    error.value = null
+    const client = getClient(props.projectId)
+    const turnId = await waitForLiveStreamTurnId(liveStream)
+    await client.request('turn/interrupt', {
+      threadId: liveStream.threadId,
+      turnId
+    })
+    liveStream.interruptAcknowledged = true
+  } catch (caughtError) {
+    const liveStream = currentLiveStream()
+    if (liveStream) {
+      liveStream.interruptRequested = false
+    }
     error.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
-    status.value = 'error'
   }
 }
 
@@ -1556,7 +1730,7 @@ watch(status, (nextStatus, previousStatus) => {
             v-model="input"
             placeholder="Describe the change you want Codex to make"
             :error="submitError"
-            :disabled="isBusy"
+            :disabled="isComposerDisabled"
             autoresize
             @submit.prevent="sendMessage"
             @keydown.enter="onPromptEnter"
@@ -1566,6 +1740,7 @@ watch(status, (nextStatus, previousStatus) => {
           >
             <UChatPromptSubmit
               :status="status"
+              @stop="stopActiveTurn"
             />
 
             <template #footer>
@@ -1575,7 +1750,7 @@ watch(status, (nextStatus, previousStatus) => {
                   type="file"
                   accept="image/*"
                   class="hidden"
-                  :disabled="isBusy"
+                  :disabled="isComposerDisabled"
                   @change="onFileInputChange"
                 >
                 <UButton
@@ -1584,7 +1759,7 @@ watch(status, (nextStatus, previousStatus) => {
                   variant="soft"
                   size="sm"
                   icon="i-lucide-paperclip"
-                  :disabled="isBusy"
+                  :disabled="isComposerDisabled"
                   @click="openFilePicker"
                 >
                   Attach image
@@ -1622,7 +1797,7 @@ watch(status, (nextStatus, previousStatus) => {
                     variant="ghost"
                     size="xs"
                     icon="i-lucide-x"
-                    :disabled="isBusy"
+                    :disabled="isComposerDisabled"
                     :aria-label="`Remove ${attachment.name}`"
                     @click="removeAttachment(attachment.id)"
                   />

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -1237,6 +1237,16 @@ const applyNotification = (notification: CodexRpcNotification) => {
       if (params.item.type === 'collabAgentToolCall') {
         applySubagentActivityItem(params.item)
       }
+      if (params.item.type === 'userMessage') {
+        for (const nextMessage of itemToMessages(params.item)) {
+          reconcilePendingUserMessage({
+            ...nextMessage,
+            pending: false
+          })
+        }
+        status.value = 'streaming'
+        return
+      }
       seedStreamingMessage(params.item)
       status.value = 'streaming'
       return

--- a/packages/client/app/composables/useChatSession.ts
+++ b/packages/client/app/composables/useChatSession.ts
@@ -4,11 +4,20 @@ import type { CodexRpcNotification } from '~~/shared/codex-rpc'
 
 export type ChatStatus = 'ready' | 'submitted' | 'streaming' | 'error'
 
+export type LiveStreamTurnIdWaiter = {
+  resolve: (turnId: string) => void
+  reject: (error: Error) => void
+}
+
 export type LiveStream = {
   threadId: string
   turnId: string | null
   bufferedNotifications: CodexRpcNotification[]
   observedSubagentThreadIds: Set<string>
+  pendingUserMessageIds: string[]
+  turnIdWaiters: LiveStreamTurnIdWaiter[]
+  interruptRequested: boolean
+  interruptAcknowledged: boolean
   unsubscribe: (() => void) | null
 }
 
@@ -29,6 +38,7 @@ export type ChatSession = {
   pendingThreadId: Ref<string | null>
   autoRedirectThreadId: Ref<string | null>
   loadVersion: Ref<number>
+  pendingLiveStream: Promise<LiveStream> | null
   liveStream: LiveStream | null
 }
 
@@ -44,6 +54,7 @@ const createSession = (): ChatSession => ({
   pendingThreadId: ref<string | null>(null),
   autoRedirectThreadId: ref<string | null>(null),
   loadVersion: ref(0),
+  pendingLiveStream: null,
   liveStream: null
 })
 

--- a/packages/client/app/utils/chat-turn-engagement.ts
+++ b/packages/client/app/utils/chat-turn-engagement.ts
@@ -1,5 +1,7 @@
 import { upsertStreamingMessage, type ChatMessage } from '../../shared/codex-chat'
 
+export type PromptSubmitStatus = 'ready' | 'submitted' | 'streaming' | 'error'
+
 const interruptIgnoredMethods = new Set([
   'item/started',
   'item/agentMessage/delta',
@@ -13,6 +15,11 @@ const interruptIgnoredMethods = new Set([
 
 export const resolveTurnSubmissionMethod = (hasActiveTurn: boolean) =>
   hasActiveTurn ? 'turn/steer' : 'turn/start'
+
+export const resolvePromptSubmitStatus = (input: {
+  status: PromptSubmitStatus
+  hasDraftContent: boolean
+}) => input.hasDraftContent ? 'ready' : input.status
 
 export const shouldIgnoreNotificationAfterInterrupt = (method: string) =>
   interruptIgnoredMethods.has(method)

--- a/packages/client/app/utils/chat-turn-engagement.ts
+++ b/packages/client/app/utils/chat-turn-engagement.ts
@@ -1,0 +1,39 @@
+import { upsertStreamingMessage, type ChatMessage } from '../../shared/codex-chat'
+
+const interruptIgnoredMethods = new Set([
+  'item/started',
+  'item/agentMessage/delta',
+  'item/plan/delta',
+  'item/reasoning/textDelta',
+  'item/reasoning/summaryTextDelta',
+  'item/commandExecution/outputDelta',
+  'item/fileChange/outputDelta',
+  'item/mcpToolCall/progress'
+])
+
+export const resolveTurnSubmissionMethod = (hasActiveTurn: boolean) =>
+  hasActiveTurn ? 'turn/steer' : 'turn/start'
+
+export const shouldIgnoreNotificationAfterInterrupt = (method: string) =>
+  interruptIgnoredMethods.has(method)
+
+export const removeChatMessage = (messages: ChatMessage[], messageId: string) =>
+  messages.filter(message => message.id !== messageId)
+
+export const removePendingUserMessageId = (messageIds: string[], messageId: string) =>
+  messageIds.filter(candidateId => candidateId !== messageId)
+
+export const reconcileOptimisticUserMessage = (
+  messages: ChatMessage[],
+  optimisticMessageId: string,
+  confirmedMessage: ChatMessage
+) => {
+  const index = messages.findIndex(message => message.id === optimisticMessageId)
+  if (index === -1) {
+    return upsertStreamingMessage(messages, confirmedMessage)
+  }
+
+  return messages.map((message, messageIndex) =>
+    messageIndex === index ? confirmedMessage : message
+  )
+}

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   reconcileOptimisticUserMessage,
   removePendingUserMessageId,
+  resolvePromptSubmitStatus,
   resolveTurnSubmissionMethod,
   shouldIgnoreNotificationAfterInterrupt
 } from '../app/utils/chat-turn-engagement'
@@ -254,6 +255,18 @@ describe('client package', () => {
   it('routes submissions to turn start or same-turn steering', () => {
     expect(resolveTurnSubmissionMethod(false)).toBe('turn/start')
     expect(resolveTurnSubmissionMethod(true)).toBe('turn/steer')
+  })
+
+  it('keeps the prompt submit button in send mode while a draft exists', () => {
+    expect(resolvePromptSubmitStatus({
+      status: 'streaming',
+      hasDraftContent: true
+    })).toBe('ready')
+
+    expect(resolvePromptSubmitStatus({
+      status: 'submitted',
+      hasDraftContent: false
+    })).toBe('submitted')
   })
 
   it('reconciles a pending optimistic user message in place', () => {

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -1,4 +1,10 @@
 import { describe, expect, it } from 'vitest'
+import {
+  reconcileOptimisticUserMessage,
+  removePendingUserMessageId,
+  resolveTurnSubmissionMethod,
+  shouldIgnoreNotificationAfterInterrupt
+} from '../app/utils/chat-turn-engagement'
 import { ITEM_PART, isSubagentActiveStatus, itemToMessages } from '../shared/codex-chat'
 import {
   buildTurnStartInput,
@@ -243,5 +249,68 @@ describe('client package', () => {
     expect(isSubagentActiveStatus('pendingInit')).toBe(true)
     expect(isSubagentActiveStatus('running')).toBe(true)
     expect(isSubagentActiveStatus('completed')).toBe(false)
+  })
+
+  it('routes submissions to turn start or same-turn steering', () => {
+    expect(resolveTurnSubmissionMethod(false)).toBe('turn/start')
+    expect(resolveTurnSubmissionMethod(true)).toBe('turn/steer')
+  })
+
+  it('reconciles a pending optimistic user message in place', () => {
+    expect(reconcileOptimisticUserMessage([{
+      id: 'local-user-1',
+      role: 'user',
+      pending: true,
+      parts: [{
+        type: 'text',
+        text: 'Follow this direction instead.',
+        state: 'done'
+      }]
+    }, {
+      id: 'agent-1',
+      role: 'assistant',
+      parts: [{
+        type: 'text',
+        text: 'Working on it',
+        state: 'streaming'
+      }]
+    }], 'local-user-1', {
+      id: 'user-1',
+      role: 'user',
+      pending: false,
+      parts: [{
+        type: 'text',
+        text: 'Follow this direction instead.',
+        state: 'done'
+      }]
+    })).toEqual([{
+      id: 'user-1',
+      role: 'user',
+      pending: false,
+      parts: [{
+        type: 'text',
+        text: 'Follow this direction instead.',
+        state: 'done'
+      }]
+    }, {
+      id: 'agent-1',
+      role: 'assistant',
+      parts: [{
+        type: 'text',
+        text: 'Working on it',
+        state: 'streaming'
+      }]
+    }])
+  })
+
+  it('removes only the failed optimistic message from the pending queue', () => {
+    expect(removePendingUserMessageId(['local-user-1', 'local-user-2'], 'local-user-1')).toEqual(['local-user-2'])
+  })
+
+  it('ignores further streaming deltas after interruption is acknowledged', () => {
+    expect(shouldIgnoreNotificationAfterInterrupt('item/agentMessage/delta')).toBe(true)
+    expect(shouldIgnoreNotificationAfterInterrupt('item/started')).toBe(true)
+    expect(shouldIgnoreNotificationAfterInterrupt('item/completed')).toBe(false)
+    expect(shouldIgnoreNotificationAfterInterrupt('turn/completed')).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- unify in-flight chat control around a shared active-turn live stream state and reconcile server-confirmed user items without duplicating optimistic turn-start and steer messages
- keep the composer usable during active turns, switching the prompt control between stop and send based on whether the draft has trimmed text or attachments
- clear stale live-stream subscriptions when switching threads and make interrupt-in-flight composer locking reactive so stop requests cannot race with new steer submissions

## Validation
- `pnpm --filter @codori/client test`
- `pnpm --filter @codori/client typecheck`
- `pnpm --filter @codori/client build`

Closes #3
Closes #4
