### PR TITLE
Fix transcript stability for completed items and reasoning feedback

### DIFF
--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -516,6 +516,12 @@ const ensureThinkingPlaceholder = () => {
   messages.value = showThinkingPlaceholder(messages.value)
 }
 
+const clearThinkingPlaceholderForVisibleItem = (item: CodexThreadItem) => {
+  if (item.type !== 'userMessage') {
+    clearThinkingPlaceholder()
+  }
+}
+
 const restoreDraftIfPristine = (text: string, submittedAttachments: DraftAttachment[]) => {
   if (!input.value.trim()) {
     input.value = text
@@ -1444,6 +1450,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
         status.value = 'streaming'
         return
       }
+      clearThinkingPlaceholderForVisibleItem(params.item)
       seedStreamingMessage(params.item)
       status.value = 'streaming'
       return
@@ -1453,9 +1460,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
       if (params.item.type === 'collabAgentToolCall') {
         applySubagentActivityItem(params.item)
       }
-      if (params.item.type === 'agentMessage' || params.item.type === 'plan' || params.item.type === 'reasoning') {
-        clearThinkingPlaceholder()
-      }
+      clearThinkingPlaceholderForVisibleItem(params.item)
       for (const nextMessage of itemToMessages(params.item)) {
         const confirmedMessage = {
           ...nextMessage,

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -20,6 +20,7 @@ import {
   eventToMessage,
   isSubagentActiveStatus,
   itemToMessages,
+  replaceStreamingMessage,
   threadToMessages,
   upsertStreamingMessage,
   type ChatMessage,
@@ -1231,7 +1232,7 @@ const applySubagentNotification = (threadId: string, notification: CodexRpcNotif
       }
       for (const nextMessage of itemToMessages(params.item)) {
         updateSubagentPanelMessages(threadId, (panelMessages) =>
-          upsertStreamingMessage(panelMessages, {
+          replaceStreamingMessage(panelMessages, {
             ...nextMessage,
             pending: false
           })
@@ -1452,7 +1453,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
           continue
         }
 
-        messages.value = upsertStreamingMessage(messages.value, confirmedMessage)
+        messages.value = replaceStreamingMessage(messages.value, confirmedMessage)
       }
       return
     }

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -16,11 +16,13 @@ import { useProjects } from '../composables/useProjects'
 import { useRpc } from '../composables/useRpc'
 import { useChatSubmitGuard } from '../composables/useChatSubmitGuard'
 import {
+  hideThinkingPlaceholder,
   ITEM_PART,
   eventToMessage,
   isSubagentActiveStatus,
   itemToMessages,
   replaceStreamingMessage,
+  showThinkingPlaceholder,
   threadToMessages,
   upsertStreamingMessage,
   type ChatMessage,
@@ -504,6 +506,14 @@ const formatAttachmentSize = (size: number) => {
 const removeOptimisticMessage = (messageId: string) => {
   messages.value = removeChatMessage(messages.value, messageId)
   optimisticAttachmentSnapshots.delete(messageId)
+}
+
+const clearThinkingPlaceholder = () => {
+  messages.value = hideThinkingPlaceholder(messages.value)
+}
+
+const ensureThinkingPlaceholder = () => {
+  messages.value = showThinkingPlaceholder(messages.value)
 }
 
 const restoreDraftIfPristine = (text: string, submittedAttachments: DraftAttachment[]) => {
@@ -1443,6 +1453,9 @@ const applyNotification = (notification: CodexRpcNotification) => {
       if (params.item.type === 'collabAgentToolCall') {
         applySubagentActivityItem(params.item)
       }
+      if (params.item.type === 'agentMessage' || params.item.type === 'plan' || params.item.type === 'reasoning') {
+        clearThinkingPlaceholder()
+      }
       for (const nextMessage of itemToMessages(params.item)) {
         const confirmedMessage = {
           ...nextMessage,
@@ -1459,6 +1472,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
     }
     case 'item/agentMessage/delta': {
       const params = notification.params as { itemId: string, delta: string }
+      clearThinkingPlaceholder()
       appendTextPartDelta(params.itemId, params.delta, {
         id: params.itemId,
         role: 'assistant',
@@ -1474,6 +1488,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
     }
     case 'item/plan/delta': {
       const params = notification.params as { itemId: string, delta: string }
+      clearThinkingPlaceholder()
       appendTextPartDelta(params.itemId, params.delta, {
         id: params.itemId,
         role: 'assistant',
@@ -1490,6 +1505,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
     case 'item/reasoning/textDelta':
     case 'item/reasoning/summaryTextDelta': {
       const params = notification.params as { itemId: string, delta: string }
+      clearThinkingPlaceholder()
       updateMessage(params.itemId, {
         id: params.itemId,
         role: 'assistant',
@@ -1597,6 +1613,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
     case 'error': {
       const params = notification.params as { error?: { message?: string } }
       const messageText = params.error?.message ?? 'The stream failed.'
+      clearThinkingPlaceholder()
       pushEventMessage('stream.error', messageText)
       clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
       clearLiveStream(new Error(messageText))
@@ -1607,6 +1624,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
     case 'turn/failed': {
       const params = notification.params as { error?: { message?: string } }
       const messageText = params.error?.message ?? 'The turn failed.'
+      clearThinkingPlaceholder()
       pushEventMessage('turn.failed', messageText)
       clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
       clearLiveStream(new Error(messageText))
@@ -1617,6 +1635,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
     case 'stream/error': {
       const params = notification.params as { message?: string }
       const messageText = params.message ?? 'The stream failed.'
+      clearThinkingPlaceholder()
       pushEventMessage('stream.error', messageText)
       clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
       clearLiveStream(new Error(messageText))
@@ -1625,6 +1644,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
       return
     }
     case 'turn/completed': {
+      clearThinkingPlaceholder()
       clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
       error.value = null
       status.value = 'ready'
@@ -1665,6 +1685,7 @@ const sendMessage = async () => {
   const optimisticMessageId = optimisticMessage.id
   rememberOptimisticAttachments(optimisticMessageId, submittedAttachments)
   messages.value = [...messages.value, optimisticMessage]
+  ensureThinkingPlaceholder()
   let startedLiveStream: LiveStream | null = null
 
   try {
@@ -1712,6 +1733,7 @@ const sendMessage = async () => {
   } catch (caughtError) {
     const messageText = caughtError instanceof Error ? caughtError.message : String(caughtError)
 
+    clearThinkingPlaceholder()
     untrackPendingUserMessage(optimisticMessageId)
     removeOptimisticMessage(optimisticMessageId)
 

--- a/packages/client/shared/codex-chat.ts
+++ b/packages/client/shared/codex-chat.ts
@@ -336,11 +336,13 @@ const normalizeParts = (message: ChatMessage): ChatPart[] =>
     return part
   })
 
+const normalizeMessage = (message: ChatMessage): ChatMessage => ({
+  ...message,
+  parts: normalizeParts(message)
+})
+
 export const upsertStreamingMessage = (messages: ChatMessage[], nextMessage: ChatMessage) => {
-  const normalizedMessage = {
-    ...nextMessage,
-    parts: normalizeParts(nextMessage)
-  }
+  const normalizedMessage = normalizeMessage(nextMessage)
   const nextMessages = messages.slice()
   const existingIndex = nextMessages.findIndex(message => message.id === normalizedMessage.id)
 
@@ -358,5 +360,19 @@ export const upsertStreamingMessage = (messages: ChatMessage[], nextMessage: Cha
     })
   })
 
+  return nextMessages
+}
+
+export const replaceStreamingMessage = (messages: ChatMessage[], nextMessage: ChatMessage) => {
+  const normalizedMessage = normalizeMessage(nextMessage)
+  const nextMessages = messages.slice()
+  const existingIndex = nextMessages.findIndex(message => message.id === normalizedMessage.id)
+
+  if (existingIndex === -1) {
+    nextMessages.push(normalizedMessage)
+    return nextMessages
+  }
+
+  nextMessages.splice(existingIndex, 1, normalizedMessage)
   return nextMessages
 }

--- a/packages/client/shared/codex-chat.ts
+++ b/packages/client/shared/codex-chat.ts
@@ -2,6 +2,7 @@ import type { CodexThread, CodexThreadItem, CodexUserInput } from './codex-rpc'
 
 export const EVENT_PART = 'data-thread-event' as const
 export const ITEM_PART = 'data-thread-item' as const
+export const THINKING_PLACEHOLDER_MESSAGE_ID = 'assistant-thinking-placeholder'
 
 export type ThreadEventData =
   | {
@@ -376,3 +377,21 @@ export const replaceStreamingMessage = (messages: ChatMessage[], nextMessage: Ch
   nextMessages.splice(existingIndex, 1, normalizedMessage)
   return nextMessages
 }
+
+export const buildThinkingPlaceholderMessage = (): ChatMessage => ({
+  id: THINKING_PLACEHOLDER_MESSAGE_ID,
+  role: 'assistant',
+  pending: true,
+  parts: [{
+    type: 'reasoning',
+    summary: ['Thinking...'],
+    content: [],
+    state: 'streaming'
+  }]
+})
+
+export const showThinkingPlaceholder = (messages: ChatMessage[]) =>
+  upsertStreamingMessage(messages, buildThinkingPlaceholderMessage())
+
+export const hideThinkingPlaceholder = (messages: ChatMessage[]) =>
+  messages.filter(message => message.id !== THINKING_PLACEHOLDER_MESSAGE_ID)

--- a/packages/client/shared/codex-chat.ts
+++ b/packages/client/shared/codex-chat.ts
@@ -393,5 +393,13 @@ export const buildThinkingPlaceholderMessage = (): ChatMessage => ({
 export const showThinkingPlaceholder = (messages: ChatMessage[]) =>
   upsertStreamingMessage(messages, buildThinkingPlaceholderMessage())
 
-export const hideThinkingPlaceholder = (messages: ChatMessage[]) =>
-  messages.filter(message => message.id !== THINKING_PLACEHOLDER_MESSAGE_ID)
+export const hideThinkingPlaceholder = (messages: ChatMessage[]) => {
+  const index = messages.findIndex(message => message.id === THINKING_PLACEHOLDER_MESSAGE_ID)
+  if (index === -1) {
+    return messages
+  }
+
+  const nextMessages = messages.slice()
+  nextMessages.splice(index, 1)
+  return nextMessages
+}

--- a/packages/client/test/chat-transcript.test.ts
+++ b/packages/client/test/chat-transcript.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import {
+  replaceStreamingMessage,
+  upsertStreamingMessage,
+  type ChatMessage
+} from '../shared/codex-chat'
+
+describe('chat transcript stability', () => {
+  it('replaces a streamed text message with the completed server payload', () => {
+    const streamedMessages = upsertStreamingMessage([], {
+      id: 'agent-1',
+      role: 'assistant',
+      pending: true,
+      parts: [{
+        type: 'text',
+        text: 'Partial reply',
+        state: 'streaming'
+      }, {
+        type: 'reasoning',
+        summary: ['Thinking'],
+        content: ['Hidden merge residue'],
+        state: 'streaming'
+      }]
+    })
+
+    expect(replaceStreamingMessage(streamedMessages, {
+      id: 'agent-1',
+      role: 'assistant',
+      pending: false,
+      parts: [{
+        type: 'text',
+        text: 'Final reply',
+        state: 'done'
+      }]
+    })).toEqual<ChatMessage[]>([{
+      id: 'agent-1',
+      role: 'assistant',
+      pending: false,
+      parts: [{
+        type: 'text',
+        text: 'Final reply',
+        state: 'done'
+      }]
+    }])
+  })
+
+  it('replaces streamed reasoning with the completed reasoning payload', () => {
+    const streamedMessages = upsertStreamingMessage([], {
+      id: 'reasoning-1',
+      role: 'assistant',
+      pending: true,
+      parts: [{
+        type: 'reasoning',
+        summary: ['Thinking...'],
+        content: ['step 1'],
+        state: 'streaming'
+      }]
+    })
+
+    expect(replaceStreamingMessage(streamedMessages, {
+      id: 'reasoning-1',
+      role: 'assistant',
+      pending: false,
+      parts: [{
+        type: 'reasoning',
+        summary: ['Plan'],
+        content: ['Final explanation'],
+        state: 'done'
+      }]
+    })).toEqual<ChatMessage[]>([{
+      id: 'reasoning-1',
+      role: 'assistant',
+      pending: false,
+      parts: [{
+        type: 'reasoning',
+        summary: ['Plan'],
+        content: ['Final explanation'],
+        state: 'done'
+      }]
+    }])
+  })
+})

--- a/packages/client/test/chat-transcript.test.ts
+++ b/packages/client/test/chat-transcript.test.ts
@@ -147,4 +147,19 @@ describe('chat transcript stability', () => {
       }]
     }])
   })
+
+  it('returns the original message array when no thinking placeholder is present', () => {
+    const messages: ChatMessage[] = [{
+      id: 'agent-1',
+      role: 'assistant',
+      pending: true,
+      parts: [{
+        type: 'text',
+        text: 'Working on it',
+        state: 'streaming'
+      }]
+    }]
+
+    expect(hideThinkingPlaceholder(messages)).toBe(messages)
+  })
 })

--- a/packages/client/test/chat-transcript.test.ts
+++ b/packages/client/test/chat-transcript.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
+  hideThinkingPlaceholder,
   replaceStreamingMessage,
+  showThinkingPlaceholder,
   upsertStreamingMessage,
   type ChatMessage
 } from '../shared/codex-chat'
@@ -76,6 +78,72 @@ describe('chat transcript stability', () => {
         summary: ['Plan'],
         content: ['Final explanation'],
         state: 'done'
+      }]
+    }])
+  })
+
+  it('adds a single thinking placeholder while the assistant has not produced content yet', () => {
+    const withPlaceholder = showThinkingPlaceholder([{
+      id: 'user-1',
+      role: 'user',
+      pending: false,
+      parts: [{
+        type: 'text',
+        text: 'Investigate the bug.',
+        state: 'done'
+      }]
+    }])
+
+    expect(showThinkingPlaceholder(withPlaceholder)).toEqual(withPlaceholder)
+    expect(withPlaceholder.at(-1)).toEqual<ChatMessage>({
+      id: 'assistant-thinking-placeholder',
+      role: 'assistant',
+      pending: true,
+      parts: [{
+        type: 'reasoning',
+        summary: ['Thinking...'],
+        content: [],
+        state: 'streaming'
+      }]
+    })
+  })
+
+  it('removes the thinking placeholder once real assistant content starts', () => {
+    expect(hideThinkingPlaceholder(showThinkingPlaceholder([{
+      id: 'user-1',
+      role: 'user',
+      pending: false,
+      parts: [{
+        type: 'text',
+        text: 'Investigate the bug.',
+        state: 'done'
+      }]
+    }, {
+      id: 'agent-1',
+      role: 'assistant',
+      pending: true,
+      parts: [{
+        type: 'text',
+        text: 'Looking into it',
+        state: 'streaming'
+      }]
+    }]))).toEqual<ChatMessage[]>([{
+      id: 'user-1',
+      role: 'user',
+      pending: false,
+      parts: [{
+        type: 'text',
+        text: 'Investigate the bug.',
+        state: 'done'
+      }]
+    }, {
+      id: 'agent-1',
+      role: 'assistant',
+      pending: true,
+      parts: [{
+        type: 'text',
+        text: 'Looking into it',
+        state: 'streaming'
       }]
     }])
   })


### PR DESCRIPTION
## Summary
- make completed transcript items replace streamed placeholders authoritatively in both the main chat and subagent transcripts
- show a temporary `Thinking...` reasoning placeholder after prompt submission until real assistant content appears
- add dedicated transcript stability regression tests outside `smoke.test.ts`

## Root cause
The client treated `item/completed` as another merge event and fed it through the normal streaming upsert path. When the final server item shape differed from the placeholder assembled from deltas, text or reasoning state could be dropped or left in an inconsistent merged state.

The chat UI also had no deterministic fallback reasoning state between prompt submission and the first visible assistant output, which made the transcript feel empty and unstable while streaming started.

## Impact
- streamed assistant text now stays visible after completion instead of disappearing
- completed reasoning items now replace their streamed state cleanly
- users see immediate `Thinking...` feedback while waiting for assistant output
- transcript stability coverage now lives in a focused test file instead of adding more weight to `smoke.test.ts`

## Validation
- `pnpm --filter client test`

Closes #15.
