### PR TITLE
Improve chat prompt footer controls and context window display

### DIFF
--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -258,30 +258,41 @@ const loadPromptControls = async () => {
     try {
       await ensureProjectRuntime()
       const client = getClient(props.projectId)
+      const initialModel = selectedModel.value
+      const initialEffort = selectedEffort.value
       let nextModels = availableModels.value.length > 0 ? availableModels.value : FALLBACK_MODELS
-      let preferredModel = selectedModel.value
-      let preferredEffort = selectedEffort.value
+      let defaultModel: string | null = null
+      let defaultEffort: ReasoningEffort | null = null
 
-      try {
-        const response = await client.request<ModelListResponse>('model/list')
-        nextModels = visibleModelOptions(normalizeModelList(response))
-      } catch {
+      const [modelsResponse, configResponse] = await Promise.allSettled([
+        client.request<ModelListResponse>('model/list'),
+        client.request<ConfigReadResponse>('config/read')
+      ])
+
+      if (modelsResponse.status === 'fulfilled') {
+        nextModels = visibleModelOptions(normalizeModelList(modelsResponse.value))
+      } else {
         nextModels = visibleModelOptions(nextModels)
       }
 
-      try {
-        const response = await client.request<ConfigReadResponse>('config/read')
-        const defaults = normalizeConfigDefaults(response)
+      if (configResponse.status === 'fulfilled') {
+        const defaults = normalizeConfigDefaults(configResponse.value)
         if (defaults.contextWindow != null) {
           modelContextWindow.value = defaults.contextWindow
         }
-        preferredModel = defaults.model ?? preferredModel
-        preferredEffort = defaults.effort ?? preferredEffort
-      } catch {
-        // Fall back to the local defaults when config is unavailable.
+        defaultModel = defaults.model
+        defaultEffort = defaults.effort
       }
 
       availableModels.value = nextModels
+
+      const preferredModel = selectedModel.value !== initialModel
+        ? selectedModel.value
+        : defaultModel ?? initialModel
+      const preferredEffort = selectedEffort.value !== initialEffort
+        ? selectedEffort.value
+        : defaultEffort ?? initialEffort
+
       normalizePromptSelection(preferredModel, preferredEffort)
       promptControlsLoaded.value = true
     } finally {
@@ -1640,7 +1651,14 @@ const sendMessage = async () => {
     return
   }
 
-  await loadPromptControls()
+  try {
+    await loadPromptControls()
+  } catch (caughtError) {
+    error.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
+    status.value = 'error'
+    return
+  }
+
   pinnedToBottom.value = true
   error.value = null
   attachmentError.value = null

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -30,6 +30,8 @@ import {
 } from '~~/shared/codex-chat'
 import { buildTurnStartInput } from '~~/shared/chat-attachments'
 import {
+  type ConfigReadResponse,
+  type ModelListResponse,
   notificationThreadId,
   notificationTurnId,
   type CodexRpcNotification,
@@ -40,6 +42,21 @@ import {
   type ThreadStartResponse,
   type TurnStartResponse
 } from '~~/shared/codex-rpc'
+import {
+  buildTurnOverrides,
+  coercePromptSelection,
+  ensureModelOption,
+  FALLBACK_MODELS,
+  formatCompactTokenCount,
+  formatReasoningEffortLabel,
+  normalizeConfigDefaults,
+  normalizeModelList,
+  normalizeThreadTokenUsage,
+  resolveContextWindowState,
+  resolveEffortOptions,
+  visibleModelOptions,
+  type ReasoningEffort
+} from '~~/shared/chat-prompt-controls'
 import { toProjectThreadRoute } from '~~/shared/codori'
 
 const props = defineProps<{
@@ -93,7 +110,14 @@ const {
   threadTitle,
   pendingThreadId,
   autoRedirectThreadId,
-  loadVersion
+  loadVersion,
+  promptControlsLoaded,
+  promptControlsLoading,
+  availableModels,
+  selectedModel,
+  selectedEffort,
+  modelContextWindow,
+  tokenUsage
 } = session
 
 const selectedProject = computed(() => getProject(props.projectId))
@@ -147,8 +171,131 @@ const starterPrompts = computed(() => {
   ]
 })
 
+const hasKnownThreadUsage = computed(() => !activeThreadId.value || tokenUsage.value !== null)
+const effectiveModelList = computed(() => {
+  const withSelected = ensureModelOption(
+    availableModels.value.length > 0 ? availableModels.value : FALLBACK_MODELS,
+    selectedModel.value,
+    selectedEffort.value
+  )
+  return visibleModelOptions(withSelected)
+})
+const selectedModelOption = computed(() =>
+  effectiveModelList.value.find(model => model.model === selectedModel.value)
+  ?? effectiveModelList.value[0]
+  ?? FALLBACK_MODELS[0]
+)
+const modelSelectItems = computed(() =>
+  effectiveModelList.value.map(model => ({
+    label: model.displayName,
+    value: model.model
+  }))
+)
+const effortOptions = computed(() => resolveEffortOptions(effectiveModelList.value, selectedModel.value))
+const effortSelectItems = computed(() =>
+  effortOptions.value.map(effort => ({
+    label: formatReasoningEffortLabel(effort),
+    value: effort
+  }))
+)
+const contextWindowState = computed(() =>
+  resolveContextWindowState(tokenUsage.value, modelContextWindow.value, hasKnownThreadUsage.value)
+)
+const contextUsedPercent = computed(() => contextWindowState.value.usedPercent ?? 0)
+const contextIndicatorLabel = computed(() => {
+  const remainingPercent = contextWindowState.value.remainingPercent
+  return remainingPercent == null ? 'ctx' : `${Math.round(remainingPercent)}%`
+})
+const contextSummaryLabel = computed(() => {
+  const remainingPercent = contextWindowState.value.remainingPercent
+  if (remainingPercent == null) {
+    return 'Context'
+  }
+
+  return `${Math.round(remainingPercent)}% left`
+})
+
+const normalizePromptSelection = (
+  preferredModel?: string | null,
+  preferredEffort?: ReasoningEffort | null
+) => {
+  const withSelected = ensureModelOption(
+    availableModels.value.length > 0 ? availableModels.value : FALLBACK_MODELS,
+    preferredModel ?? selectedModel.value,
+    preferredEffort ?? selectedEffort.value
+  )
+  const visibleModels = visibleModelOptions(withSelected)
+  const nextSelection = coercePromptSelection(visibleModels, preferredModel ?? selectedModel.value, preferredEffort ?? selectedEffort.value)
+
+  availableModels.value = visibleModels
+  if (selectedModel.value !== nextSelection.model) {
+    selectedModel.value = nextSelection.model
+  }
+  if (selectedEffort.value !== nextSelection.effort) {
+    selectedEffort.value = nextSelection.effort
+  }
+}
+
+const syncPromptSelectionFromThread = (
+  model: string | null | undefined,
+  effort: ReasoningEffort | null | undefined
+) => {
+  normalizePromptSelection(model ?? null, effort ?? null)
+}
+
+const loadPromptControls = async () => {
+  if (promptControlsLoaded.value) {
+    return
+  }
+
+  if (promptControlsPromise) {
+    return await promptControlsPromise
+  }
+
+  promptControlsPromise = (async () => {
+    promptControlsLoading.value = true
+
+    try {
+      await ensureProjectRuntime()
+      const client = getClient(props.projectId)
+      let nextModels = availableModels.value.length > 0 ? availableModels.value : FALLBACK_MODELS
+      let preferredModel = selectedModel.value
+      let preferredEffort = selectedEffort.value
+
+      try {
+        const response = await client.request<ModelListResponse>('model/list')
+        nextModels = visibleModelOptions(normalizeModelList(response))
+      } catch {
+        nextModels = visibleModelOptions(nextModels)
+      }
+
+      try {
+        const response = await client.request<ConfigReadResponse>('config/read')
+        const defaults = normalizeConfigDefaults(response)
+        if (defaults.contextWindow != null) {
+          modelContextWindow.value = defaults.contextWindow
+        }
+        preferredModel = defaults.model ?? preferredModel
+        preferredEffort = defaults.effort ?? preferredEffort
+      } catch {
+        // Fall back to the local defaults when config is unavailable.
+      }
+
+      availableModels.value = nextModels
+      normalizePromptSelection(preferredModel, preferredEffort)
+      promptControlsLoaded.value = true
+    } finally {
+      promptControlsLoading.value = false
+      promptControlsPromise = null
+    }
+  })()
+
+  return await promptControlsPromise
+}
+
 const subagentBootstrapPromises = new Map<string, Promise<void>>()
 const optimisticAttachmentSnapshots = new Map<string, DraftAttachment[]>()
+let promptControlsPromise: Promise<void> | null = null
 
 const isActiveTurnStatus = (value: string | null | undefined) => {
   if (!value) {
@@ -535,6 +682,7 @@ const hydrateThread = async (threadId: string) => {
   const requestVersion = loadVersion.value + 1
   loadVersion.value = requestVersion
   error.value = null
+  tokenUsage.value = null
 
   try {
     await ensureProjectRuntime()
@@ -579,7 +727,7 @@ const hydrateThread = async (threadId: string) => {
       setSessionLiveStream(nextLiveStream)
     }
 
-    await client.request<ThreadResumeResponse>('thread/resume', {
+    const resumeResponse = await client.request<ThreadResumeResponse>('thread/resume', {
       threadId,
       cwd: selectedProject.value?.projectPath ?? null,
       approvalPolicy: 'never',
@@ -594,6 +742,10 @@ const hydrateThread = async (threadId: string) => {
       return
     }
 
+    syncPromptSelectionFromThread(
+      resumeResponse.model ?? null,
+      (resumeResponse.reasoningEffort as ReasoningEffort | null | undefined) ?? null
+    )
     activeThreadId.value = response.thread.id
     threadTitle.value = resolveThreadTitle(response.thread)
     messages.value = threadToMessages(response.thread)
@@ -640,6 +792,7 @@ const resetDraftThread = () => {
   messages.value = []
   subagentPanels.value = []
   error.value = null
+  tokenUsage.value = null
   status.value = 'ready'
 }
 
@@ -1427,6 +1580,16 @@ const applyNotification = (notification: CodexRpcNotification) => {
       status.value = 'streaming'
       return
     }
+    case 'thread/tokenUsage/updated': {
+      const nextUsage = normalizeThreadTokenUsage(notification.params)
+      if (nextUsage) {
+        tokenUsage.value = nextUsage
+        if (nextUsage.modelContextWindow != null) {
+          modelContextWindow.value = nextUsage.modelContextWindow
+        }
+      }
+      return
+    }
     case 'error': {
       const params = notification.params as { error?: { message?: string } }
       const messageText = params.error?.message ?? 'The stream failed.'
@@ -1477,6 +1640,7 @@ const sendMessage = async () => {
     return
   }
 
+  await loadPromptControls()
   pinnedToBottom.value = true
   error.value = null
   attachmentError.value = null
@@ -1504,7 +1668,8 @@ const sendMessage = async () => {
       await client.request<TurnStartResponse>('turn/steer', {
         threadId: liveStream.threadId,
         expectedTurnId: turnId,
-        input: buildTurnStartInput(text, uploadedAttachments)
+        input: buildTurnStartInput(text, uploadedAttachments),
+        ...buildTurnOverrides(selectedModel.value, selectedEffort.value)
       })
       return
     }
@@ -1519,7 +1684,8 @@ const sendMessage = async () => {
       threadId,
       input: buildTurnStartInput(text, uploadedAttachments),
       cwd: selectedProject.value?.projectPath ?? null,
-      approvalPolicy: 'never'
+      approvalPolicy: 'never',
+      ...buildTurnOverrides(selectedModel.value, selectedEffort.value)
     })
 
     setLiveStreamTurnId(liveStream, turnStart.turn.id)
@@ -1607,6 +1773,7 @@ onMounted(() => {
     void refreshProjects()
   }
 
+  void loadPromptControls()
   void scheduleScrollToBottom('auto')
 })
 
@@ -1660,6 +1827,18 @@ watch(status, (nextStatus, previousStatus) => {
 
   void scheduleScrollToBottom(nextStatus === 'streaming' ? 'auto' : 'smooth')
 }, { flush: 'post' })
+
+watch([selectedModel, availableModels], () => {
+  const nextSelection = coercePromptSelection(effectiveModelList.value, selectedModel.value, selectedEffort.value)
+  if (selectedModel.value !== nextSelection.model) {
+    selectedModel.value = nextSelection.model
+    return
+  }
+
+  if (selectedEffort.value !== nextSelection.effort) {
+    selectedEffort.value = nextSelection.effort
+  }
+}, { flush: 'sync' })
 </script>
 
 <template>
@@ -1779,45 +1958,15 @@ watch(status, (nextStatus, previousStatus) => {
             @compositionend="onCompositionEnd"
             @paste="onPaste"
           >
-            <UChatPromptSubmit
-              :status="promptSubmitStatus"
-              @stop="stopActiveTurn"
-            />
-
-            <template #footer>
-              <div class="flex flex-wrap items-center gap-2 pt-1">
-                <input
-                  ref="fileInput"
-                  type="file"
-                  accept="image/*"
-                  class="hidden"
-                  :disabled="isComposerDisabled"
-                  @change="onFileInputChange"
-                >
-                <UButton
-                  type="button"
-                  color="neutral"
-                  variant="soft"
-                  size="sm"
-                  icon="i-lucide-paperclip"
-                  :disabled="isComposerDisabled"
-                  @click="openFilePicker"
-                >
-                  Attach image
-                </UButton>
-                <span class="text-xs text-muted">
-                  Drag and drop or paste an image
-                </span>
-              </div>
-
+            <template #header>
               <div
                 v-if="attachments.length"
-                class="mt-3 flex flex-wrap gap-2"
+                class="flex flex-wrap gap-2 pb-2"
               >
                 <div
                   v-for="attachment in attachments"
                   :key="attachment.id"
-                  class="flex max-w-full items-center gap-3 rounded-2xl border border-default bg-elevated/35 px-3 py-2"
+                  class="flex max-w-full items-center gap-2 rounded-2xl border border-default bg-elevated/35 px-2 py-1.5"
                 >
                   <img
                     :src="attachment.previewUrl"
@@ -1825,10 +1974,10 @@ watch(status, (nextStatus, previousStatus) => {
                     class="size-10 rounded-xl object-cover"
                   >
                   <div class="min-w-0">
-                    <div class="truncate text-sm font-medium text-highlighted">
+                    <div class="max-w-40 truncate text-xs font-medium text-highlighted">
                       {{ attachment.name }}
                     </div>
-                    <div class="text-xs text-muted">
+                    <div class="text-[11px] text-muted">
                       {{ formatAttachmentSize(attachment.size) }}
                     </div>
                   </div>
@@ -1839,10 +1988,201 @@ watch(status, (nextStatus, previousStatus) => {
                     size="xs"
                     icon="i-lucide-x"
                     :disabled="isComposerDisabled"
+                    class="rounded-full"
                     :aria-label="`Remove ${attachment.name}`"
                     @click="removeAttachment(attachment.id)"
                   />
                 </div>
+              </div>
+            </template>
+
+            <UChatPromptSubmit
+              :status="promptSubmitStatus"
+              @stop="stopActiveTurn"
+            />
+
+            <template #footer>
+              <input
+                ref="fileInput"
+                type="file"
+                accept="image/*"
+                class="hidden"
+                :disabled="isComposerDisabled"
+                @change="onFileInputChange"
+              >
+
+              <div class="flex items-start justify-between gap-3 pt-1">
+                <div class="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+                  <UButton
+                    type="button"
+                    color="neutral"
+                    variant="ghost"
+                    size="sm"
+                    icon="i-lucide-plus"
+                    :disabled="isComposerDisabled"
+                    class="size-8 shrink-0 justify-center rounded-full border border-default/70"
+                    :ui="{ leadingIcon: 'size-4', base: 'px-0' }"
+                    aria-label="Attach image"
+                    @click="openFilePicker"
+                  />
+
+                  <USelect
+                    v-model="selectedModel"
+                    :items="modelSelectItems"
+                    color="neutral"
+                    variant="ghost"
+                    size="sm"
+                    :loading="promptControlsLoading"
+                    :disabled="isComposerDisabled"
+                    class="min-w-0 flex-1 sm:max-w-52 sm:flex-none"
+                    :ui="{ base: 'rounded-full border border-default/70 bg-default/70', value: 'truncate', content: 'min-w-56' }"
+                  />
+
+                  <USelect
+                    v-model="selectedEffort"
+                    :items="effortSelectItems"
+                    color="neutral"
+                    variant="ghost"
+                    size="sm"
+                    :disabled="isComposerDisabled"
+                    class="min-w-0 flex-1 sm:max-w-36 sm:flex-none"
+                    :ui="{ base: 'rounded-full border border-default/70 bg-default/70', value: 'truncate' }"
+                  />
+
+                  <span class="hidden text-[11px] text-muted md:inline">
+                    Drag, drop, or paste an image
+                  </span>
+                </div>
+
+                <UPopover
+                  :content="{ side: 'top', align: 'end' }"
+                  arrow
+                >
+                  <button
+                    type="button"
+                    class="flex shrink-0 items-center gap-2 rounded-full border border-default/70 bg-default/70 px-2 py-1 text-left"
+                  >
+                    <span class="relative flex size-8 items-center justify-center">
+                      <svg
+                        viewBox="0 0 36 36"
+                        class="size-8 -rotate-90"
+                        aria-hidden="true"
+                      >
+                        <circle
+                          cx="18"
+                          cy="18"
+                          r="15.5"
+                          fill="none"
+                          stroke-width="3"
+                          pathLength="100"
+                          class="stroke-current text-muted/20"
+                          stroke-dasharray="100 100"
+                        />
+                        <circle
+                          cx="18"
+                          cy="18"
+                          r="15.5"
+                          fill="none"
+                          stroke-width="3"
+                          pathLength="100"
+                          class="stroke-current text-primary"
+                          stroke-linecap="round"
+                          :stroke-dasharray="`${contextUsedPercent} 100`"
+                        />
+                      </svg>
+                      <span class="absolute text-[9px] font-semibold text-highlighted">
+                        {{ contextIndicatorLabel }}
+                      </span>
+                    </span>
+
+                    <div class="hidden min-w-0 leading-tight sm:block">
+                      <div class="text-[11px] font-medium text-highlighted">
+                        {{ contextSummaryLabel }}
+                      </div>
+                      <div class="text-[10px] text-muted">
+                        {{ modelContextWindow ? `${formatCompactTokenCount(modelContextWindow)} ctx` : 'Context window' }}
+                      </div>
+                    </div>
+                  </button>
+
+                  <template #content>
+                    <div class="w-72 space-y-3 p-4">
+                      <div class="space-y-1">
+                        <div class="text-xs font-semibold uppercase tracking-[0.22em] text-primary">
+                          Context Window
+                        </div>
+                        <div class="text-sm font-medium text-highlighted">
+                          {{ selectedModelOption?.displayName ?? 'Selected model' }}
+                        </div>
+                      </div>
+
+                      <div
+                        v-if="contextWindowState.contextWindow && contextWindowState.usedTokens !== null"
+                        class="grid grid-cols-2 gap-3 text-sm"
+                      >
+                        <div class="rounded-2xl border border-default bg-elevated/35 px-3 py-2">
+                          <div class="text-[11px] uppercase tracking-[0.18em] text-muted">
+                            Remaining
+                          </div>
+                          <div class="mt-1 font-semibold text-highlighted">
+                            {{ Math.round(contextWindowState.remainingPercent ?? 0) }}%
+                          </div>
+                          <div class="text-xs text-muted">
+                            {{ formatCompactTokenCount(contextWindowState.remainingTokens ?? 0) }} tokens
+                          </div>
+                        </div>
+                        <div class="rounded-2xl border border-default bg-elevated/35 px-3 py-2">
+                          <div class="text-[11px] uppercase tracking-[0.18em] text-muted">
+                            Used
+                          </div>
+                          <div class="mt-1 font-semibold text-highlighted">
+                            {{ formatCompactTokenCount(contextWindowState.usedTokens ?? 0) }}
+                          </div>
+                          <div class="text-xs text-muted">
+                            of {{ formatCompactTokenCount(contextWindowState.contextWindow) }}
+                          </div>
+                        </div>
+                      </div>
+
+                      <div
+                        v-else
+                        class="rounded-2xl border border-default bg-elevated/35 px-3 py-2 text-sm text-muted"
+                      >
+                        <div v-if="contextWindowState.contextWindow">
+                          Live token usage will appear after the next turn completes.
+                        </div>
+                        <div v-else>
+                          Context window details are not available from the runtime yet.
+                        </div>
+                      </div>
+
+                      <div class="grid grid-cols-2 gap-3 text-sm">
+                        <div class="rounded-2xl border border-default bg-elevated/35 px-3 py-2">
+                          <div class="text-[11px] uppercase tracking-[0.18em] text-muted">
+                            Input
+                          </div>
+                          <div class="mt-1 font-semibold text-highlighted">
+                            {{ formatCompactTokenCount(tokenUsage?.totalInputTokens ?? 0) }}
+                          </div>
+                          <div class="text-xs text-muted">
+                            cached {{ formatCompactTokenCount(tokenUsage?.totalCachedInputTokens ?? 0) }}
+                          </div>
+                        </div>
+                        <div class="rounded-2xl border border-default bg-elevated/35 px-3 py-2">
+                          <div class="text-[11px] uppercase tracking-[0.18em] text-muted">
+                            Output
+                          </div>
+                          <div class="mt-1 font-semibold text-highlighted">
+                            {{ formatCompactTokenCount(tokenUsage?.totalOutputTokens ?? 0) }}
+                          </div>
+                          <div class="text-xs text-muted">
+                            effort {{ formatReasoningEffortLabel(selectedEffort) }}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </template>
+                </UPopover>
               </div>
             </template>
           </UChatPrompt>

--- a/packages/client/app/composables/useChatSession.ts
+++ b/packages/client/app/composables/useChatSession.ts
@@ -1,6 +1,12 @@
 import { ref, type Ref } from 'vue'
 import type { ChatMessage, SubagentAgentStatus, VisualSubagentPanel } from '~~/shared/codex-chat'
 import type { CodexRpcNotification } from '~~/shared/codex-rpc'
+import {
+  FALLBACK_MODELS,
+  type ModelOption,
+  type ReasoningEffort,
+  type TokenUsageSnapshot
+} from '~~/shared/chat-prompt-controls'
 
 export type ChatStatus = 'ready' | 'submitted' | 'streaming' | 'error'
 
@@ -38,6 +44,13 @@ export type ChatSession = {
   pendingThreadId: Ref<string | null>
   autoRedirectThreadId: Ref<string | null>
   loadVersion: Ref<number>
+  promptControlsLoaded: Ref<boolean>
+  promptControlsLoading: Ref<boolean>
+  availableModels: Ref<ModelOption[]>
+  selectedModel: Ref<string>
+  selectedEffort: Ref<ReasoningEffort>
+  modelContextWindow: Ref<number | null>
+  tokenUsage: Ref<TokenUsageSnapshot | null>
   pendingLiveStream: Promise<LiveStream> | null
   liveStream: LiveStream | null
 }
@@ -54,6 +67,13 @@ const createSession = (): ChatSession => ({
   pendingThreadId: ref<string | null>(null),
   autoRedirectThreadId: ref<string | null>(null),
   loadVersion: ref(0),
+  promptControlsLoaded: ref(false),
+  promptControlsLoading: ref(false),
+  availableModels: ref<ModelOption[]>(FALLBACK_MODELS),
+  selectedModel: ref(FALLBACK_MODELS[0]!.model),
+  selectedEffort: ref(FALLBACK_MODELS[0]!.defaultReasoningEffort),
+  modelContextWindow: ref<number | null>(null),
+  tokenUsage: ref<TokenUsageSnapshot | null>(null),
   pendingLiveStream: null,
   liveStream: null
 })

--- a/packages/client/shared/chat-prompt-controls.ts
+++ b/packages/client/shared/chat-prompt-controls.ts
@@ -1,0 +1,339 @@
+export const FALLBACK_REASONING_EFFORTS = [
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh'
+] as const
+
+export type ReasoningEffort = typeof FALLBACK_REASONING_EFFORTS[number]
+
+export type ModelOption = {
+  id: string
+  model: string
+  displayName: string
+  hidden: boolean
+  isDefault: boolean
+  defaultReasoningEffort: ReasoningEffort
+  supportedReasoningEfforts: ReasoningEffort[]
+}
+
+export type TokenUsageSnapshot = {
+  totalInputTokens: number
+  totalCachedInputTokens: number
+  totalOutputTokens: number
+  lastInputTokens: number
+  lastCachedInputTokens: number
+  lastOutputTokens: number
+  modelContextWindow: number | null
+}
+
+type ReasoningEffortOptionRecord = {
+  reasoningEffort?: unknown
+}
+
+type ModelRecord = {
+  id?: unknown
+  model?: unknown
+  displayName?: unknown
+  hidden?: unknown
+  isDefault?: unknown
+  defaultReasoningEffort?: unknown
+  supportedReasoningEfforts?: unknown
+}
+
+export const FALLBACK_MODELS: ModelOption[] = [
+  {
+    id: 'gpt-5.4',
+    model: 'gpt-5.4',
+    displayName: 'GPT-5.4',
+    hidden: false,
+    isDefault: true,
+    defaultReasoningEffort: 'medium',
+    supportedReasoningEfforts: [...FALLBACK_REASONING_EFFORTS]
+  },
+  {
+    id: 'gpt-5.4-mini',
+    model: 'gpt-5.4-mini',
+    displayName: 'GPT-5.4 Mini',
+    hidden: false,
+    isDefault: false,
+    defaultReasoningEffort: 'medium',
+    supportedReasoningEfforts: [...FALLBACK_REASONING_EFFORTS]
+  },
+  {
+    id: 'gpt-5.3-codex',
+    model: 'gpt-5.3-codex',
+    displayName: 'GPT-5.3 Codex',
+    hidden: false,
+    isDefault: false,
+    defaultReasoningEffort: 'medium',
+    supportedReasoningEfforts: [...FALLBACK_REASONING_EFFORTS]
+  }
+]
+
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isReasoningEffort = (value: unknown): value is ReasoningEffort =>
+  typeof value === 'string' && FALLBACK_REASONING_EFFORTS.includes(value as ReasoningEffort)
+
+const toFiniteNumber = (value: unknown) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === 'bigint') {
+    return Number(value)
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) {
+      return parsed
+    }
+  }
+
+  return null
+}
+
+const toReasoningEfforts = (value: unknown): ReasoningEffort[] => {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.flatMap((entry) => {
+    if (isReasoningEffort(entry)) {
+      return [entry]
+    }
+
+    const record = isObjectRecord(entry) ? entry as ReasoningEffortOptionRecord : null
+    return isReasoningEffort(record?.reasoningEffort) ? [record.reasoningEffort] : []
+  })
+}
+
+const normalizeModel = (value: unknown): ModelOption | null => {
+  const record = isObjectRecord(value) ? value as ModelRecord : null
+  if (!record || typeof record.model !== 'string') {
+    return null
+  }
+
+  const supportedReasoningEfforts = toReasoningEfforts(record.supportedReasoningEfforts)
+  const defaultReasoningEffort = isReasoningEffort(record.defaultReasoningEffort)
+    ? record.defaultReasoningEffort
+    : supportedReasoningEfforts[0] ?? 'medium'
+
+  return {
+    id: typeof record.id === 'string' ? record.id : record.model,
+    model: record.model,
+    displayName: typeof record.displayName === 'string' && record.displayName.trim()
+      ? record.displayName.trim()
+      : record.model,
+    hidden: Boolean(record.hidden),
+    isDefault: Boolean(record.isDefault),
+    defaultReasoningEffort,
+    supportedReasoningEfforts: supportedReasoningEfforts.length > 0
+      ? supportedReasoningEfforts
+      : [...FALLBACK_REASONING_EFFORTS]
+  }
+}
+
+export const normalizeModelList = (value: unknown): ModelOption[] => {
+  const data = isObjectRecord(value) && Array.isArray(value.data)
+    ? value.data
+    : Array.isArray(value)
+      ? value
+      : []
+
+  const models = data
+    .map(normalizeModel)
+    .filter((entry): entry is ModelOption => entry !== null)
+
+  return models.length > 0 ? models : FALLBACK_MODELS
+}
+
+export const ensureModelOption = (
+  models: ModelOption[],
+  model: string | null | undefined,
+  effort?: ReasoningEffort | null
+) => {
+  if (!model || models.some(entry => entry.model === model)) {
+    return models
+  }
+
+  return [{
+    id: model,
+    model,
+    displayName: model,
+    hidden: false,
+    isDefault: false,
+    defaultReasoningEffort: effort ?? 'medium',
+    supportedReasoningEfforts: [...FALLBACK_REASONING_EFFORTS]
+  }, ...models]
+}
+
+export const visibleModelOptions = (models: ModelOption[]) => {
+  const visible = models.filter(model => !model.hidden)
+  return visible.length > 0 ? visible : FALLBACK_MODELS
+}
+
+export const resolveSelectedModel = (
+  models: ModelOption[],
+  preferredModel?: string | null
+) => {
+  if (preferredModel && models.some(model => model.model === preferredModel)) {
+    return preferredModel
+  }
+
+  const defaultModel = models.find(model => model.isDefault)?.model
+  return defaultModel ?? models[0]?.model ?? FALLBACK_MODELS[0]!.model
+}
+
+export const resolveEffortOptions = (
+  models: ModelOption[],
+  model: string | null | undefined
+) => {
+  const selectedModel = models.find(entry => entry.model === model)
+  return selectedModel?.supportedReasoningEfforts.length
+    ? selectedModel.supportedReasoningEfforts
+    : [...FALLBACK_REASONING_EFFORTS]
+}
+
+export const resolveSelectedEffort = (
+  models: ModelOption[],
+  model: string | null | undefined,
+  preferredEffort?: ReasoningEffort | null
+) => {
+  const effortOptions = resolveEffortOptions(models, model)
+  if (preferredEffort && effortOptions.includes(preferredEffort)) {
+    return preferredEffort
+  }
+
+  const selectedModel = models.find(entry => entry.model === model)
+  if (selectedModel && effortOptions.includes(selectedModel.defaultReasoningEffort)) {
+    return selectedModel.defaultReasoningEffort
+  }
+
+  return effortOptions[0] ?? 'medium'
+}
+
+export const coercePromptSelection = (
+  models: ModelOption[],
+  preferredModel?: string | null,
+  preferredEffort?: ReasoningEffort | null
+) => {
+  const nextModel = resolveSelectedModel(models, preferredModel)
+  return {
+    model: nextModel,
+    effort: resolveSelectedEffort(models, nextModel, preferredEffort)
+  }
+}
+
+export const normalizeConfigDefaults = (value: unknown) => {
+  const config = isObjectRecord(value) && isObjectRecord(value.config)
+    ? value.config
+    : null
+
+  return {
+    model: typeof config?.model === 'string' ? config.model : null,
+    effort: isReasoningEffort(config?.model_reasoning_effort) ? config.model_reasoning_effort : null,
+    contextWindow: toFiniteNumber(config?.model_context_window)
+  }
+}
+
+export const normalizeThreadTokenUsage = (value: unknown): TokenUsageSnapshot | null => {
+  const params = isObjectRecord(value) ? value : null
+  const tokenUsage = isObjectRecord(params?.tokenUsage) ? params.tokenUsage : null
+  if (!tokenUsage) {
+    return null
+  }
+
+  const total = isObjectRecord(tokenUsage.total) ? tokenUsage.total : {}
+  const last = isObjectRecord(tokenUsage.last) ? tokenUsage.last : {}
+
+  return {
+    totalInputTokens: toFiniteNumber(total.inputTokens) ?? 0,
+    totalCachedInputTokens: toFiniteNumber(total.cachedInputTokens) ?? 0,
+    totalOutputTokens: toFiniteNumber(total.outputTokens) ?? 0,
+    lastInputTokens: toFiniteNumber(last.inputTokens) ?? 0,
+    lastCachedInputTokens: toFiniteNumber(last.cachedInputTokens) ?? 0,
+    lastOutputTokens: toFiniteNumber(last.outputTokens) ?? 0,
+    modelContextWindow: toFiniteNumber(tokenUsage.modelContextWindow)
+  }
+}
+
+export const buildTurnOverrides = (
+  model: string | null | undefined,
+  effort: ReasoningEffort | null | undefined
+) => {
+  const overrides: {
+    model?: string
+    effort?: ReasoningEffort
+  } = {}
+
+  if (model) {
+    overrides.model = model
+  }
+
+  if (effort) {
+    overrides.effort = effort
+  }
+
+  return overrides
+}
+
+export const formatReasoningEffortLabel = (value: ReasoningEffort) => {
+  switch (value) {
+    case 'xhigh':
+      return 'Very high'
+    case 'none':
+      return 'None'
+    default:
+      return value.charAt(0).toUpperCase() + value.slice(1)
+  }
+}
+
+export const formatCompactTokenCount = (value: number) => {
+  if (value < 1000) {
+    return String(value)
+  }
+
+  const short = value / 1000
+  const rounded = short >= 10 ? short.toFixed(0) : short.toFixed(1)
+  return `${rounded.replace(/\\.0$/, '')}k`
+}
+
+export const resolveContextWindowState = (
+  tokenUsage: TokenUsageSnapshot | null,
+  fallbackContextWindow: number | null,
+  usageKnown = true
+) => {
+  const contextWindow = tokenUsage?.modelContextWindow ?? fallbackContextWindow
+  const usedTokens = tokenUsage
+    ? tokenUsage.totalInputTokens + tokenUsage.totalOutputTokens
+    : usageKnown
+      ? 0
+      : null
+
+  if (!contextWindow || usedTokens == null) {
+    return {
+      contextWindow,
+      usedTokens,
+      remainingTokens: null,
+      usedPercent: null,
+      remainingPercent: null
+    }
+  }
+
+  const cappedUsedTokens = Math.max(0, Math.min(contextWindow, usedTokens))
+  const usedPercent = Math.max(0, Math.min(100, (cappedUsedTokens / contextWindow) * 100))
+
+  return {
+    contextWindow,
+    usedTokens: cappedUsedTokens,
+    remainingTokens: Math.max(0, contextWindow - cappedUsedTokens),
+    usedPercent,
+    remainingPercent: Math.max(0, 100 - usedPercent)
+  }
+}

--- a/packages/client/shared/codex-rpc.ts
+++ b/packages/client/shared/codex-rpc.ts
@@ -4,6 +4,14 @@ type JsonRpcError = {
   data?: unknown
 }
 
+export type ReasoningEffort =
+  | 'none'
+  | 'minimal'
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'xhigh'
+
 type JsonRpcRequest = {
   id: number
   method: string
@@ -163,10 +171,14 @@ export type ThreadListResponse = {
 
 export type ThreadStartResponse = {
   thread: CodexThread
+  model?: string | null
+  reasoningEffort?: ReasoningEffort | null
 }
 
 export type ThreadResumeResponse = {
   thread: CodexThread
+  model?: string | null
+  reasoningEffort?: ReasoningEffort | null
 }
 
 export type ThreadReadResponse = {
@@ -177,6 +189,18 @@ export type TurnStartResponse = {
   turn: {
     id: string
   }
+}
+
+export type ModelListResponse = {
+  data?: unknown[]
+}
+
+export type ConfigReadResponse = {
+  config?: {
+    model?: string | null
+    model_context_window?: number | string | null
+    model_reasoning_effort?: ReasoningEffort | null
+  } | null
 }
 
 export type CodexRpcNotification = {

--- a/packages/client/shared/codex-rpc.ts
+++ b/packages/client/shared/codex-rpc.ts
@@ -4,13 +4,8 @@ type JsonRpcError = {
   data?: unknown
 }
 
-export type ReasoningEffort =
-  | 'none'
-  | 'minimal'
-  | 'low'
-  | 'medium'
-  | 'high'
-  | 'xhigh'
+export type { ReasoningEffort } from './chat-prompt-controls'
+import type { ReasoningEffort } from './chat-prompt-controls'
 
 type JsonRpcRequest = {
   id: number

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -14,6 +14,16 @@ import {
   validateAttachmentSelection
 } from '../shared/chat-attachments'
 import {
+  buildTurnOverrides,
+  coercePromptSelection,
+  ensureModelOption,
+  formatCompactTokenCount,
+  normalizeConfigDefaults,
+  normalizeModelList,
+  resolveContextWindowState,
+  resolveEffortOptions
+} from '../shared/chat-prompt-controls'
+import {
   encodeProjectIdSegment,
   normalizeProjectIdParam,
   projectStatusMeta,
@@ -325,5 +335,146 @@ describe('client package', () => {
     expect(shouldIgnoreNotificationAfterInterrupt('item/started')).toBe(true)
     expect(shouldIgnoreNotificationAfterInterrupt('item/completed')).toBe(false)
     expect(shouldIgnoreNotificationAfterInterrupt('turn/completed')).toBe(false)
+  })
+
+  it('normalizes model metadata from app-server responses', () => {
+    expect(normalizeModelList({
+      data: [{
+        id: 'model-1',
+        model: 'gpt-5.4',
+        displayName: 'GPT-5.4',
+        hidden: false,
+        isDefault: true,
+        defaultReasoningEffort: 'medium',
+        supportedReasoningEfforts: [
+          { reasoningEffort: 'low' },
+          { reasoningEffort: 'medium' },
+          { reasoningEffort: 'high' }
+        ]
+      }]
+    })).toEqual([{
+      id: 'model-1',
+      model: 'gpt-5.4',
+      displayName: 'GPT-5.4',
+      hidden: false,
+      isDefault: true,
+      defaultReasoningEffort: 'medium',
+      supportedReasoningEfforts: ['low', 'medium', 'high']
+    }])
+  })
+
+  it('derives initial selector defaults from config and coerces invalid effort values', () => {
+    const defaults = normalizeConfigDefaults({
+      config: {
+        model: 'gpt-5.4-mini',
+        model_context_window: '272000',
+        model_reasoning_effort: 'high'
+      }
+    })
+
+    const models = normalizeModelList({
+      data: [{
+        model: 'gpt-5.4-mini',
+        displayName: 'GPT-5.4 Mini',
+        hidden: false,
+        isDefault: true,
+        defaultReasoningEffort: 'medium',
+        supportedReasoningEfforts: [
+          { reasoningEffort: 'minimal' },
+          { reasoningEffort: 'medium' }
+        ]
+      }]
+    })
+
+    expect(defaults).toEqual({
+      model: 'gpt-5.4-mini',
+      effort: 'high',
+      contextWindow: 272000
+    })
+    expect(coercePromptSelection(models, defaults.model, defaults.effort)).toEqual({
+      model: 'gpt-5.4-mini',
+      effort: 'medium'
+    })
+  })
+
+  it('updates effort options when the selected model changes', () => {
+    const models = normalizeModelList({
+      data: [{
+        model: 'gpt-5.4',
+        displayName: 'GPT-5.4',
+        hidden: false,
+        isDefault: true,
+        defaultReasoningEffort: 'medium',
+        supportedReasoningEfforts: [
+          { reasoningEffort: 'low' },
+          { reasoningEffort: 'medium' },
+          { reasoningEffort: 'high' }
+        ]
+      }, {
+        model: 'gpt-5.4-mini',
+        displayName: 'GPT-5.4 Mini',
+        hidden: false,
+        isDefault: false,
+        defaultReasoningEffort: 'minimal',
+        supportedReasoningEfforts: [
+          { reasoningEffort: 'none' },
+          { reasoningEffort: 'minimal' }
+        ]
+      }]
+    })
+
+    expect(resolveEffortOptions(models, 'gpt-5.4-mini')).toEqual(['none', 'minimal'])
+    expect(coercePromptSelection(models, 'gpt-5.4-mini', 'high')).toEqual({
+      model: 'gpt-5.4-mini',
+      effort: 'minimal'
+    })
+  })
+
+  it('keeps the active thread model visible when it is missing from the fetched list', () => {
+    const models = normalizeModelList({
+      data: [{
+        model: 'gpt-5.4',
+        displayName: 'GPT-5.4',
+        hidden: false,
+        isDefault: true,
+        defaultReasoningEffort: 'medium',
+        supportedReasoningEfforts: [
+          { reasoningEffort: 'medium' }
+        ]
+      }]
+    })
+
+    expect(ensureModelOption(models, 'gpt-5.5-preview', 'high')[0]).toEqual({
+      id: 'gpt-5.5-preview',
+      model: 'gpt-5.5-preview',
+      displayName: 'gpt-5.5-preview',
+      hidden: false,
+      isDefault: false,
+      defaultReasoningEffort: 'high',
+      supportedReasoningEfforts: ['none', 'minimal', 'low', 'medium', 'high', 'xhigh']
+    })
+  })
+
+  it('builds turn overrides and context summaries for the footer controls', () => {
+    expect(buildTurnOverrides('gpt-5.4', 'high')).toEqual({
+      model: 'gpt-5.4',
+      effort: 'high'
+    })
+    expect(resolveContextWindowState({
+      totalInputTokens: 24000,
+      totalCachedInputTokens: 6000,
+      totalOutputTokens: 4000,
+      lastInputTokens: 2000,
+      lastCachedInputTokens: 500,
+      lastOutputTokens: 700,
+      modelContextWindow: 64000
+    }, null)).toEqual({
+      contextWindow: 64000,
+      usedTokens: 28000,
+      remainingTokens: 36000,
+      usedPercent: 43.75,
+      remainingPercent: 56.25
+    })
+    expect(formatCompactTokenCount(12800)).toBe('13k')
   })
 })


### PR DESCRIPTION
## Summary
- add compact model and effort selectors to the chat prompt footer
- move attachment previews into the prompt header and simplify the attachment affordance
- show remaining context at a glance with a compact indicator and detailed token usage popover
- load model/default metadata from app-server surfaces with fallbacks and include overrides in subsequent turn requests
- add client tests for model loading, selector coercion, turn overrides, and context window calculations

## Additional updates
- parallelize prompt-control initialization RPC calls with `Promise.allSettled`
- preserve resumed thread model and effort selections when async control loading completes
- route prompt-control loading failures through the existing send error path
- deduplicate the shared `ReasoningEffort` type export

## Validation
- `pnpm --filter @codori/client test`
- `pnpm --filter @codori/client typecheck`
- `pnpm --filter @codori/client lint` (existing warning remains in `packages/client/app/components/ProjectStatusDot.vue`)

Closes #11
