### PR TITLE
Enhance subagent panel UX across mobile and desktop

### DIFF
--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -206,14 +206,6 @@ const contextIndicatorLabel = computed(() => {
   const remainingPercent = contextWindowState.value.remainingPercent
   return remainingPercent == null ? 'ctx' : `${Math.round(remainingPercent)}%`
 })
-const contextSummaryLabel = computed(() => {
-  const remainingPercent = contextWindowState.value.remainingPercent
-  if (remainingPercent == null) {
-    return 'Context'
-  }
-
-  return `${Math.round(remainingPercent)}% left`
-})
 
 const normalizePromptSelection = (
   preferredModel?: string | null,
@@ -2029,7 +2021,7 @@ watch([selectedModel, availableModels], () => {
                 @change="onFileInputChange"
               >
 
-              <div class="flex items-start justify-between gap-3 pt-1">
+              <div class="flex w-full flex-wrap items-center gap-2 pt-1">
                 <div class="flex min-w-0 flex-1 flex-wrap items-center gap-2">
                   <UButton
                     type="button"
@@ -2066,141 +2058,132 @@ watch([selectedModel, availableModels], () => {
                     class="min-w-0 flex-1 sm:max-w-36 sm:flex-none"
                     :ui="{ base: 'rounded-full border border-default/70 bg-default/70', value: 'truncate' }"
                   />
-
-                  <span class="hidden text-[11px] text-muted md:inline">
-                    Drag, drop, or paste an image
-                  </span>
                 </div>
 
-                <UPopover
-                  :content="{ side: 'top', align: 'end' }"
-                  arrow
-                >
-                  <button
-                    type="button"
-                    class="flex shrink-0 items-center gap-2 rounded-full border border-default/70 bg-default/70 px-2 py-1 text-left"
+                <div class="ml-auto flex shrink-0 items-center">
+                  <UPopover
+                    :content="{ side: 'top', align: 'end' }"
+                    arrow
                   >
-                    <span class="relative flex size-8 items-center justify-center">
-                      <svg
-                        viewBox="0 0 36 36"
-                        class="size-8 -rotate-90"
-                        aria-hidden="true"
-                      >
-                        <circle
-                          cx="18"
-                          cy="18"
-                          r="15.5"
-                          fill="none"
-                          stroke-width="3"
-                          pathLength="100"
-                          class="stroke-current text-muted/20"
-                          stroke-dasharray="100 100"
-                        />
-                        <circle
-                          cx="18"
-                          cy="18"
-                          r="15.5"
-                          fill="none"
-                          stroke-width="3"
-                          pathLength="100"
-                          class="stroke-current text-primary"
-                          stroke-linecap="round"
-                          :stroke-dasharray="`${contextUsedPercent} 100`"
-                        />
-                      </svg>
-                      <span class="absolute text-[9px] font-semibold text-highlighted">
-                        {{ contextIndicatorLabel }}
+                    <button
+                      type="button"
+                      class="flex h-8 shrink-0 items-center gap-2 px-0 text-left text-muted"
+                    >
+                      <span class="relative flex size-7 items-center justify-center">
+                        <svg
+                          viewBox="0 0 36 36"
+                          class="size-7 -rotate-90"
+                          aria-hidden="true"
+                        >
+                          <circle
+                            cx="18"
+                            cy="18"
+                            r="15.5"
+                            fill="none"
+                            stroke-width="3"
+                            pathLength="100"
+                            class="stroke-current text-muted/20"
+                            stroke-dasharray="100 100"
+                          />
+                          <circle
+                            cx="18"
+                            cy="18"
+                            r="15.5"
+                            fill="none"
+                            stroke-width="3"
+                            pathLength="100"
+                            class="stroke-current text-primary"
+                            stroke-linecap="round"
+                            :stroke-dasharray="`${contextUsedPercent} 100`"
+                          />
+                        </svg>
+                        <span class="absolute text-[9px] font-semibold text-highlighted">
+                          {{ contextIndicatorLabel }}
+                        </span>
                       </span>
-                    </span>
 
-                    <div class="hidden min-w-0 leading-tight sm:block">
-                      <div class="text-[11px] font-medium text-highlighted">
-                        {{ contextSummaryLabel }}
-                      </div>
-                      <div class="text-[10px] text-muted">
-                        {{ modelContextWindow ? `${formatCompactTokenCount(modelContextWindow)} ctx` : 'Context window' }}
-                      </div>
-                    </div>
-                  </button>
+                      <span class="text-[11px] leading-none text-muted">context window</span>
+                    </button>
 
-                  <template #content>
-                    <div class="w-72 space-y-3 p-4">
-                      <div class="space-y-1">
-                        <div class="text-xs font-semibold uppercase tracking-[0.22em] text-primary">
-                          Context Window
+                    <template #content>
+                      <div class="w-72 space-y-3 p-4">
+                        <div class="space-y-1">
+                          <div class="text-xs font-semibold uppercase tracking-[0.22em] text-primary">
+                            Context Window
+                          </div>
+                          <div class="text-sm font-medium text-highlighted">
+                            {{ selectedModelOption?.displayName ?? 'Selected model' }}
+                          </div>
                         </div>
-                        <div class="text-sm font-medium text-highlighted">
-                          {{ selectedModelOption?.displayName ?? 'Selected model' }}
-                        </div>
-                      </div>
 
-                      <div
-                        v-if="contextWindowState.contextWindow && contextWindowState.usedTokens !== null"
-                        class="grid grid-cols-2 gap-3 text-sm"
-                      >
-                        <div class="rounded-2xl border border-default bg-elevated/35 px-3 py-2">
-                          <div class="text-[11px] uppercase tracking-[0.18em] text-muted">
-                            Remaining
+                        <div
+                          v-if="contextWindowState.contextWindow && contextWindowState.usedTokens !== null"
+                          class="grid grid-cols-2 gap-3 text-sm"
+                        >
+                          <div class="rounded-2xl border border-default bg-elevated/35 px-3 py-2">
+                            <div class="text-[11px] uppercase tracking-[0.18em] text-muted">
+                              Remaining
+                            </div>
+                            <div class="mt-1 font-semibold text-highlighted">
+                              {{ Math.round(contextWindowState.remainingPercent ?? 0) }}%
+                            </div>
+                            <div class="text-xs text-muted">
+                              {{ formatCompactTokenCount(contextWindowState.remainingTokens ?? 0) }} tokens
+                            </div>
                           </div>
-                          <div class="mt-1 font-semibold text-highlighted">
-                            {{ Math.round(contextWindowState.remainingPercent ?? 0) }}%
-                          </div>
-                          <div class="text-xs text-muted">
-                            {{ formatCompactTokenCount(contextWindowState.remainingTokens ?? 0) }} tokens
+                          <div class="rounded-2xl border border-default bg-elevated/35 px-3 py-2">
+                            <div class="text-[11px] uppercase tracking-[0.18em] text-muted">
+                              Used
+                            </div>
+                            <div class="mt-1 font-semibold text-highlighted">
+                              {{ formatCompactTokenCount(contextWindowState.usedTokens ?? 0) }}
+                            </div>
+                            <div class="text-xs text-muted">
+                              of {{ formatCompactTokenCount(contextWindowState.contextWindow) }}
+                            </div>
                           </div>
                         </div>
-                        <div class="rounded-2xl border border-default bg-elevated/35 px-3 py-2">
-                          <div class="text-[11px] uppercase tracking-[0.18em] text-muted">
-                            Used
-                          </div>
-                          <div class="mt-1 font-semibold text-highlighted">
-                            {{ formatCompactTokenCount(contextWindowState.usedTokens ?? 0) }}
-                          </div>
-                          <div class="text-xs text-muted">
-                            of {{ formatCompactTokenCount(contextWindowState.contextWindow) }}
-                          </div>
-                        </div>
-                      </div>
 
-                      <div
-                        v-else
-                        class="rounded-2xl border border-default bg-elevated/35 px-3 py-2 text-sm text-muted"
-                      >
-                        <div v-if="contextWindowState.contextWindow">
-                          Live token usage will appear after the next turn completes.
+                        <div
+                          v-else
+                          class="rounded-2xl border border-default bg-elevated/35 px-3 py-2 text-sm text-muted"
+                        >
+                          <div v-if="contextWindowState.contextWindow">
+                            Live token usage will appear after the next turn completes.
+                          </div>
+                          <div v-else>
+                            Context window details are not available from the runtime yet.
+                          </div>
                         </div>
-                        <div v-else>
-                          Context window details are not available from the runtime yet.
-                        </div>
-                      </div>
 
-                      <div class="grid grid-cols-2 gap-3 text-sm">
-                        <div class="rounded-2xl border border-default bg-elevated/35 px-3 py-2">
-                          <div class="text-[11px] uppercase tracking-[0.18em] text-muted">
-                            Input
+                        <div class="grid grid-cols-2 gap-3 text-sm">
+                          <div class="rounded-2xl border border-default bg-elevated/35 px-3 py-2">
+                            <div class="text-[11px] uppercase tracking-[0.18em] text-muted">
+                              Input
+                            </div>
+                            <div class="mt-1 font-semibold text-highlighted">
+                              {{ formatCompactTokenCount(tokenUsage?.totalInputTokens ?? 0) }}
+                            </div>
+                            <div class="text-xs text-muted">
+                              cached {{ formatCompactTokenCount(tokenUsage?.totalCachedInputTokens ?? 0) }}
+                            </div>
                           </div>
-                          <div class="mt-1 font-semibold text-highlighted">
-                            {{ formatCompactTokenCount(tokenUsage?.totalInputTokens ?? 0) }}
-                          </div>
-                          <div class="text-xs text-muted">
-                            cached {{ formatCompactTokenCount(tokenUsage?.totalCachedInputTokens ?? 0) }}
-                          </div>
-                        </div>
-                        <div class="rounded-2xl border border-default bg-elevated/35 px-3 py-2">
-                          <div class="text-[11px] uppercase tracking-[0.18em] text-muted">
-                            Output
-                          </div>
-                          <div class="mt-1 font-semibold text-highlighted">
-                            {{ formatCompactTokenCount(tokenUsage?.totalOutputTokens ?? 0) }}
-                          </div>
-                          <div class="text-xs text-muted">
-                            effort {{ formatReasoningEffortLabel(selectedEffort) }}
+                          <div class="rounded-2xl border border-default bg-elevated/35 px-3 py-2">
+                            <div class="text-[11px] uppercase tracking-[0.18em] text-muted">
+                              Output
+                            </div>
+                            <div class="mt-1 font-semibold text-highlighted">
+                              {{ formatCompactTokenCount(tokenUsage?.totalOutputTokens ?? 0) }}
+                            </div>
+                            <div class="text-xs text-muted">
+                              effort {{ formatReasoningEffortLabel(selectedEffort) }}
+                            </div>
                           </div>
                         </div>
                       </div>
-                    </div>
-                  </template>
-                </UPopover>
+                    </template>
+                  </UPopover>
+                </div>
               </div>
             </template>
           </UChatPrompt>

--- a/packages/client/app/components/SubagentDrawerList.vue
+++ b/packages/client/app/components/SubagentDrawerList.vue
@@ -33,8 +33,8 @@ const emit = defineEmits<{
         class="flex items-center gap-3 px-4 py-3"
       >
         <div
-          class="size-2.5 shrink-0 rounded-full"
-          :class="resolveSubagentAccent(index).avatarClass"
+          class="size-2.5 shrink-0 rounded-full ring-4"
+          :class="resolveSubagentAccent(index).dotClass"
         />
 
         <div class="min-w-0 flex-1">

--- a/packages/client/app/components/SubagentDrawerList.vue
+++ b/packages/client/app/components/SubagentDrawerList.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import type { VisualSubagentPanel } from '~~/shared/codex-chat'
+import {
+  resolveSubagentAccent,
+  resolveSubagentStatusMeta
+} from '~~/shared/subagent-panels'
+
+defineProps<{
+  agents: VisualSubagentPanel[]
+}>()
+
+const emit = defineEmits<{
+  expand: [threadId: string]
+}>()
+</script>
+
+<template>
+  <div class="min-h-0">
+    <div
+      v-if="agents.length === 0"
+      class="rounded-lg border border-dashed border-default px-4 py-6 text-sm text-muted"
+    >
+      No subagents yet.
+    </div>
+
+    <ul
+      v-else
+      class="divide-y divide-default"
+    >
+      <li
+        v-for="(agent, index) in agents"
+        :key="agent.threadId"
+        class="flex items-center gap-3 px-4 py-3"
+      >
+        <div
+          class="size-2.5 shrink-0 rounded-full"
+          :class="resolveSubagentAccent(index).avatarClass"
+        />
+
+        <div class="min-w-0 flex-1">
+          <p
+            class="truncate text-sm font-medium"
+            :class="resolveSubagentAccent(index).textClass"
+          >
+            {{ agent.name }}
+          </p>
+          <p class="text-xs text-muted">
+            {{ resolveSubagentStatusMeta(agent.status).label }}
+          </p>
+        </div>
+
+        <UButton
+          icon="i-lucide-expand"
+          color="neutral"
+          variant="ghost"
+          size="sm"
+          square
+          :aria-label="`Expand ${agent.name}`"
+          @click="emit('expand', agent.threadId)"
+        />
+      </li>
+    </ul>
+  </div>
+</template>

--- a/packages/client/app/components/SubagentTranscriptPanel.vue
+++ b/packages/client/app/components/SubagentTranscriptPanel.vue
@@ -6,16 +6,16 @@ const sharedStickToBottomStates = new Map<string, boolean>()
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import type { VisualSubagentPanel } from '~~/shared/codex-chat'
-import { resolveSubagentStatusMeta } from '~~/shared/subagent-panels'
+import { resolveSubagentStatusMeta, type SubagentAccent } from '~~/shared/subagent-panels'
 
 const props = withDefaults(defineProps<{
   agent: VisualSubagentPanel
-  accentClass?: string
+  accent?: SubagentAccent | null
   expanded?: boolean
   showExpandButton?: boolean
   showCollapseButton?: boolean
 }>(), {
-  accentClass: '',
+  accent: null,
   expanded: false,
   showExpandButton: false,
   showCollapseButton: false
@@ -151,11 +151,14 @@ onBeforeUnmount(() => {
 
 <template>
   <section class="flex h-full min-h-0 flex-col bg-elevated/25">
-    <header class="flex items-center justify-between gap-2 border-b border-default px-3 py-2">
+    <header
+      class="flex items-center justify-between gap-2 border-b border-default px-3 py-2"
+      :class="props.accent?.headerClass"
+    >
       <div class="min-w-0">
         <p
           class="truncate text-sm font-semibold"
-          :class="accentClass || 'text-highlighted'"
+          :class="props.accent?.textClass || 'text-highlighted'"
         >
           {{ agent.name }}
         </p>
@@ -187,12 +190,12 @@ onBeforeUnmount(() => {
         />
         <UButton
           v-if="showCollapseButton"
-          icon="i-lucide-arrow-left"
+          icon="i-lucide-shrink"
           color="neutral"
           variant="ghost"
           size="xs"
           square
-          aria-label="Close expanded subagent"
+          aria-label="Collapse subagent"
           @click="emit('collapse')"
         />
       </div>

--- a/packages/client/app/components/SubagentTranscriptPanel.vue
+++ b/packages/client/app/components/SubagentTranscriptPanel.vue
@@ -14,11 +14,13 @@ const props = withDefaults(defineProps<{
   expanded?: boolean
   showExpandButton?: boolean
   showCollapseButton?: boolean
+  scrollScope?: string
 }>(), {
   accent: null,
   expanded: false,
   showExpandButton: false,
-  showCollapseButton: false
+  showCollapseButton: false,
+  scrollScope: 'default'
 })
 
 const emit = defineEmits<{
@@ -32,11 +34,44 @@ const SCROLL_STICKY_THRESHOLD_PX = 24
 
 const scrollContainer = ref<HTMLElement | null>(null)
 let scrollRetryTimer: number | null = null
+let isTickPending = false
 
 const statusMeta = computed(() => resolveSubagentStatusMeta(props.agent.status))
+const scrollStateKey = computed(() => `${props.scrollScope}:${props.agent.threadId}`)
+const lastMessageSignature = computed(() => {
+  const lastMessage = props.agent.messages.at(-1)
+  if (!lastMessage) {
+    return ''
+  }
+
+  return JSON.stringify({
+    id: lastMessage.id,
+    pending: lastMessage.pending ?? false,
+    parts: lastMessage.parts.map((part) => {
+      if (part.type === 'text') {
+        return [part.type, part.state ?? '', part.text.length]
+      }
+
+      if (part.type === 'reasoning') {
+        return [
+          part.type,
+          part.state ?? '',
+          part.summary.join('\n').length,
+          part.content.join('\n').length
+        ]
+      }
+
+      if (part.type === 'attachment') {
+        return [part.type, part.attachment.name, part.attachment.url ?? part.attachment.localPath ?? '']
+      }
+
+      return [part.type, JSON.stringify(part.data).length]
+    })
+  })
+})
 const panelSignature = computed(() => [
   props.agent.messages.length,
-  props.agent.messages.at(-1)?.id ?? '',
+  lastMessageSignature.value,
   props.agent.status ?? ''
 ].join(':'))
 
@@ -55,8 +90,8 @@ const rememberScrollState = () => {
     return
   }
 
-  sharedScrollPositions.set(props.agent.threadId, scrollContainer.value.scrollTop)
-  sharedStickToBottomStates.set(props.agent.threadId, isNearBottom(scrollContainer.value))
+  sharedScrollPositions.set(scrollStateKey.value, scrollContainer.value.scrollTop)
+  sharedStickToBottomStates.set(scrollStateKey.value, isNearBottom(scrollContainer.value))
 }
 
 const restoreScrollState = () => {
@@ -64,13 +99,13 @@ const restoreScrollState = () => {
     return
   }
 
-  const savedTop = sharedScrollPositions.get(props.agent.threadId)
+  const savedTop = sharedScrollPositions.get(scrollStateKey.value)
   if (savedTop !== undefined) {
     scrollContainer.value.scrollTop = savedTop
   }
 
   sharedStickToBottomStates.set(
-    props.agent.threadId,
+    scrollStateKey.value,
     savedTop === undefined || isNearBottom(scrollContainer.value)
   )
 }
@@ -91,9 +126,17 @@ const queueScrollToBottom = (attempt = 0) => {
 
   if (attempt === 0) {
     clearScrollRetry()
+    if (isTickPending) {
+      return
+    }
+    isTickPending = true
   }
 
   void nextTick(() => {
+    if (attempt === 0) {
+      isTickPending = false
+    }
+
     scrollToBottom()
     if (attempt >= SCROLL_RETRY_COUNT) {
       return
@@ -116,7 +159,7 @@ watch(scrollContainer, (container) => {
   }
 
   restoreScrollState()
-  if (!sharedScrollPositions.has(props.agent.threadId)) {
+  if (!sharedScrollPositions.has(scrollStateKey.value)) {
     queueScrollToBottom()
   }
 }, { immediate: true })
@@ -129,19 +172,19 @@ watch(() => props.agent.threadId, (_, previousThreadId) => {
   clearScrollRetry()
   void nextTick(() => {
     restoreScrollState()
-    if (!sharedScrollPositions.has(props.agent.threadId)) {
+    if (!sharedScrollPositions.has(scrollStateKey.value)) {
       queueScrollToBottom()
     }
   })
 })
 
 watch(panelSignature, () => {
-  if (sharedStickToBottomStates.get(props.agent.threadId) === false) {
+  if (sharedStickToBottomStates.get(scrollStateKey.value) === false) {
     return
   }
 
   queueScrollToBottom()
-}, { immediate: true })
+})
 
 onBeforeUnmount(() => {
   rememberScrollState()

--- a/packages/client/app/components/SubagentTranscriptPanel.vue
+++ b/packages/client/app/components/SubagentTranscriptPanel.vue
@@ -1,0 +1,259 @@
+<script lang="ts">
+const sharedScrollPositions = new Map<string, number>()
+const sharedStickToBottomStates = new Map<string, boolean>()
+</script>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import type { VisualSubagentPanel } from '~~/shared/codex-chat'
+import { resolveSubagentStatusMeta } from '~~/shared/subagent-panels'
+
+const props = withDefaults(defineProps<{
+  agent: VisualSubagentPanel
+  accentClass?: string
+  expanded?: boolean
+  showExpandButton?: boolean
+  showCollapseButton?: boolean
+}>(), {
+  accentClass: '',
+  expanded: false,
+  showExpandButton: false,
+  showCollapseButton: false
+})
+
+const emit = defineEmits<{
+  expand: []
+  collapse: []
+}>()
+
+const SCROLL_RETRY_DELAY_MS = 48
+const SCROLL_RETRY_COUNT = 4
+const SCROLL_STICKY_THRESHOLD_PX = 24
+
+const scrollContainer = ref<HTMLElement | null>(null)
+let scrollRetryTimer: number | null = null
+
+const statusMeta = computed(() => resolveSubagentStatusMeta(props.agent.status))
+const panelSignature = computed(() => [
+  props.agent.messages.length,
+  props.agent.messages.at(-1)?.id ?? '',
+  props.agent.status ?? ''
+].join(':'))
+
+const clearScrollRetry = () => {
+  if (scrollRetryTimer !== null) {
+    window.clearTimeout(scrollRetryTimer)
+    scrollRetryTimer = null
+  }
+}
+
+const isNearBottom = (container: HTMLElement) =>
+  container.scrollHeight - container.scrollTop - container.clientHeight <= SCROLL_STICKY_THRESHOLD_PX
+
+const rememberScrollState = () => {
+  if (!scrollContainer.value) {
+    return
+  }
+
+  sharedScrollPositions.set(props.agent.threadId, scrollContainer.value.scrollTop)
+  sharedStickToBottomStates.set(props.agent.threadId, isNearBottom(scrollContainer.value))
+}
+
+const restoreScrollState = () => {
+  if (!scrollContainer.value) {
+    return
+  }
+
+  const savedTop = sharedScrollPositions.get(props.agent.threadId)
+  if (savedTop !== undefined) {
+    scrollContainer.value.scrollTop = savedTop
+  }
+
+  sharedStickToBottomStates.set(
+    props.agent.threadId,
+    savedTop === undefined || isNearBottom(scrollContainer.value)
+  )
+}
+
+const scrollToBottom = () => {
+  if (!scrollContainer.value) {
+    return
+  }
+
+  scrollContainer.value.scrollTop = scrollContainer.value.scrollHeight
+  rememberScrollState()
+}
+
+const queueScrollToBottom = (attempt = 0) => {
+  if (!import.meta.client) {
+    return
+  }
+
+  if (attempt === 0) {
+    clearScrollRetry()
+  }
+
+  void nextTick(() => {
+    scrollToBottom()
+    if (attempt >= SCROLL_RETRY_COUNT) {
+      return
+    }
+
+    scrollRetryTimer = window.setTimeout(() => {
+      queueScrollToBottom(attempt + 1)
+    }, SCROLL_RETRY_DELAY_MS)
+  })
+}
+
+const onScroll = () => {
+  rememberScrollState()
+}
+
+watch(scrollContainer, (container) => {
+  if (!container) {
+    clearScrollRetry()
+    return
+  }
+
+  restoreScrollState()
+  if (!sharedScrollPositions.has(props.agent.threadId)) {
+    queueScrollToBottom()
+  }
+}, { immediate: true })
+
+watch(() => props.agent.threadId, (_, previousThreadId) => {
+  if (previousThreadId) {
+    rememberScrollState()
+  }
+
+  clearScrollRetry()
+  void nextTick(() => {
+    restoreScrollState()
+    if (!sharedScrollPositions.has(props.agent.threadId)) {
+      queueScrollToBottom()
+    }
+  })
+})
+
+watch(panelSignature, () => {
+  if (sharedStickToBottomStates.get(props.agent.threadId) === false) {
+    return
+  }
+
+  queueScrollToBottom()
+}, { immediate: true })
+
+onBeforeUnmount(() => {
+  rememberScrollState()
+  clearScrollRetry()
+})
+</script>
+
+<template>
+  <section class="flex h-full min-h-0 flex-col bg-elevated/25">
+    <header class="flex items-center justify-between gap-2 border-b border-default px-3 py-2">
+      <div class="min-w-0">
+        <p
+          class="truncate text-sm font-semibold"
+          :class="accentClass || 'text-highlighted'"
+        >
+          {{ agent.name }}
+        </p>
+        <p
+          v-if="expanded"
+          class="text-xs text-muted"
+        >
+          Focused subagent transcript
+        </p>
+      </div>
+
+      <div class="flex shrink-0 items-center gap-1.5">
+        <UBadge
+          :color="statusMeta.color"
+          variant="soft"
+          size="sm"
+        >
+          {{ statusMeta.label }}
+        </UBadge>
+        <UButton
+          v-if="showExpandButton"
+          icon="i-lucide-expand"
+          color="neutral"
+          variant="ghost"
+          size="xs"
+          square
+          aria-label="Expand subagent"
+          @click="emit('expand')"
+        />
+        <UButton
+          v-if="showCollapseButton"
+          icon="i-lucide-arrow-left"
+          color="neutral"
+          variant="ghost"
+          size="xs"
+          square
+          aria-label="Close expanded subagent"
+          @click="emit('collapse')"
+        />
+      </div>
+    </header>
+
+    <div
+      ref="scrollContainer"
+      class="min-h-0 flex-1 overflow-y-auto px-3 py-2"
+      @scroll="onScroll"
+    >
+      <div
+        v-if="agent.messages.length === 0"
+        class="rounded-lg border border-dashed border-default px-3 py-4 text-sm text-muted"
+      >
+        Waiting for subagent output...
+      </div>
+
+      <UChatMessages
+        v-else
+        :messages="agent.messages"
+        :status="agent.status === 'pendingInit' || agent.status === 'running' ? 'streaming' : 'ready'"
+        :user="{
+          ui: {
+            root: 'scroll-mt-4',
+            container: 'gap-3 pb-8',
+            content: 'px-4 py-3 rounded-lg min-h-12'
+          }
+        }"
+        :ui="{ root: 'subagent-chat-messages min-h-full min-w-0 [&>article]:min-w-0 [&_[data-slot=content]]:min-w-0' }"
+        compact
+      >
+        <template #content="{ message }">
+          <MessageContent :message="message as VisualSubagentPanel['messages'][number]" />
+        </template>
+      </UChatMessages>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.subagent-chat-messages :deep(.cd-markdown),
+.subagent-chat-messages :deep([data-slot='content']) {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.subagent-chat-messages :deep(.cd-markdown p),
+.subagent-chat-messages :deep(.cd-markdown li),
+.subagent-chat-messages :deep(.cd-markdown a),
+.subagent-chat-messages :deep(.cd-markdown code) {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.subagent-chat-messages :deep(.cd-markdown pre),
+.subagent-chat-messages :deep(.cd-markdown .shiki),
+.subagent-chat-messages :deep(.cd-markdown .shiki code) {
+  max-width: 100%;
+  white-space: pre-wrap !important;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  overflow-x: hidden !important;
+}
+</style>

--- a/packages/client/app/components/ThreadPanel.vue
+++ b/packages/client/app/components/ThreadPanel.vue
@@ -7,9 +7,12 @@ defineProps<{
   projectId: string | null
 }>()
 
+const readDesktopViewport = () =>
+  import.meta.client ? window.matchMedia('(min-width: 1280px)').matches : false
+
 const { open, closePanel } = useThreadPanel()
 const threadListKey = ref(0)
-const isDesktopViewport = ref(false)
+const isDesktopViewport = ref(readDesktopViewport())
 
 let viewportQuery: MediaQueryList | null = null
 let removeViewportListener: (() => void) | null = null

--- a/packages/client/app/components/ThreadPanel.vue
+++ b/packages/client/app/components/ThreadPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { onBeforeUnmount, onMounted, ref } from 'vue'
 import { useThreadPanel } from '../composables/useThreadPanel'
 import ThreadList from './ThreadList.vue'
 
@@ -9,60 +9,76 @@ defineProps<{
 
 const { open, closePanel } = useThreadPanel()
 const threadListKey = ref(0)
+const isDesktopViewport = ref(false)
+
+let viewportQuery: MediaQueryList | null = null
+let removeViewportListener: (() => void) | null = null
 
 const refreshThreads = () => {
   threadListKey.value += 1
 }
+
+onMounted(() => {
+  if (!import.meta.client) {
+    return
+  }
+
+  viewportQuery = window.matchMedia('(min-width: 1280px)')
+  isDesktopViewport.value = viewportQuery.matches
+
+  const handleViewportChange = (event: MediaQueryListEvent) => {
+    isDesktopViewport.value = event.matches
+  }
+
+  viewportQuery.addEventListener('change', handleViewportChange)
+  removeViewportListener = () => {
+    viewportQuery?.removeEventListener('change', handleViewportChange)
+  }
+})
+
+onBeforeUnmount(() => {
+  removeViewportListener?.()
+})
 </script>
 
 <template>
-  <div class="hidden h-full min-h-0 xl:flex">
-    <UDashboardPanel
-      v-if="projectId && open"
-      id="thread-panel"
-      :ui="{ body: 'p-0' }"
-      class="h-full min-h-0 border-l border-default"
-      :default-size="24"
-      :min-size="20"
-      :max-size="30"
-      resizable
-    >
-      <template #header>
-        <div class="flex items-center justify-between gap-2 px-3 py-2">
-          <div class="text-sm font-medium text-highlighted">
-            Resume Threads
-          </div>
-          <div class="flex items-center gap-1">
-            <UButton
-              icon="i-lucide-refresh-cw"
-              color="neutral"
-              variant="ghost"
-              size="xs"
-              square
-              @click="refreshThreads"
-            />
-            <UButton
-              icon="i-lucide-panel-right-close"
-              color="neutral"
-              variant="ghost"
-              size="xs"
-              square
-              @click="closePanel"
-            />
-          </div>
-        </div>
-      </template>
-      <template #body>
-        <ThreadList
-          :key="threadListKey"
-          :project-id="projectId"
+  <aside
+    v-if="projectId && open && isDesktopViewport"
+    class="hidden h-full min-h-0 w-[22rem] shrink-0 flex-col border-l border-default bg-default xl:flex"
+  >
+    <div class="flex items-center justify-between gap-2 border-b border-default px-3 py-2">
+      <div class="text-sm font-medium text-highlighted">
+        Resume Threads
+      </div>
+      <div class="flex items-center gap-1">
+        <UButton
+          icon="i-lucide-refresh-cw"
+          color="neutral"
+          variant="ghost"
+          size="xs"
+          square
+          @click="refreshThreads"
         />
-      </template>
-    </UDashboardPanel>
-  </div>
+        <UButton
+          icon="i-lucide-panel-right-close"
+          color="neutral"
+          variant="ghost"
+          size="xs"
+          square
+          @click="closePanel"
+        />
+      </div>
+    </div>
+    <div class="min-h-0 flex-1 overflow-hidden">
+      <ThreadList
+        :key="threadListKey"
+        :project-id="projectId"
+      />
+    </div>
+  </aside>
 
   <USlideover
-    v-if="projectId"
+    v-if="projectId && !isDesktopViewport"
     v-model:open="open"
     title="Resume Threads"
     side="right"

--- a/packages/client/app/components/VisualSubagentStack.vue
+++ b/packages/client/app/components/VisualSubagentStack.vue
@@ -1,27 +1,15 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, watch, type ComponentPublicInstance, type VNodeRef } from 'vue'
+import { computed } from 'vue'
 import type { VisualSubagentPanel } from '~~/shared/codex-chat'
+import { resolveSubagentAccent } from '~~/shared/subagent-panels'
 
 const props = defineProps<{
   agents: VisualSubagentPanel[]
 }>()
 
-const SCROLL_RETRY_DELAY_MS = 48
-const SCROLL_RETRY_COUNT = 4
-const SUBAGENT_ACCENT_PALETTE = [
-  'text-emerald-700 dark:text-emerald-300',
-  'text-sky-700 dark:text-sky-300',
-  'text-amber-800 dark:text-amber-300',
-  'text-rose-700 dark:text-rose-300',
-  'text-violet-700 dark:text-violet-300',
-  'text-cyan-700 dark:text-cyan-300',
-  'text-lime-800 dark:text-lime-300',
-  'text-orange-700 dark:text-orange-300'
-] as const
-
-const scrollContainers = new Map<string, HTMLElement>()
-const scrollRetryTimers = new Map<string, number>()
-const scrollContainerRefs = new Map<string, VNodeRef>()
+const emit = defineEmits<{
+  expand: [threadId: string]
+}>()
 
 const paneSize = computed(() => {
   if (!props.agents.length) {
@@ -30,238 +18,19 @@ const paneSize = computed(() => {
 
   return 100 / props.agents.length
 })
-
-const agentAccentClass = (index: number) =>
-  SUBAGENT_ACCENT_PALETTE[index % SUBAGENT_ACCENT_PALETTE.length]
-
-const statusColor = (status: VisualSubagentPanel['status']) => {
-  switch (status) {
-    case 'running':
-      return 'info'
-    case 'pendingInit':
-      return 'primary'
-    case 'completed':
-      return 'success'
-    case 'interrupted':
-      return 'warning'
-    case 'errored':
-      return 'error'
-    case 'shutdown':
-    case 'notFound':
-      return 'neutral'
-    default:
-      return 'neutral'
-  }
-}
-
-const statusLabel = (status: VisualSubagentPanel['status']) => {
-  switch (status) {
-    case 'pendingInit':
-      return 'pending'
-    case 'running':
-      return 'running'
-    case 'completed':
-      return 'completed'
-    case 'interrupted':
-      return 'interrupted'
-    case 'errored':
-      return 'errored'
-    case 'shutdown':
-      return 'shutdown'
-    case 'notFound':
-      return 'not found'
-    default:
-      return 'active'
-  }
-}
-
-const isStreamingStatus = (status: VisualSubagentPanel['status']) =>
-  status === 'pendingInit' || status === 'running'
-
-const clearScrollRetry = (threadId: string) => {
-  const timer = scrollRetryTimers.get(threadId)
-  if (timer !== undefined) {
-    window.clearTimeout(timer)
-    scrollRetryTimers.delete(threadId)
-  }
-}
-
-const scrollContainerToBottom = (threadId: string) => {
-  const container = scrollContainers.get(threadId)
-  if (!container) {
-    return
-  }
-  container.scrollTop = container.scrollHeight
-}
-
-const queueScrollToBottom = (threadId: string, attempt = 0) => {
-  if (!import.meta.client) {
-    return
-  }
-
-  if (attempt === 0) {
-    clearScrollRetry(threadId)
-  }
-
-  void nextTick(() => {
-    scrollContainerToBottom(threadId)
-    if (attempt >= SCROLL_RETRY_COUNT) {
-      return
-    }
-
-    const timer = window.setTimeout(() => {
-      queueScrollToBottom(threadId, attempt + 1)
-    }, SCROLL_RETRY_DELAY_MS)
-
-    scrollRetryTimers.set(threadId, timer)
-  })
-}
-
-const setScrollContainer = (threadId: string, container: Element | null) => {
-  if (!(container instanceof HTMLElement)) {
-    scrollContainers.delete(threadId)
-    clearScrollRetry(threadId)
-    return
-  }
-
-  scrollContainers.set(threadId, container)
-  queueScrollToBottom(threadId)
-}
-
-const scrollContainerRef = (threadId: string) => {
-  const existing = scrollContainerRefs.get(threadId)
-  if (existing) {
-    return existing
-  }
-
-  const ref: VNodeRef = (container: Element | ComponentPublicInstance | null) => {
-    const resolved = container instanceof Element
-      ? container
-      : container && '$el' in container && container.$el instanceof Element
-        ? container.$el
-        : null
-    setScrollContainer(threadId, resolved)
-  }
-
-  scrollContainerRefs.set(threadId, ref)
-  return ref
-}
-
-const panelSignatures = computed(() =>
-  props.agents.map(agent => ({
-    threadId: agent.threadId,
-    signature: [
-      agent.messages.length,
-      agent.messages.at(-1)?.id ?? '',
-      agent.status ?? ''
-    ].join(':')
-  }))
-)
-
-watch(panelSignatures, (signatures) => {
-  const activeThreadIds = new Set(signatures.map(entry => entry.threadId))
-
-  for (const { threadId } of signatures) {
-    queueScrollToBottom(threadId)
-  }
-
-  for (const threadId of scrollRetryTimers.keys()) {
-    if (!activeThreadIds.has(threadId)) {
-      clearScrollRetry(threadId)
-    }
-  }
-}, { immediate: true })
-
-onBeforeUnmount(() => {
-  for (const threadId of scrollRetryTimers.keys()) {
-    clearScrollRetry(threadId)
-  }
-})
 </script>
 
 <template>
   <div class="flex h-full min-h-0 flex-col divide-y divide-default">
-    <section
+    <SubagentTranscriptPanel
       v-for="(agent, index) in agents"
       :key="agent.threadId"
-      class="flex min-h-0 flex-1 flex-col bg-elevated/25"
+      :agent="agent"
+      :accent-class="resolveSubagentAccent(index).textClass"
+      show-expand-button
+      class="min-h-0 flex-1"
       :style="{ flexBasis: `${paneSize}%` }"
-    >
-      <header class="flex items-center justify-between gap-2 border-b border-default px-3 py-2">
-        <div class="min-w-0">
-          <p
-            class="truncate text-sm font-semibold"
-            :class="agentAccentClass(index)"
-          >
-            {{ agent.name }}
-          </p>
-        </div>
-        <UBadge
-          :color="statusColor(agent.status)"
-          variant="soft"
-          size="sm"
-        >
-          {{ statusLabel(agent.status) }}
-        </UBadge>
-      </header>
-
-      <div
-        :ref="scrollContainerRef(agent.threadId)"
-        class="min-h-0 flex-1 overflow-y-auto px-3 py-2"
-      >
-        <div
-          v-if="agent.messages.length === 0"
-          class="rounded-lg border border-dashed border-default px-3 py-4 text-sm text-muted"
-        >
-          Waiting for subagent output...
-        </div>
-
-        <UChatMessages
-          v-else
-          :messages="agent.messages"
-          :status="isStreamingStatus(agent.status) ? 'streaming' : 'ready'"
-          :user="{
-            ui: {
-              root: 'scroll-mt-4',
-              container: 'gap-3 pb-8',
-              content: 'px-4 py-3 rounded-lg min-h-12'
-            }
-          }"
-          :ui="{ root: 'subagent-chat-messages min-h-full min-w-0 [&>article]:min-w-0 [&_[data-slot=content]]:min-w-0' }"
-          compact
-          should-auto-scroll
-        >
-          <template #content="{ message }">
-            <MessageContent :message="message as VisualSubagentPanel['messages'][number]" />
-          </template>
-        </UChatMessages>
-      </div>
-    </section>
+      @expand="emit('expand', agent.threadId)"
+    />
   </div>
 </template>
-
-<style scoped>
-.subagent-chat-messages :deep(.cd-markdown),
-.subagent-chat-messages :deep([data-slot='content']) {
-  min-width: 0;
-  max-width: 100%;
-}
-
-.subagent-chat-messages :deep(.cd-markdown p),
-.subagent-chat-messages :deep(.cd-markdown li),
-.subagent-chat-messages :deep(.cd-markdown a),
-.subagent-chat-messages :deep(.cd-markdown code) {
-  overflow-wrap: anywhere;
-  word-break: break-word;
-}
-
-.subagent-chat-messages :deep(.cd-markdown pre),
-.subagent-chat-messages :deep(.cd-markdown .shiki),
-.subagent-chat-messages :deep(.cd-markdown .shiki code) {
-  max-width: 100%;
-  white-space: pre-wrap !important;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-  overflow-x: hidden !important;
-}
-</style>

--- a/packages/client/app/components/VisualSubagentStack.vue
+++ b/packages/client/app/components/VisualSubagentStack.vue
@@ -26,7 +26,7 @@ const paneSize = computed(() => {
       v-for="(agent, index) in agents"
       :key="agent.threadId"
       :agent="agent"
-      :accent-class="resolveSubagentAccent(index).textClass"
+      :accent="resolveSubagentAccent(index)"
       show-expand-button
       class="min-h-0 flex-1"
       :style="{ flexBasis: `${paneSize}%` }"

--- a/packages/client/app/components/VisualSubagentStack.vue
+++ b/packages/client/app/components/VisualSubagentStack.vue
@@ -27,6 +27,7 @@ const paneSize = computed(() => {
       :key="agent.threadId"
       :agent="agent"
       :accent="resolveSubagentAccent(index)"
+      scroll-scope="stack"
       show-expand-button
       class="min-h-0 flex-1"
       :style="{ flexBasis: `${paneSize}%` }"

--- a/packages/client/app/pages/projects/[...projectId]/index.vue
+++ b/packages/client/app/pages/projects/[...projectId]/index.vue
@@ -7,7 +7,7 @@ import { normalizeProjectIdParam } from '~~/shared/codori'
 
 const route = useRoute()
 const router = useRouter()
-const { openPanel } = useThreadPanel()
+const { togglePanel } = useThreadPanel()
 const { loaded, refreshProjects, getProject, pendingProjectId } = useProjects()
 
 const projectId = computed(() => normalizeProjectIdParam(route.params.projectId as string | string[] | undefined))
@@ -83,7 +83,7 @@ onMounted(() => {
                   color="neutral"
                   variant="outline"
                   square
-                  @click="openPanel"
+                  @click="togglePanel"
                 />
               </UTooltip>
             </div>

--- a/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
+++ b/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
@@ -442,6 +442,7 @@ watch(
           v-if="expandedSubagentPanel"
           :agent="expandedSubagentPanel"
           :accent="expandedSubagentAccent"
+          scroll-scope="expanded"
           expanded
           show-collapse-button
           class="h-full"

--- a/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
+++ b/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
@@ -92,13 +92,13 @@ const subagentAvatarItems = computed(() =>
 const expandedSubagentPanel = computed(() =>
   resolveExpandedSubagentPanel(availablePanels.value, expandedSubagentThreadId.value)
 )
-const expandedSubagentAccentClass = computed(() => {
+const expandedSubagentAccent = computed(() => {
   if (!expandedSubagentPanel.value) {
-    return ''
+    return null
   }
 
   const index = availablePanels.value.findIndex(panel => panel.threadId === expandedSubagentPanel.value?.threadId)
-  return index >= 0 ? resolveSubagentAccent(index).textClass : ''
+  return index >= 0 ? resolveSubagentAccent(index) : null
 })
 const isExpandedSubagentOpen = computed({
   get: () => expandedSubagentPanel.value !== null,
@@ -435,6 +435,8 @@ watch(
       v-model:open="isExpandedSubagentOpen"
       fullscreen
       :ui="{
+        header: 'hidden',
+        close: 'hidden',
         content: 'overflow-hidden bg-default',
         body: '!h-full !p-0'
       }"
@@ -443,7 +445,7 @@ watch(
         <SubagentTranscriptPanel
           v-if="expandedSubagentPanel"
           :agent="expandedSubagentPanel"
-          :accent-class="expandedSubagentAccentClass"
+          :accent="expandedSubagentAccent"
           expanded
           show-collapse-button
           class="h-full"

--- a/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
+++ b/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
@@ -265,10 +265,13 @@ watch(
       :min-size="20"
       :max-size="40"
       resizable
-      :ui="{ body: '!p-0' }"
+      :ui="{ header: '!p-0 bg-[var(--ui-bg)]', body: '!p-0' }"
     >
       <template #header>
-        <div class="flex items-center justify-between gap-2 px-4 py-3">
+        <div
+          class="flex items-center justify-between gap-2 border-b border-default px-4 py-3"
+          style="background-color: var(--ui-bg);"
+        >
           <div class="flex items-center gap-2">
             <span class="text-sm font-semibold text-highlighted">Subagents</span>
             <UBadge

--- a/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
+++ b/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
@@ -71,11 +71,7 @@ const isDesktopSubagentsPanelVisible = computed(() =>
 const isSubagentsSurfaceOpen = computed(() =>
   isMobileViewport.value ? isMobileSubagentsDrawerOpen.value : isDesktopSubagentsPanelVisible.value
 )
-const subagentsToggleIcon = computed(() =>
-  isMobileViewport.value
-    ? (isMobileSubagentsDrawerOpen.value ? 'i-lucide-x' : 'i-lucide-list-tree')
-    : (isDesktopSubagentsPanelVisible.value ? 'i-lucide-panel-right-close' : 'i-lucide-panel-right-open')
-)
+const subagentsToggleIcon = computed(() => 'i-lucide-bot')
 const subagentsToggleLabel = computed(() =>
   isMobileViewport.value
     ? (isMobileSubagentsDrawerOpen.value ? 'Hide subagents' : 'Show subagents')
@@ -272,6 +268,31 @@ watch(
           </template>
           <template #right>
             <div class="flex items-center gap-1.5 lg:gap-2">
+              <UTooltip :text="`RPC ${rpcStatus}`">
+                <ProjectStatusDot
+                  :status="rpcStatus"
+                  pulse
+                  padded
+                />
+              </UTooltip>
+              <UTooltip text="New thread">
+                <UButton
+                  icon="i-lucide-plus"
+                  color="primary"
+                  variant="soft"
+                  square
+                  @click="onNewThread"
+                />
+              </UTooltip>
+              <UTooltip text="Previous threads">
+                <UButton
+                  icon="i-lucide-history"
+                  color="neutral"
+                  variant="outline"
+                  square
+                  @click="openPanel"
+                />
+              </UTooltip>
               <UTooltip
                 v-if="hasAvailableSubagents"
                 text="Subagents"
@@ -300,31 +321,6 @@ watch(
                     />
                   </UAvatarGroup>
                 </UButton>
-              </UTooltip>
-              <UTooltip :text="`RPC ${rpcStatus}`">
-                <ProjectStatusDot
-                  :status="rpcStatus"
-                  pulse
-                  padded
-                />
-              </UTooltip>
-              <UTooltip text="New thread">
-                <UButton
-                  icon="i-lucide-plus"
-                  color="primary"
-                  variant="soft"
-                  square
-                  @click="onNewThread"
-                />
-              </UTooltip>
-              <UTooltip text="Previous threads">
-                <UButton
-                  icon="i-lucide-history"
-                  color="neutral"
-                  variant="outline"
-                  square
-                  @click="openPanel"
-                />
               </UTooltip>
             </div>
           </template>

--- a/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
+++ b/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
@@ -16,7 +16,7 @@ import {
 
 const route = useRoute()
 const router = useRouter()
-const { openPanel } = useThreadPanel()
+const { togglePanel } = useThreadPanel()
 const { loaded, refreshProjects, getProject, pendingProjectId } = useProjects()
 
 const projectId = computed(() => normalizeProjectIdParam(route.params.projectId as string | string[] | undefined))
@@ -290,7 +290,7 @@ watch(
                   color="neutral"
                   variant="outline"
                   square
-                  @click="openPanel"
+                  @click="togglePanel"
                 />
               </UTooltip>
               <UTooltip

--- a/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
+++ b/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
@@ -1,11 +1,18 @@
 <script setup lang="ts">
 import { useRoute, useRouter } from '#imports'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useChatSession } from '../../../../composables/useChatSession'
 import { useProjects } from '../../../../composables/useProjects'
 import { useThreadPanel } from '../../../../composables/useThreadPanel'
 import { useVisualSubagentPanels } from '../../../../composables/useVisualSubagentPanels'
 import { normalizeProjectIdParam, toProjectRoute } from '~~/shared/codori'
+import {
+  pruneExpandedSubagentThreadId,
+  resolveExpandedSubagentPanel,
+  resolveSubagentAccent,
+  resolveSubagentPanelAutoOpen,
+  toSubagentAvatarText
+} from '~~/shared/subagent-panels'
 
 const route = useRoute()
 const router = useRouter()
@@ -51,41 +58,85 @@ const rpcStatus = computed(() => {
   }
 })
 const isSubagentsPanelOpen = ref(false)
+const isMobileSubagentsDrawerOpen = ref(false)
+const expandedSubagentThreadId = ref<string | null>(null)
 const hasUserToggledSubagentsPanel = ref(false)
 const hasResolvedSubagentPanelState = ref(false)
 const previousActiveSubagentCount = ref(0)
+const isMobileViewport = ref(true)
 const hasAvailableSubagents = computed(() => availablePanels.value.length > 0)
-const isSubagentsPanelVisible = computed(() =>
-  isSubagentsPanelOpen.value && hasAvailableSubagents.value
+const isDesktopSubagentsPanelVisible = computed(() =>
+  !isMobileViewport.value && isSubagentsPanelOpen.value && hasAvailableSubagents.value
+)
+const isSubagentsSurfaceOpen = computed(() =>
+  isMobileViewport.value ? isMobileSubagentsDrawerOpen.value : isDesktopSubagentsPanelVisible.value
 )
 const subagentsToggleIcon = computed(() =>
-  isSubagentsPanelVisible.value
-    ? 'i-lucide-panel-right-close'
-    : 'i-lucide-panel-right-open'
+  isMobileViewport.value
+    ? (isMobileSubagentsDrawerOpen.value ? 'i-lucide-x' : 'i-lucide-list-tree')
+    : (isDesktopSubagentsPanelVisible.value ? 'i-lucide-panel-right-close' : 'i-lucide-panel-right-open')
 )
-const toSubagentAvatarText = (name: string) => {
-  const normalized = name.replace(/\s+/g, '').trim()
-  return Array.from(normalized || 'AG').slice(0, 2).join('')
-}
+const subagentsToggleLabel = computed(() =>
+  isMobileViewport.value
+    ? (isMobileSubagentsDrawerOpen.value ? 'Hide subagents' : 'Show subagents')
+    : (isDesktopSubagentsPanelVisible.value ? 'Hide subagents' : 'Show subagents')
+)
 const subagentAvatarItems = computed(() =>
   availablePanels.value.map((panel, index) => ({
     threadId: panel.threadId,
     name: panel.name,
     text: toSubagentAvatarText(panel.name),
-    class: [
-      'bg-emerald-500/15 text-emerald-700 ring-1 ring-inset ring-emerald-500/30 dark:text-emerald-300',
-      'bg-sky-500/15 text-sky-700 ring-1 ring-inset ring-sky-500/30 dark:text-sky-300',
-      'bg-amber-500/15 text-amber-800 ring-1 ring-inset ring-amber-500/35 dark:text-amber-300',
-      'bg-rose-500/15 text-rose-700 ring-1 ring-inset ring-rose-500/30 dark:text-rose-300',
-      'bg-violet-500/15 text-violet-700 ring-1 ring-inset ring-violet-500/30 dark:text-violet-300'
-    ][index % 5]
+    class: resolveSubagentAccent(index).avatarClass
   }))
 )
+const expandedSubagentPanel = computed(() =>
+  resolveExpandedSubagentPanel(availablePanels.value, expandedSubagentThreadId.value)
+)
+const expandedSubagentAccentClass = computed(() => {
+  if (!expandedSubagentPanel.value) {
+    return ''
+  }
+
+  const index = availablePanels.value.findIndex(panel => panel.threadId === expandedSubagentPanel.value?.threadId)
+  return index >= 0 ? resolveSubagentAccent(index).textClass : ''
+})
+const isExpandedSubagentOpen = computed({
+  get: () => expandedSubagentPanel.value !== null,
+  set: (open) => {
+    if (!open) {
+      expandedSubagentThreadId.value = null
+    }
+  }
+})
+
+let viewportQuery: MediaQueryList | null = null
+let removeViewportListener: (() => void) | null = null
+
+const syncViewportMode = (mobile: boolean) => {
+  isMobileViewport.value = mobile
+
+  if (mobile) {
+    isSubagentsPanelOpen.value = false
+    return
+  }
+
+  isMobileSubagentsDrawerOpen.value = false
+
+  if (hasAvailableSubagents.value && !hasUserToggledSubagentsPanel.value && activePanels.value.length > 0) {
+    isSubagentsPanelOpen.value = true
+  }
+}
 
 const toggleSubagentsPanel = () => {
   if (!hasAvailableSubagents.value) {
     return
   }
+
+  if (isMobileViewport.value) {
+    isMobileSubagentsDrawerOpen.value = !isMobileSubagentsDrawerOpen.value
+    return
+  }
+
   hasUserToggledSubagentsPanel.value = true
   isSubagentsPanelOpen.value = !isSubagentsPanelOpen.value
 }
@@ -93,6 +144,15 @@ const toggleSubagentsPanel = () => {
 const closeSubagentsPanel = () => {
   hasUserToggledSubagentsPanel.value = true
   isSubagentsPanelOpen.value = false
+}
+
+const openExpandedSubagent = (subagentThreadId: string) => {
+  expandedSubagentThreadId.value = subagentThreadId
+  isMobileSubagentsDrawerOpen.value = false
+}
+
+const closeExpandedSubagent = () => {
+  expandedSubagentThreadId.value = null
 }
 
 const onNewThread = async () => {
@@ -107,6 +167,26 @@ onMounted(() => {
   if (!loaded.value) {
     void refreshProjects()
   }
+
+  if (!import.meta.client) {
+    return
+  }
+
+  viewportQuery = window.matchMedia('(max-width: 767px)')
+  syncViewportMode(viewportQuery.matches)
+
+  const handleViewportChange = (event: MediaQueryListEvent) => {
+    syncViewportMode(event.matches)
+  }
+
+  viewportQuery.addEventListener('change', handleViewportChange)
+  removeViewportListener = () => {
+    viewportQuery?.removeEventListener('change', handleViewportChange)
+  }
+})
+
+onBeforeUnmount(() => {
+  removeViewportListener?.()
 })
 
 watch(threadId, () => {
@@ -114,6 +194,8 @@ watch(threadId, () => {
   hasResolvedSubagentPanelState.value = false
   previousActiveSubagentCount.value = 0
   isSubagentsPanelOpen.value = false
+  isMobileSubagentsDrawerOpen.value = false
+  expandedSubagentThreadId.value = null
 }, { immediate: true })
 
 watch(hasAvailableSubagents, (value) => {
@@ -122,31 +204,33 @@ watch(hasAvailableSubagents, (value) => {
     hasResolvedSubagentPanelState.value = false
     previousActiveSubagentCount.value = 0
     isSubagentsPanelOpen.value = false
+    isMobileSubagentsDrawerOpen.value = false
+    expandedSubagentThreadId.value = null
   }
+}, { immediate: true })
+
+watch(availablePanels, (panels) => {
+  expandedSubagentThreadId.value = pruneExpandedSubagentThreadId(panels, expandedSubagentThreadId.value)
 }, { immediate: true })
 
 watch(
   () => activePanels.value.length,
   (nextCount) => {
-    if (!hasAvailableSubagents.value) {
-      return
-    }
+    const nextState = resolveSubagentPanelAutoOpen({
+      isMobile: isMobileViewport.value,
+      hasAvailableSubagents: hasAvailableSubagents.value,
+      hasResolvedState: hasResolvedSubagentPanelState.value,
+      hasUserToggled: hasUserToggledSubagentsPanel.value,
+      previousActiveCount: previousActiveSubagentCount.value,
+      nextActiveCount: nextCount
+    })
 
-    if (!hasResolvedSubagentPanelState.value) {
-      hasResolvedSubagentPanelState.value = true
-      previousActiveSubagentCount.value = nextCount
-      isSubagentsPanelOpen.value = nextCount > 0
-      return
-    }
+    hasResolvedSubagentPanelState.value = nextState.hasResolvedState
+    previousActiveSubagentCount.value = nextState.previousActiveCount
 
-    if (!hasUserToggledSubagentsPanel.value
-      && previousActiveSubagentCount.value === 0
-      && nextCount > 0
-    ) {
-      isSubagentsPanelOpen.value = true
+    if (nextState.nextOpen !== null) {
+      isSubagentsPanelOpen.value = nextState.nextOpen
     }
-
-    previousActiveSubagentCount.value = nextCount
   },
   { immediate: true }
 )
@@ -157,10 +241,10 @@ watch(
     <UDashboardPanel
       id="thread-shell"
       class="min-h-0 min-w-0 flex-1"
-      :default-size="isSubagentsPanelVisible ? 70 : undefined"
-      :min-size="isSubagentsPanelVisible ? 50 : undefined"
-      :max-size="isSubagentsPanelVisible ? 75 : undefined"
-      :resizable="isSubagentsPanelVisible"
+      :default-size="isDesktopSubagentsPanelVisible ? 70 : undefined"
+      :min-size="isDesktopSubagentsPanelVisible ? 50 : undefined"
+      :max-size="isDesktopSubagentsPanelVisible ? 75 : undefined"
+      :resizable="isDesktopSubagentsPanelVisible"
       :ui="{ root: '!p-0', body: '!p-0 sm:!p-0 !gap-0 sm:!gap-0' }"
     >
       <template #header>
@@ -193,12 +277,12 @@ watch(
                 text="Subagents"
               >
                 <UButton
-                  :color="isSubagentsPanelVisible ? 'primary' : 'neutral'"
-                  :variant="isSubagentsPanelVisible ? 'soft' : 'ghost'"
+                  :color="isSubagentsSurfaceOpen ? 'primary' : 'neutral'"
+                  :variant="isSubagentsSurfaceOpen ? 'soft' : 'ghost'"
                   :icon="subagentsToggleIcon"
                   size="sm"
                   class="px-2 xl:ps-2 xl:pe-2.5"
-                  :aria-label="isSubagentsPanelVisible ? 'Hide subagents' : 'Show subagents'"
+                  :aria-label="subagentsToggleLabel"
                   @click="toggleSubagentsPanel"
                 >
                   <UAvatarGroup
@@ -258,7 +342,7 @@ watch(
     </UDashboardPanel>
 
     <UDashboardPanel
-      v-if="isSubagentsPanelVisible"
+      v-if="isDesktopSubagentsPanelVisible"
       id="thread-subagents-panel"
       class="h-full min-h-0"
       :default-size="30"
@@ -297,9 +381,76 @@ watch(
         <VisualSubagentStack
           :agents="availablePanels"
           class="h-full min-h-0"
+          @expand="openExpandedSubagent"
         />
       </template>
     </UDashboardPanel>
+
+    <UDrawer
+      v-if="hasAvailableSubagents"
+      v-model:open="isMobileSubagentsDrawerOpen"
+      direction="bottom"
+      :handle="true"
+      :ui="{
+        content: 'max-h-[85dvh] rounded-t-2xl md:hidden',
+        container: 'gap-0 p-0',
+        header: 'px-4 pb-2 pt-4',
+        body: '!p-0',
+        footer: 'hidden'
+      }"
+    >
+      <template #header>
+        <div class="flex items-center justify-between gap-2">
+          <div class="flex items-center gap-2">
+            <span class="text-sm font-semibold text-highlighted">Subagents</span>
+            <UBadge
+              color="primary"
+              variant="soft"
+              size="sm"
+            >
+              {{ availablePanels.length }}
+            </UBadge>
+          </div>
+          <UButton
+            icon="i-lucide-x"
+            color="neutral"
+            variant="ghost"
+            size="xs"
+            square
+            aria-label="Close subagents drawer"
+            @click="isMobileSubagentsDrawerOpen = false"
+          />
+        </div>
+      </template>
+
+      <template #body>
+        <SubagentDrawerList
+          :agents="availablePanels"
+          @expand="openExpandedSubagent"
+        />
+      </template>
+    </UDrawer>
+
+    <UModal
+      v-model:open="isExpandedSubagentOpen"
+      fullscreen
+      :ui="{
+        content: 'overflow-hidden bg-default',
+        body: '!h-full !p-0'
+      }"
+    >
+      <template #body>
+        <SubagentTranscriptPanel
+          v-if="expandedSubagentPanel"
+          :agent="expandedSubagentPanel"
+          :accent-class="expandedSubagentAccentClass"
+          expanded
+          show-collapse-button
+          class="h-full"
+          @collapse="closeExpandedSubagent"
+        />
+      </template>
+    </UModal>
 
     <ThreadPanel :project-id="projectId" />
   </div>

--- a/packages/client/shared/subagent-panels.ts
+++ b/packages/client/shared/subagent-panels.ts
@@ -1,0 +1,135 @@
+import type { SubagentAgentStatus, VisualSubagentPanel } from './codex-chat'
+
+export type SubagentPanelAutoOpenInput = {
+  isMobile: boolean
+  hasAvailableSubagents: boolean
+  hasResolvedState: boolean
+  hasUserToggled: boolean
+  previousActiveCount: number
+  nextActiveCount: number
+}
+
+export type SubagentPanelAutoOpenResult = {
+  hasResolvedState: boolean
+  previousActiveCount: number
+  nextOpen: boolean | null
+}
+
+const SUBAGENT_ACCENT_STYLES = [
+  {
+    textClass: 'text-emerald-700 dark:text-emerald-300',
+    avatarClass: 'bg-emerald-500/15 text-emerald-700 ring-1 ring-inset ring-emerald-500/30 dark:text-emerald-300'
+  },
+  {
+    textClass: 'text-sky-700 dark:text-sky-300',
+    avatarClass: 'bg-sky-500/15 text-sky-700 ring-1 ring-inset ring-sky-500/30 dark:text-sky-300'
+  },
+  {
+    textClass: 'text-amber-800 dark:text-amber-300',
+    avatarClass: 'bg-amber-500/15 text-amber-800 ring-1 ring-inset ring-amber-500/35 dark:text-amber-300'
+  },
+  {
+    textClass: 'text-rose-700 dark:text-rose-300',
+    avatarClass: 'bg-rose-500/15 text-rose-700 ring-1 ring-inset ring-rose-500/30 dark:text-rose-300'
+  },
+  {
+    textClass: 'text-violet-700 dark:text-violet-300',
+    avatarClass: 'bg-violet-500/15 text-violet-700 ring-1 ring-inset ring-violet-500/30 dark:text-violet-300'
+  },
+  {
+    textClass: 'text-cyan-700 dark:text-cyan-300',
+    avatarClass: 'bg-cyan-500/15 text-cyan-700 ring-1 ring-inset ring-cyan-500/30 dark:text-cyan-300'
+  },
+  {
+    textClass: 'text-lime-800 dark:text-lime-300',
+    avatarClass: 'bg-lime-500/15 text-lime-800 ring-1 ring-inset ring-lime-500/35 dark:text-lime-300'
+  },
+  {
+    textClass: 'text-orange-700 dark:text-orange-300',
+    avatarClass: 'bg-orange-500/15 text-orange-700 ring-1 ring-inset ring-orange-500/30 dark:text-orange-300'
+  }
+] as const
+
+export const resolveSubagentAccent = (index: number) =>
+  SUBAGENT_ACCENT_STYLES[index % SUBAGENT_ACCENT_STYLES.length] ?? SUBAGENT_ACCENT_STYLES[0]!
+
+export const toSubagentAvatarText = (name: string) => {
+  const normalized = name.replace(/\s+/g, '').trim()
+  return Array.from(normalized || 'AG').slice(0, 2).join('')
+}
+
+export const resolveSubagentStatusMeta = (status: SubagentAgentStatus) => {
+  switch (status) {
+    case 'pendingInit':
+      return { color: 'primary', label: 'pending' }
+    case 'running':
+      return { color: 'info', label: 'running' }
+    case 'completed':
+      return { color: 'success', label: 'completed' }
+    case 'interrupted':
+      return { color: 'warning', label: 'interrupted' }
+    case 'errored':
+      return { color: 'error', label: 'errored' }
+    case 'shutdown':
+      return { color: 'neutral', label: 'shutdown' }
+    case 'notFound':
+      return { color: 'neutral', label: 'not found' }
+    default:
+      return { color: 'neutral', label: 'active' }
+  }
+}
+
+export const resolveSubagentPanelAutoOpen = (
+  input: SubagentPanelAutoOpenInput
+): SubagentPanelAutoOpenResult => {
+  if (!input.hasAvailableSubagents) {
+    return {
+      hasResolvedState: false,
+      previousActiveCount: 0,
+      nextOpen: false
+    }
+  }
+
+  if (!input.hasResolvedState) {
+    return {
+      hasResolvedState: true,
+      previousActiveCount: input.nextActiveCount,
+      nextOpen: input.isMobile ? false : input.nextActiveCount > 0
+    }
+  }
+
+  if (
+    !input.isMobile
+    && !input.hasUserToggled
+    && input.previousActiveCount === 0
+    && input.nextActiveCount > 0
+  ) {
+    return {
+      hasResolvedState: true,
+      previousActiveCount: input.nextActiveCount,
+      nextOpen: true
+    }
+  }
+
+  return {
+    hasResolvedState: true,
+    previousActiveCount: input.nextActiveCount,
+    nextOpen: null
+  }
+}
+
+export const resolveExpandedSubagentPanel = (
+  panels: VisualSubagentPanel[],
+  expandedThreadId: string | null
+) => {
+  if (!expandedThreadId) {
+    return null
+  }
+
+  return panels.find(panel => panel.threadId === expandedThreadId) ?? null
+}
+
+export const pruneExpandedSubagentThreadId = (
+  panels: VisualSubagentPanel[],
+  expandedThreadId: string | null
+) => resolveExpandedSubagentPanel(panels, expandedThreadId)?.threadId ?? null

--- a/packages/client/shared/subagent-panels.ts
+++ b/packages/client/shared/subagent-panels.ts
@@ -1,5 +1,12 @@
 import type { SubagentAgentStatus, VisualSubagentPanel } from './codex-chat'
 
+export type SubagentAccent = {
+  textClass: string
+  avatarClass: string
+  dotClass: string
+  headerClass: string
+}
+
 export type SubagentPanelAutoOpenInput = {
   isMobile: boolean
   hasAvailableSubagents: boolean
@@ -18,39 +25,55 @@ export type SubagentPanelAutoOpenResult = {
 const SUBAGENT_ACCENT_STYLES = [
   {
     textClass: 'text-emerald-700 dark:text-emerald-300',
-    avatarClass: 'bg-emerald-500/15 text-emerald-700 ring-1 ring-inset ring-emerald-500/30 dark:text-emerald-300'
+    avatarClass: 'bg-emerald-500/15 text-emerald-700 ring-1 ring-inset ring-emerald-500/30 dark:text-emerald-300',
+    dotClass: 'bg-emerald-500 ring-emerald-500/25',
+    headerClass: 'border-s-2 border-emerald-500/45 bg-emerald-500/6'
   },
   {
     textClass: 'text-sky-700 dark:text-sky-300',
-    avatarClass: 'bg-sky-500/15 text-sky-700 ring-1 ring-inset ring-sky-500/30 dark:text-sky-300'
+    avatarClass: 'bg-sky-500/15 text-sky-700 ring-1 ring-inset ring-sky-500/30 dark:text-sky-300',
+    dotClass: 'bg-sky-500 ring-sky-500/25',
+    headerClass: 'border-s-2 border-sky-500/45 bg-sky-500/6'
   },
   {
     textClass: 'text-amber-800 dark:text-amber-300',
-    avatarClass: 'bg-amber-500/15 text-amber-800 ring-1 ring-inset ring-amber-500/35 dark:text-amber-300'
+    avatarClass: 'bg-amber-500/15 text-amber-800 ring-1 ring-inset ring-amber-500/35 dark:text-amber-300',
+    dotClass: 'bg-amber-500 ring-amber-500/25',
+    headerClass: 'border-s-2 border-amber-500/45 bg-amber-500/6'
   },
   {
     textClass: 'text-rose-700 dark:text-rose-300',
-    avatarClass: 'bg-rose-500/15 text-rose-700 ring-1 ring-inset ring-rose-500/30 dark:text-rose-300'
+    avatarClass: 'bg-rose-500/15 text-rose-700 ring-1 ring-inset ring-rose-500/30 dark:text-rose-300',
+    dotClass: 'bg-rose-500 ring-rose-500/25',
+    headerClass: 'border-s-2 border-rose-500/45 bg-rose-500/6'
   },
   {
     textClass: 'text-violet-700 dark:text-violet-300',
-    avatarClass: 'bg-violet-500/15 text-violet-700 ring-1 ring-inset ring-violet-500/30 dark:text-violet-300'
+    avatarClass: 'bg-violet-500/15 text-violet-700 ring-1 ring-inset ring-violet-500/30 dark:text-violet-300',
+    dotClass: 'bg-violet-500 ring-violet-500/25',
+    headerClass: 'border-s-2 border-violet-500/45 bg-violet-500/6'
   },
   {
     textClass: 'text-cyan-700 dark:text-cyan-300',
-    avatarClass: 'bg-cyan-500/15 text-cyan-700 ring-1 ring-inset ring-cyan-500/30 dark:text-cyan-300'
+    avatarClass: 'bg-cyan-500/15 text-cyan-700 ring-1 ring-inset ring-cyan-500/30 dark:text-cyan-300',
+    dotClass: 'bg-cyan-500 ring-cyan-500/25',
+    headerClass: 'border-s-2 border-cyan-500/45 bg-cyan-500/6'
   },
   {
     textClass: 'text-lime-800 dark:text-lime-300',
-    avatarClass: 'bg-lime-500/15 text-lime-800 ring-1 ring-inset ring-lime-500/35 dark:text-lime-300'
+    avatarClass: 'bg-lime-500/15 text-lime-800 ring-1 ring-inset ring-lime-500/35 dark:text-lime-300',
+    dotClass: 'bg-lime-500 ring-lime-500/25',
+    headerClass: 'border-s-2 border-lime-500/45 bg-lime-500/6'
   },
   {
     textClass: 'text-orange-700 dark:text-orange-300',
-    avatarClass: 'bg-orange-500/15 text-orange-700 ring-1 ring-inset ring-orange-500/30 dark:text-orange-300'
+    avatarClass: 'bg-orange-500/15 text-orange-700 ring-1 ring-inset ring-orange-500/30 dark:text-orange-300',
+    dotClass: 'bg-orange-500 ring-orange-500/25',
+    headerClass: 'border-s-2 border-orange-500/45 bg-orange-500/6'
   }
 ] as const
 
-export const resolveSubagentAccent = (index: number) =>
+export const resolveSubagentAccent = (index: number): SubagentAccent =>
   SUBAGENT_ACCENT_STYLES[index % SUBAGENT_ACCENT_STYLES.length] ?? SUBAGENT_ACCENT_STYLES[0]!
 
 export const toSubagentAvatarText = (name: string) => {

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -24,6 +24,13 @@ import {
   resolveEffortOptions
 } from '../shared/chat-prompt-controls'
 import {
+  pruneExpandedSubagentThreadId,
+  resolveExpandedSubagentPanel,
+  resolveSubagentPanelAutoOpen,
+  resolveSubagentStatusMeta,
+  toSubagentAvatarText
+} from '../shared/subagent-panels'
+import {
   encodeProjectIdSegment,
   normalizeProjectIdParam,
   projectStatusMeta,
@@ -476,5 +483,83 @@ describe('client package', () => {
       remainingPercent: 56.25
     })
     expect(formatCompactTokenCount(12800)).toBe('13k')
+  })
+
+  it('keeps the subagent panel closed by default on mobile even with active agents', () => {
+    expect(resolveSubagentPanelAutoOpen({
+      isMobile: true,
+      hasAvailableSubagents: true,
+      hasResolvedState: false,
+      hasUserToggled: false,
+      previousActiveCount: 0,
+      nextActiveCount: 1
+    })).toEqual({
+      hasResolvedState: true,
+      previousActiveCount: 1,
+      nextOpen: false
+    })
+  })
+
+  it('auto-opens the subagent panel on desktop when the first active agent appears', () => {
+    expect(resolveSubagentPanelAutoOpen({
+      isMobile: false,
+      hasAvailableSubagents: true,
+      hasResolvedState: true,
+      hasUserToggled: false,
+      previousActiveCount: 0,
+      nextActiveCount: 2
+    })).toEqual({
+      hasResolvedState: true,
+      previousActiveCount: 2,
+      nextOpen: true
+    })
+  })
+
+  it('preserves manual desktop visibility decisions after the user toggles the panel', () => {
+    expect(resolveSubagentPanelAutoOpen({
+      isMobile: false,
+      hasAvailableSubagents: true,
+      hasResolvedState: true,
+      hasUserToggled: true,
+      previousActiveCount: 0,
+      nextActiveCount: 1
+    })).toEqual({
+      hasResolvedState: true,
+      previousActiveCount: 1,
+      nextOpen: null
+    })
+  })
+
+  it('drops the expanded subagent selection when the target panel disappears', () => {
+    const panels = [{
+      threadId: 'agent-1',
+      name: 'Planner',
+      status: 'running',
+      messages: [],
+      firstSeenAt: 1,
+      lastSeenAt: 2
+    }, {
+      threadId: 'agent-2',
+      name: 'Reviewer',
+      status: 'completed',
+      messages: [],
+      firstSeenAt: 3,
+      lastSeenAt: 4
+    }] as const
+
+    expect(resolveExpandedSubagentPanel([...panels], 'agent-2')?.name).toBe('Reviewer')
+    expect(pruneExpandedSubagentThreadId([...panels], 'agent-3')).toBeNull()
+  })
+
+  it('formats subagent identity helpers for compact UI labels', () => {
+    expect(toSubagentAvatarText('Code Reviewer')).toBe('Co')
+    expect(resolveSubagentStatusMeta('pendingInit')).toEqual({
+      color: 'primary',
+      label: 'pending'
+    })
+    expect(resolveSubagentStatusMeta(null)).toEqual({
+      color: 'neutral',
+      label: 'active'
+    })
   })
 })

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -6,7 +6,12 @@ import {
   resolveTurnSubmissionMethod,
   shouldIgnoreNotificationAfterInterrupt
 } from '../app/utils/chat-turn-engagement'
-import { ITEM_PART, isSubagentActiveStatus, itemToMessages } from '../shared/codex-chat'
+import {
+  ITEM_PART,
+  isSubagentActiveStatus,
+  itemToMessages,
+  type VisualSubagentPanel
+} from '../shared/codex-chat'
 import {
   buildTurnStartInput,
   resolveAttachmentPreviewUrl,
@@ -531,7 +536,7 @@ describe('client package', () => {
   })
 
   it('drops the expanded subagent selection when the target panel disappears', () => {
-    const panels = [{
+    const panels: VisualSubagentPanel[] = [{
       threadId: 'agent-1',
       name: 'Planner',
       status: 'running',
@@ -545,7 +550,7 @@ describe('client package', () => {
       messages: [],
       firstSeenAt: 3,
       lastSeenAt: 4
-    }] as const
+    }]
 
     expect(resolveExpandedSubagentPanel([...panels], 'agent-2')?.name).toBe('Reviewer')
     expect(pruneExpandedSubagentThreadId([...panels], 'agent-3')).toBeNull()


### PR DESCRIPTION
## Summary
- add responsive subagent experiences with a desktop split panel, a mobile bottom drawer, and fullscreen focused transcript expansion
- preserve subagent identity with consistent palette styling, clearer navbar toggles, and explicit expand or collapse controls
- fix thread history regressions by stabilizing the desktop resume panel layout and making the navbar history action behave as a true toggle
- harden viewport and transcript behavior by removing first-mount desktop/mobile flicker, isolating scroll state between stacked and expanded views, and keeping streaming subagent output auto-scrolled

## Testing
- pnpm --filter @codori/client test
- pnpm --filter @codori/client typecheck

Closes #9