### PR TITLE
Add idle shutdown for project runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,9 +231,16 @@ Example:
   "ports": {
     "start": 46000,
     "end": 46999
+  },
+  "idleShutdown": {
+    "enabled": true,
+    "timeoutMs": 1800000,
+    "sweepIntervalMs": 60000
   }
 }
 ```
+
+`idleShutdown.enabled` can disable automatic cleanup entirely. When enabled, `timeoutMs` controls how long a runtime may stay inactive before Codori stops it, and `sweepIntervalMs` controls how often the server checks for idle runtimes.
 
 ## Project Discovery Rules
 
@@ -250,6 +257,9 @@ Codori ignores common heavy directories during recursive scanning such as `node_
 
 - Each project gets at most one active Codex app-server.
 - If a PID/runtime file points to a live process, Codori reuses it instead of spawning another runtime.
+- Codori records `startedAt` and `lastActivityAt` for each runtime under `~/.codori/run/`.
+- Idle runtimes are stopped automatically after the configured inactivity timeout.
+- Runtimes with an active proxied WebSocket session are never reaped as idle.
 - If a PID/runtime file is stale, Codori cleans it up and starts a fresh runtime.
 - Runtime metadata is stored under `~/.codori/run/`.
 
@@ -286,7 +296,6 @@ Codori v1 does not provide:
 - built-in authentication
 - SSO
 - multi-root project indexing
-- automatic idle shutdown
 - a separate Codori-owned thread database
 
 If you want to access Codori from another machine, you must provide your own private network path with something like Tailscale or Cloudflare Tunnel.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -22,7 +22,6 @@ Codori is a self-hosted remote coding control plane for Codex app-server.
 - No built-in authentication or identity layer in v1.
 - No tunnel, reverse proxy, or ingress automation in v1.
 - No multi-root support in v1.
-- No automatic app-server idle shutdown in v1.
 - No Codori-owned thread database in v1.
 - No direct browser connection to raw project app-server ports.
 
@@ -61,6 +60,11 @@ Config shape:
   "ports": {
     "start": 46000,
     "end": 46999
+  },
+  "idleShutdown": {
+    "enabled": true,
+    "timeoutMs": 1800000,
+    "sweepIntervalMs": 60000
   }
 }
 ```
@@ -69,6 +73,9 @@ Rules:
 
 - `root` is required at runtime after precedence resolution.
 - `ports.start` and `ports.end` define the inclusive port allocation range for project app-servers.
+- `idleShutdown.enabled` controls whether idle runtimes are reaped automatically.
+- `idleShutdown.timeoutMs` defines the inactivity window before a runtime becomes eligible for automatic stop.
+- `idleShutdown.sweepIntervalMs` defines how often Codori evaluates running runtimes for idle cleanup.
 - Invalid config should produce a startup error with a precise message.
 
 ## 6. Project Discovery
@@ -128,9 +135,18 @@ PID/runtime file requirements:
   "projectPath": "/Users/comfuture/Project/codori",
   "pid": 12345,
   "port": 46001,
-  "startedAt": 1760000000000
+  "startedAt": 1760000000000,
+  "lastActivityAt": 1760000000000
 }
 ```
+
+Idle lifecycle behavior:
+
+- Codori updates `lastActivityAt` when it starts or reuses a runtime.
+- Proxied WebSocket traffic counts as activity.
+- A runtime with at least one active proxied WebSocket session is not considered idle.
+- When `Date.now() - lastActivityAt >= idleShutdown.timeoutMs` and there are no active sessions, Codori stops the runtime automatically.
+- The next project interaction follows the same on-demand start path and transparently recreates the runtime.
 
 Stop behavior:
 
@@ -253,6 +269,7 @@ Returns:
 Returns:
 
 - same runtime envelope used by list/detail responses
+- includes `startedAt`, `lastActivityAt`, `activeSessionCount`, and `idleDeadlineAt` when the runtime is running
 
 ### `WS /api/projects/:projectId/rpc`
 
@@ -408,6 +425,9 @@ Automated coverage must include:
 - root-relative id generation
 - stale PID cleanup
 - existing process reuse
+- last-activity tracking
+- idle runtime reaping
+- skipping idle reaping while a proxied session is active
 - free-port selection
 - stop semantics
 - REST status envelopes

--- a/packages/client/shared/codori.ts
+++ b/packages/client/shared/codori.ts
@@ -7,6 +7,10 @@ export type ProjectRecord = {
   pid: number | null
   port: number | null
   startedAt: number | null
+  lastActivityAt: number | null
+  activeSessionCount: number
+  idleTimeoutMs: number | null
+  idleDeadlineAt: number | null
   error: string | null
 }
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -8,10 +8,13 @@ export const DEFAULT_SERVER_HOST = '127.0.0.1'
 export const DEFAULT_SERVER_PORT = 4310
 const DEFAULT_PORT_START = 46000
 const DEFAULT_PORT_END = 46999
+const DEFAULT_IDLE_TIMEOUT_MS = 30 * 60 * 1000
+const DEFAULT_IDLE_SWEEP_INTERVAL_MS = 60 * 1000
 
 type PartialConfig = Partial<CodoriConfig> & {
   server?: Partial<CodoriConfig['server']>
   ports?: Partial<CodoriConfig['ports']>
+  idleShutdown?: Partial<CodoriConfig['idleShutdown']>
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -64,6 +67,22 @@ const ensureValidPort = (value: unknown, label: string): number => {
   return value
 }
 
+const ensureValidDurationMs = (value: unknown, label: string): number => {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+    throw new CodoriError('INVALID_CONFIG', `${label} must be a positive integer in milliseconds.`)
+  }
+
+  return value
+}
+
+const ensureValidBoolean = (value: unknown, label: string): boolean => {
+  if (typeof value !== 'boolean') {
+    throw new CodoriError('INVALID_CONFIG', `${label} must be a boolean.`)
+  }
+
+  return value
+}
+
 export const resolveConfig = (
   overrides: ConfigOverrides = {},
   homeDir = os.homedir()
@@ -91,6 +110,21 @@ export const resolveConfig = (
   const resolvedPort = ensureValidPort(port, 'server.port')
   const resolvedPortStart = ensureValidPort(portStart, 'ports.start')
   const resolvedPortEnd = ensureValidPort(portEnd, 'ports.end')
+  const idleShutdownEnabled = overrides.idleShutdownEnabled
+    ?? (fileConfig.idleShutdown?.enabled === undefined
+      ? undefined
+      : ensureValidBoolean(fileConfig.idleShutdown.enabled, 'idleShutdown.enabled'))
+    ?? true
+  const idleShutdownTimeoutMs = overrides.idleShutdownTimeoutMs
+    ?? (fileConfig.idleShutdown?.timeoutMs === undefined
+      ? undefined
+      : ensureValidDurationMs(fileConfig.idleShutdown.timeoutMs, 'idleShutdown.timeoutMs'))
+    ?? DEFAULT_IDLE_TIMEOUT_MS
+  const idleShutdownSweepIntervalMs = overrides.idleShutdownSweepIntervalMs
+    ?? (fileConfig.idleShutdown?.sweepIntervalMs === undefined
+      ? undefined
+      : ensureValidDurationMs(fileConfig.idleShutdown.sweepIntervalMs, 'idleShutdown.sweepIntervalMs'))
+    ?? DEFAULT_IDLE_SWEEP_INTERVAL_MS
 
   if (resolvedPortStart > resolvedPortEnd) {
     throw new CodoriError('INVALID_CONFIG', 'ports.start must be less than or equal to ports.end.')
@@ -107,6 +141,11 @@ export const resolveConfig = (
     ports: {
       start: resolvedPortStart,
       end: resolvedPortEnd
+    },
+    idleShutdown: {
+      enabled: idleShutdownEnabled,
+      timeoutMs: idleShutdownTimeoutMs,
+      sweepIntervalMs: idleShutdownSweepIntervalMs
     }
   }
 }

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -110,21 +110,20 @@ export const resolveConfig = (
   const resolvedPort = ensureValidPort(port, 'server.port')
   const resolvedPortStart = ensureValidPort(portStart, 'ports.start')
   const resolvedPortEnd = ensureValidPort(portEnd, 'ports.end')
-  const idleShutdownEnabled = overrides.idleShutdownEnabled
-    ?? (fileConfig.idleShutdown?.enabled === undefined
-      ? undefined
-      : ensureValidBoolean(fileConfig.idleShutdown.enabled, 'idleShutdown.enabled'))
-    ?? true
-  const idleShutdownTimeoutMs = overrides.idleShutdownTimeoutMs
-    ?? (fileConfig.idleShutdown?.timeoutMs === undefined
-      ? undefined
-      : ensureValidDurationMs(fileConfig.idleShutdown.timeoutMs, 'idleShutdown.timeoutMs'))
-    ?? DEFAULT_IDLE_TIMEOUT_MS
-  const idleShutdownSweepIntervalMs = overrides.idleShutdownSweepIntervalMs
-    ?? (fileConfig.idleShutdown?.sweepIntervalMs === undefined
-      ? undefined
-      : ensureValidDurationMs(fileConfig.idleShutdown.sweepIntervalMs, 'idleShutdown.sweepIntervalMs'))
-    ?? DEFAULT_IDLE_SWEEP_INTERVAL_MS
+  const idleShutdownEnabled = ensureValidBoolean(
+    overrides.idleShutdownEnabled ?? fileConfig.idleShutdown?.enabled ?? true,
+    'idleShutdown.enabled'
+  )
+  const idleShutdownTimeoutMs = ensureValidDurationMs(
+    overrides.idleShutdownTimeoutMs ?? fileConfig.idleShutdown?.timeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS,
+    'idleShutdown.timeoutMs'
+  )
+  const idleShutdownSweepIntervalMs = ensureValidDurationMs(
+    overrides.idleShutdownSweepIntervalMs
+      ?? fileConfig.idleShutdown?.sweepIntervalMs
+      ?? DEFAULT_IDLE_SWEEP_INTERVAL_MS,
+    'idleShutdown.sweepIntervalMs'
+  )
 
   if (resolvedPortStart > resolvedPortEnd) {
     throw new CodoriError('INVALID_CONFIG', 'ports.start must be less than or equal to ports.end.')

--- a/packages/server/src/http-server.ts
+++ b/packages/server/src/http-server.ts
@@ -37,7 +37,10 @@ export type RuntimeManagerLike = {
   startProject: (projectId: string) => MaybePromise<StartProjectResult>
   stopProject: (projectId: string) => MaybePromise<ProjectStatusRecord>
   noteProjectActivity?: (projectId: string) => MaybePromise<ProjectStatusRecord | void>
-  acquireProjectSession?: (projectId: string) => { release: () => void }
+  acquireProjectSession?: (projectId: string) => {
+    touchActivity?: (at?: number) => MaybePromise<ProjectStatusRecord | void>
+    release: () => void
+  }
   dispose?: () => MaybePromise<void>
   config?: {
     server: {
@@ -148,6 +151,18 @@ const touchProjectActivity = async (manager: RuntimeManagerLike, projectId: stri
   }
 
   await resolveValue(manager.noteProjectActivity(projectId))
+}
+
+const touchProjectActivityInBackground = (
+  manager: RuntimeManagerLike,
+  projectId: string,
+  session?: { touchActivity?: (at?: number) => MaybePromise<ProjectStatusRecord | void> } | null
+) => {
+  const task = session?.touchActivity
+    ? resolveValue(session.touchActivity())
+    : touchProjectActivity(manager, projectId)
+
+  void task.catch(() => {})
 }
 
 const wait = async (ms: number) =>
@@ -473,7 +488,7 @@ export const createHttpServer = async (
       }
 
       clientSocket.on('message', (message: WebSocket.RawData, isBinary: boolean) => {
-        void touchProjectActivity(manager, projectId)
+        touchProjectActivityInBackground(manager, projectId, session)
         if (upstream?.readyState === WebSocket.OPEN) {
           upstream.send(message, { binary: isBinary })
           return
@@ -515,7 +530,7 @@ export const createHttpServer = async (
         })
 
         upstream.on('message', (message: WebSocket.RawData, isBinary: boolean) => {
-          void touchProjectActivity(manager, projectId)
+          touchProjectActivityInBackground(manager, projectId, session)
           clientSocket.send(message, { binary: isBinary })
         })
 

--- a/packages/server/src/http-server.ts
+++ b/packages/server/src/http-server.ts
@@ -36,6 +36,9 @@ export type RuntimeManagerLike = {
   getProjectStatus: (projectId: string) => MaybePromise<ProjectStatusRecord>
   startProject: (projectId: string) => MaybePromise<StartProjectResult>
   stopProject: (projectId: string) => MaybePromise<ProjectStatusRecord>
+  noteProjectActivity?: (projectId: string) => MaybePromise<ProjectStatusRecord | void>
+  acquireProjectSession?: (projectId: string) => { release: () => void }
+  dispose?: () => MaybePromise<void>
   config?: {
     server: {
       host: string
@@ -139,6 +142,14 @@ const normalizeImageMediaType = (input: { filename: string, declaredMediaType: s
   return null
 }
 
+const touchProjectActivity = async (manager: RuntimeManagerLike, projectId: string) => {
+  if (!manager.noteProjectActivity) {
+    return
+  }
+
+  await resolveValue(manager.noteProjectActivity(projectId))
+}
+
 const wait = async (ms: number) =>
   new Promise<void>((resolvePromise) => {
     setTimeout(resolvePromise, ms)
@@ -185,6 +196,10 @@ export const createHttpServer = async (
 ): Promise<FastifyInstance> => {
   const app = Fastify({
     logger: false
+  })
+
+  app.addHook('onClose', async () => {
+    await resolveValue(manager.dispose?.())
   })
   const clientBundleDir = options.clientBundleDir === undefined
     ? resolveBundledClientDir()
@@ -299,6 +314,7 @@ export const createHttpServer = async (
     async (request, reply) => {
       const projectId = getProjectIdFromRequest(request.params.projectId)
       const project = await resolveValue(manager.getProjectStatus(projectId))
+      await touchProjectActivity(manager, projectId)
       const files: PersistedAttachment[] = []
       let threadId: string | null = null
 
@@ -364,6 +380,7 @@ export const createHttpServer = async (
       }
 
       const project = await resolveValue(manager.getProjectStatus(projectId))
+      await touchProjectActivity(manager, projectId)
       const allowedRoot = resolveProjectAttachmentsDir(project.projectPath, options.attachmentsRootDir)
       const resolvedPath = resolve(requestedPath)
 
@@ -433,7 +450,18 @@ export const createHttpServer = async (
     async (clientSocket: WebSocket, request: FastifyRequest<{ Params: { projectId: string } }>) => {
       const projectId = getProjectIdFromRequest(request.params.projectId)
       const pendingClientMessages: Array<{ message: WebSocket.RawData, isBinary: boolean }> = []
+      const session = manager.acquireProjectSession?.(projectId) ?? null
       let upstream: WebSocket | null = null
+      let sessionReleased = false
+
+      const releaseSession = () => {
+        if (sessionReleased) {
+          return
+        }
+
+        sessionReleased = true
+        session?.release()
+      }
 
       const closeBoth = (code = 1011, reason = 'proxy error') => {
         if (clientSocket.readyState === clientSocket.OPEN || clientSocket.readyState === clientSocket.CONNECTING) {
@@ -445,6 +473,7 @@ export const createHttpServer = async (
       }
 
       clientSocket.on('message', (message: WebSocket.RawData, isBinary: boolean) => {
+        void touchProjectActivity(manager, projectId)
         if (upstream?.readyState === WebSocket.OPEN) {
           upstream.send(message, { binary: isBinary })
           return
@@ -458,6 +487,7 @@ export const createHttpServer = async (
       })
 
       clientSocket.on('close', () => {
+        releaseSession()
         if (upstream && (upstream.readyState === WebSocket.OPEN || upstream.readyState === WebSocket.CONNECTING)) {
           upstream.close()
         }
@@ -485,6 +515,7 @@ export const createHttpServer = async (
         })
 
         upstream.on('message', (message: WebSocket.RawData, isBinary: boolean) => {
+          void touchProjectActivity(manager, projectId)
           clientSocket.send(message, { binary: isBinary })
         })
 

--- a/packages/server/src/process-manager.ts
+++ b/packages/server/src/process-manager.ts
@@ -20,6 +20,7 @@ type CommandFactory = (port: number, project: ProjectRecord) => {
 }
 
 type ProjectSessionLease = {
+  touchActivity: (at?: number) => ProjectStatusRecord
   release: () => void
 }
 
@@ -210,8 +211,7 @@ export class RuntimeManager {
     return this.normalizeStatus(project, loaded.record, null)
   }
 
-  noteProjectActivity(projectId: string, at = Date.now()) {
-    const project = this.resolveProject(projectId)
+  private touchProjectRuntime(project: ProjectRecord, at = Date.now()) {
     const runtime = this.loadActiveRuntime(project)
     if (!runtime) {
       return this.normalizeStatus(project, null, null)
@@ -220,13 +220,18 @@ export class RuntimeManager {
     return this.normalizeStatus(project, this.touchRuntimeRecord(runtime, at), null)
   }
 
+  noteProjectActivity(projectId: string, at = Date.now()) {
+    return this.touchProjectRuntime(this.resolveProject(projectId), at)
+  }
+
   acquireProjectSession(projectId: string): ProjectSessionLease {
     const project = this.resolveProject(projectId)
     this.incrementActiveSessions(project.id)
-    this.noteProjectActivity(project.id)
+    this.touchProjectRuntime(project)
 
     let released = false
     return {
+      touchActivity: (at = Date.now()) => this.touchProjectRuntime(project, at),
       release: () => {
         if (released) {
           return

--- a/packages/server/src/process-manager.ts
+++ b/packages/server/src/process-manager.ts
@@ -19,6 +19,10 @@ type CommandFactory = (port: number, project: ProjectRecord) => {
   args: string[]
 }
 
+type ProjectSessionLease = {
+  release: () => void
+}
+
 type RuntimeManagerOptions = {
   homeDir?: string
   configOverrides?: ConfigOverrides
@@ -82,10 +86,23 @@ export class RuntimeManager {
 
   private readonly commandFactory: CommandFactory
 
+  private readonly activeSessions = new Map<string, number>()
+
+  private idleReaper: NodeJS.Timeout | null = null
+
+  private idleSweepInFlight = false
+
   constructor(options: RuntimeManagerOptions = {}) {
     this.config = options.config ?? resolveConfig(options.configOverrides, options.homeDir)
     this.store = new RuntimeStore(options.homeDir)
     this.commandFactory = options.commandFactory ?? defaultCommandFactory
+
+    if (this.config.idleShutdown.enabled) {
+      this.idleReaper = setInterval(() => {
+        void this.reapIdleRuntimes()
+      }, this.config.idleShutdown.sweepIntervalMs)
+      this.idleReaper.unref?.()
+    }
   }
 
   listProjects() {
@@ -101,6 +118,7 @@ export class RuntimeManager {
   }
 
   private normalizeStatus(project: ProjectRecord, runtime: RuntimeRecord | null, error: string | null): ProjectStatusRecord {
+    const activeSessionCount = this.getActiveSessionCount(project.id)
     return {
       projectId: project.id,
       projectPath: project.path,
@@ -108,8 +126,70 @@ export class RuntimeManager {
       pid: runtime?.pid ?? null,
       port: runtime?.port ?? null,
       startedAt: runtime?.startedAt ?? null,
+      lastActivityAt: runtime?.lastActivityAt ?? null,
+      activeSessionCount,
+      idleTimeoutMs: this.config.idleShutdown.enabled ? this.config.idleShutdown.timeoutMs : null,
+      idleDeadlineAt: this.resolveIdleDeadline(runtime, activeSessionCount),
       error
     }
+  }
+
+  private getActiveSessionCount(projectId: string) {
+    return this.activeSessions.get(projectId) ?? 0
+  }
+
+  private resolveIdleDeadline(runtime: RuntimeRecord | null, activeSessionCount: number) {
+    if (!runtime || !this.config.idleShutdown.enabled || activeSessionCount > 0) {
+      return null
+    }
+
+    return runtime.lastActivityAt + this.config.idleShutdown.timeoutMs
+  }
+
+  private writeRuntime(record: RuntimeRecord) {
+    this.store.write(record)
+    return record
+  }
+
+  private touchRuntimeRecord(record: RuntimeRecord, at = Date.now()) {
+    return this.writeRuntime({
+      ...record,
+      lastActivityAt: Math.max(record.lastActivityAt, at)
+    })
+  }
+
+  private incrementActiveSessions(projectId: string) {
+    this.activeSessions.set(projectId, this.getActiveSessionCount(projectId) + 1)
+  }
+
+  private decrementActiveSessions(projectId: string) {
+    const next = this.getActiveSessionCount(projectId) - 1
+    if (next > 0) {
+      this.activeSessions.set(projectId, next)
+      return
+    }
+
+    this.activeSessions.delete(projectId)
+  }
+
+  private loadActiveRuntime(project: ProjectRecord) {
+    const loaded = this.store.load(project.path)
+
+    if (loaded.kind === 'missing') {
+      return null
+    }
+
+    if (loaded.kind === 'invalid') {
+      this.store.remove(project.path)
+      return null
+    }
+
+    if (!isProcessAlive(loaded.record.pid)) {
+      this.store.remove(project.path)
+      return null
+    }
+
+    return loaded.record
   }
 
   private readRunningRuntime(project: ProjectRecord) {
@@ -130,6 +210,34 @@ export class RuntimeManager {
     return this.normalizeStatus(project, loaded.record, null)
   }
 
+  noteProjectActivity(projectId: string, at = Date.now()) {
+    const project = this.resolveProject(projectId)
+    const runtime = this.loadActiveRuntime(project)
+    if (!runtime) {
+      return this.normalizeStatus(project, null, null)
+    }
+
+    return this.normalizeStatus(project, this.touchRuntimeRecord(runtime, at), null)
+  }
+
+  acquireProjectSession(projectId: string): ProjectSessionLease {
+    const project = this.resolveProject(projectId)
+    this.incrementActiveSessions(project.id)
+    this.noteProjectActivity(project.id)
+
+    let released = false
+    return {
+      release: () => {
+        if (released) {
+          return
+        }
+
+        released = true
+        this.decrementActiveSessions(project.id)
+      }
+    }
+  }
+
   listProjectStatuses() {
     return this.listProjects().map(project => this.readRunningRuntime(project))
   }
@@ -143,8 +251,9 @@ export class RuntimeManager {
     const loaded = this.store.load(project.path)
 
     if (loaded.kind === 'valid' && isProcessAlive(loaded.record.pid)) {
+      const runtime = this.touchRuntimeRecord(loaded.record)
       return {
-        ...this.normalizeStatus(project, loaded.record, null),
+        ...this.normalizeStatus(project, runtime, null),
         reusedExisting: true
       }
     }
@@ -161,14 +270,16 @@ export class RuntimeManager {
       throw new CodoriError('PROCESS_START_FAILED', `Failed to determine PID for project "${projectId}".`)
     }
 
+    const now = Date.now()
     const runtime: RuntimeRecord = {
       projectId: project.id,
       projectPath: project.path,
       pid: child.pid,
       port,
-      startedAt: Date.now()
+      startedAt: now,
+      lastActivityAt: now
     }
-    this.store.write(runtime)
+    this.writeRuntime(runtime)
 
     return {
       ...this.normalizeStatus(project, runtime, null),
@@ -200,6 +311,49 @@ export class RuntimeManager {
 
     this.store.remove(project.path)
     return this.normalizeStatus(project, null, null)
+  }
+
+  async reapIdleRuntimes() {
+    if (!this.config.idleShutdown.enabled || this.idleSweepInFlight) {
+      return 0
+    }
+
+    this.idleSweepInFlight = true
+    let stopped = 0
+
+    try {
+      const now = Date.now()
+      for (const project of this.listProjects()) {
+        const runtime = this.loadActiveRuntime(project)
+        if (!runtime) {
+          continue
+        }
+
+        if (this.getActiveSessionCount(project.id) > 0) {
+          continue
+        }
+
+        if (now - runtime.lastActivityAt < this.config.idleShutdown.timeoutMs) {
+          continue
+        }
+
+        await this.stopProject(project.id)
+        stopped += 1
+      }
+
+      return stopped
+    } finally {
+      this.idleSweepInFlight = false
+    }
+  }
+
+  dispose() {
+    if (!this.idleReaper) {
+      return
+    }
+
+    clearInterval(this.idleReaper)
+    this.idleReaper = null
   }
 }
 

--- a/packages/server/src/runtime-store.ts
+++ b/packages/server/src/runtime-store.ts
@@ -13,7 +13,7 @@ const normalizeRuntimeRecord = (value: unknown): RuntimeRecord | null => {
     return null
   }
 
-  const { projectId, projectPath, pid, port, startedAt } = value
+  const { projectId, projectPath, pid, port, startedAt, lastActivityAt } = value
   if (
     typeof projectId !== 'string'
     || typeof projectPath !== 'string'
@@ -22,6 +22,7 @@ const normalizeRuntimeRecord = (value: unknown): RuntimeRecord | null => {
     || typeof port !== 'number'
     || !Number.isInteger(port)
     || typeof startedAt !== 'number'
+    || (lastActivityAt !== undefined && typeof lastActivityAt !== 'number')
   ) {
     return null
   }
@@ -31,7 +32,8 @@ const normalizeRuntimeRecord = (value: unknown): RuntimeRecord | null => {
     projectPath,
     pid,
     port,
-    startedAt
+    startedAt,
+    lastActivityAt: typeof lastActivityAt === 'number' ? lastActivityAt : startedAt
   }
 }
 

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -8,12 +8,20 @@ export type CodoriConfig = {
     start: number
     end: number
   }
+  idleShutdown: {
+    enabled: boolean
+    timeoutMs: number
+    sweepIntervalMs: number
+  }
 }
 
 export type ConfigOverrides = {
   root?: string
   host?: string
   port?: number
+  idleShutdownEnabled?: boolean
+  idleShutdownTimeoutMs?: number
+  idleShutdownSweepIntervalMs?: number
 }
 
 export type ProjectRecord = {
@@ -27,6 +35,7 @@ export type RuntimeRecord = {
   pid: number
   port: number
   startedAt: number
+  lastActivityAt: number
 }
 
 export type ProjectRuntimeStatus = 'running' | 'stopped' | 'error'
@@ -38,10 +47,13 @@ export type ProjectStatusRecord = {
   pid: number | null
   port: number | null
   startedAt: number | null
+  lastActivityAt: number | null
+  activeSessionCount: number
+  idleTimeoutMs: number | null
+  idleDeadlineAt: number | null
   error: string | null
 }
 
 export type StartProjectResult = ProjectStatusRecord & {
   reusedExisting: boolean
 }
-

--- a/packages/server/test/config.test.ts
+++ b/packages/server/test/config.test.ts
@@ -102,4 +102,17 @@ describe('resolveConfig', () => {
       sweepIntervalMs: 15_000
     })
   })
+
+  it('validates idle shutdown overrides the same way as file config', () => {
+    const homeDir = createHome()
+
+    expect(() => resolveConfig({
+      root: '/tmp/from-cli',
+      idleShutdownTimeoutMs: 0 as number
+    }, homeDir)).toThrow(/idleShutdown\.timeoutMs/)
+    expect(() => resolveConfig({
+      root: '/tmp/from-cli',
+      idleShutdownEnabled: 'yes' as unknown as boolean
+    }, homeDir)).toThrow(/idleShutdown\.enabled/)
+  })
 })

--- a/packages/server/test/config.test.ts
+++ b/packages/server/test/config.test.ts
@@ -26,6 +26,11 @@ describe('resolveConfig', () => {
 
     expect(config.server.host).toBe('127.0.0.1')
     expect(config.server.port).toBe(4310)
+    expect(config.idleShutdown).toEqual({
+      enabled: true,
+      timeoutMs: 30 * 60 * 1000,
+      sweepIntervalMs: 60 * 1000
+    })
   })
 
   it('uses overrides ahead of file config', () => {
@@ -48,5 +53,53 @@ describe('resolveConfig', () => {
     expect(config.root).toBe('/tmp/from-cli')
     expect(config.server.host).toBe('127.0.0.1')
     expect(config.server.port).toBe(4100)
+  })
+
+  it('reads idle shutdown configuration from the user config file', () => {
+    const homeDir = createHome()
+    const codoriDir = join(homeDir, '.codori')
+    mkdirSync(codoriDir, { recursive: true })
+    writeFileSync(join(codoriDir, 'config.json'), JSON.stringify({
+      root: '/tmp/from-file',
+      idleShutdown: {
+        enabled: false,
+        timeoutMs: 5_000,
+        sweepIntervalMs: 2_000
+      }
+    }))
+
+    const config = resolveConfig({}, homeDir)
+
+    expect(config.idleShutdown).toEqual({
+      enabled: false,
+      timeoutMs: 5_000,
+      sweepIntervalMs: 2_000
+    })
+  })
+
+  it('lets cli overrides replace idle shutdown config values', () => {
+    const homeDir = createHome()
+    const codoriDir = join(homeDir, '.codori')
+    mkdirSync(codoriDir, { recursive: true })
+    writeFileSync(join(codoriDir, 'config.json'), JSON.stringify({
+      root: '/tmp/from-file',
+      idleShutdown: {
+        enabled: true,
+        timeoutMs: 10_000,
+        sweepIntervalMs: 5_000
+      }
+    }))
+
+    const config = resolveConfig({
+      idleShutdownEnabled: false,
+      idleShutdownTimeoutMs: 45_000,
+      idleShutdownSweepIntervalMs: 15_000
+    }, homeDir)
+
+    expect(config.idleShutdown).toEqual({
+      enabled: false,
+      timeoutMs: 45_000,
+      sweepIntervalMs: 15_000
+    })
   })
 })

--- a/packages/server/test/http-server.test.ts
+++ b/packages/server/test/http-server.test.ts
@@ -79,6 +79,10 @@ const createManager = (overrides: Partial<RuntimeManagerLike> = {}): RuntimeMana
     lastActivityAt: null,
     idleDeadlineAt: null
   }),
+  noteProjectActivity: () => {},
+  acquireProjectSession: () => ({
+    release: () => {}
+  }),
   ...overrides
 })
 
@@ -306,6 +310,98 @@ describe('createHttpServer', () => {
           reject(error instanceof Error ? error : new Error(String(error)))
         } finally {
           client.close()
+        }
+      })
+      client.once('error', reject)
+    })
+  })
+
+  it('marks websocket sessions active while the proxy is connected', async () => {
+    const tcpServer = createNetServer()
+    await new Promise<void>((resolvePromise, reject) => {
+      tcpServer.listen(0, '127.0.0.1', (error?: Error) => {
+        if (error) {
+          reject(error)
+          return
+        }
+        resolvePromise()
+      })
+    })
+    const address = tcpServer.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Failed to get test server address.')
+    }
+    const backendPort = address.port
+    await new Promise<void>((resolvePromise, reject) => {
+      tcpServer.close((error) => {
+        if (error) {
+          reject(error)
+          return
+        }
+        resolvePromise()
+      })
+    })
+
+    const backend = new WebSocketServer({
+      host: '127.0.0.1',
+      port: backendPort
+    })
+    startedSocketServers.push(backend)
+    await new Promise<void>((resolvePromise) => {
+      backend.once('listening', () => {
+        resolvePromise()
+      })
+    })
+    backend.on('connection', (socket: WebSocket) => {
+      socket.on('message', (message: WebSocket.RawData) => {
+        socket.send(rawDataToString(message))
+      })
+    })
+
+    const events: string[] = []
+    const manager = createManager({
+      startProject: () => ({
+        ...createProjectRecord(),
+        port: backendPort,
+        reusedExisting: true
+      } satisfies StartProjectResult),
+      noteProjectActivity: () => {
+        events.push('touch')
+      },
+      acquireProjectSession: () => {
+        events.push('acquire')
+        return {
+          release: () => {
+            events.push('release')
+          }
+        }
+      }
+    })
+    const app = await createHttpServer(manager)
+    startedApps.push(app)
+    await app.listen({
+      host: '127.0.0.1',
+      port: 0
+    })
+
+    const serverAddress = app.addresses()[0]
+    const client = new WebSocket(`ws://127.0.0.1:${serverAddress.port}/api/projects/demo/rpc`)
+
+    await new Promise<void>((resolvePromise, reject) => {
+      client.once('open', () => {
+        client.send('ping')
+      })
+      client.once('message', () => {
+        client.close()
+      })
+      client.once('close', () => {
+        try {
+          expect(events[0]).toBe('acquire')
+          expect(events).toContain('touch')
+          expect(events.at(-1)).toBe('release')
+          resolvePromise()
+        } catch (error) {
+          reject(error instanceof Error ? error : new Error(String(error)))
         }
       })
       client.once('error', reject)

--- a/packages/server/test/http-server.test.ts
+++ b/packages/server/test/http-server.test.ts
@@ -56,6 +56,10 @@ const createProjectRecord = (): ProjectStatusRecord => ({
   pid: 123,
   port: 46000,
   startedAt: 1,
+  lastActivityAt: 1,
+  activeSessionCount: 0,
+  idleTimeoutMs: 30 * 60 * 1000,
+  idleDeadlineAt: 30 * 60 * 1000 + 1,
   error: null
 })
 
@@ -71,7 +75,9 @@ const createManager = (overrides: Partial<RuntimeManagerLike> = {}): RuntimeMana
     status: 'stopped',
     pid: null,
     port: null,
-    startedAt: null
+    startedAt: null,
+    lastActivityAt: null,
+    idleDeadlineAt: null
   }),
   ...overrides
 })

--- a/packages/server/test/http-server.test.ts
+++ b/packages/server/test/http-server.test.ts
@@ -81,6 +81,7 @@ const createManager = (overrides: Partial<RuntimeManagerLike> = {}): RuntimeMana
   }),
   noteProjectActivity: () => {},
   acquireProjectSession: () => ({
+    touchActivity: () => {},
     release: () => {}
   }),
   ...overrides
@@ -365,16 +366,19 @@ describe('createHttpServer', () => {
         port: backendPort,
         reusedExisting: true
       } satisfies StartProjectResult),
-      noteProjectActivity: () => {
-        events.push('touch')
-      },
       acquireProjectSession: () => {
         events.push('acquire')
         return {
+          touchActivity: () => {
+            events.push('touch')
+          },
           release: () => {
             events.push('release')
           }
         }
+      },
+      noteProjectActivity: () => {
+        throw new Error('websocket activity should use the cached session context')
       }
     })
     const app = await createHttpServer(manager)
@@ -402,6 +406,89 @@ describe('createHttpServer', () => {
           resolvePromise()
         } catch (error) {
           reject(error instanceof Error ? error : new Error(String(error)))
+        }
+      })
+      client.once('error', reject)
+    })
+  })
+
+  it('swallows rejected background activity updates in websocket handlers', async () => {
+    const tcpServer = createNetServer()
+    await new Promise<void>((resolvePromise, reject) => {
+      tcpServer.listen(0, '127.0.0.1', (error?: Error) => {
+        if (error) {
+          reject(error)
+          return
+        }
+        resolvePromise()
+      })
+    })
+    const address = tcpServer.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Failed to get test server address.')
+    }
+    const backendPort = address.port
+    await new Promise<void>((resolvePromise, reject) => {
+      tcpServer.close((error) => {
+        if (error) {
+          reject(error)
+          return
+        }
+        resolvePromise()
+      })
+    })
+
+    const backend = new WebSocketServer({
+      host: '127.0.0.1',
+      port: backendPort
+    })
+    startedSocketServers.push(backend)
+    await new Promise<void>((resolvePromise) => {
+      backend.once('listening', () => {
+        resolvePromise()
+      })
+    })
+    backend.on('connection', (socket: WebSocket) => {
+      socket.on('message', (message: WebSocket.RawData) => {
+        socket.send(rawDataToString(message).toUpperCase())
+      })
+    })
+
+    const manager = createManager({
+      startProject: () => ({
+        ...createProjectRecord(),
+        port: backendPort,
+        reusedExisting: true
+      } satisfies StartProjectResult),
+      acquireProjectSession: () => ({
+        touchActivity: async () => {
+          throw new Error('disk write failed')
+        },
+        release: () => {}
+      })
+    })
+    const app = await createHttpServer(manager)
+    startedApps.push(app)
+    await app.listen({
+      host: '127.0.0.1',
+      port: 0
+    })
+
+    const serverAddress = app.addresses()[0]
+    const client = new WebSocket(`ws://127.0.0.1:${serverAddress.port}/api/projects/demo/rpc`)
+
+    await new Promise<void>((resolvePromise, reject) => {
+      client.once('open', () => {
+        client.send('ping')
+      })
+      client.once('message', (data: WebSocket.RawData) => {
+        try {
+          expect(rawDataToString(data)).toBe('PING')
+          resolvePromise()
+        } catch (error) {
+          reject(error instanceof Error ? error : new Error(String(error)))
+        } finally {
+          client.close()
         }
       })
       client.once('error', reject)

--- a/packages/server/test/runtime-manager.test.ts
+++ b/packages/server/test/runtime-manager.test.ts
@@ -119,7 +119,8 @@ describe('RuntimeManager', () => {
       projectPath: join(fixture.root, 'demo'),
       pid: 999999,
       port: 46000,
-      startedAt: Date.now()
+      startedAt: Date.now(),
+      lastActivityAt: Date.now()
     })
 
     const manager = createRuntimeManager({

--- a/packages/server/test/runtime-manager.test.ts
+++ b/packages/server/test/runtime-manager.test.ts
@@ -15,6 +15,7 @@ afterEach(async () => {
     for (const project of manager.listProjects()) {
       await manager.stopProject(project.id)
     }
+    manager.dispose()
   }
 
   for (const server of occupiedServers.splice(0, occupiedServers.length)) {
@@ -163,5 +164,90 @@ describe('RuntimeManager', () => {
 
     const started = await manager.startProject('demo')
     expect(started.port).toBe(startPort + 1)
+  })
+
+  it('tracks runtime activity and reaps only idle runtimes without active sessions', async () => {
+    const fixture = createFixture()
+    const manager = createRuntimeManager({
+      homeDir: fixture.homeDir,
+      config: {
+        ...fixture.config,
+        idleShutdown: {
+          enabled: true,
+          timeoutMs: 50,
+          sweepIntervalMs: 10_000
+        }
+      },
+      commandFactory: () => ({
+        command: process.execPath,
+        args: ['-e', 'setInterval(() => {}, 1000)']
+      })
+    })
+    runningManagers.push(manager)
+
+    const started = await manager.startProject('demo')
+    expect(started.lastActivityAt).not.toBeNull()
+
+    const store = new RuntimeStore(fixture.homeDir)
+    const loaded = store.load(join(fixture.root, 'demo'))
+    expect(loaded.kind).toBe('valid')
+    if (loaded.kind !== 'valid') {
+      throw new Error('Expected a valid runtime record.')
+    }
+
+    const session = manager.acquireProjectSession('demo')
+    const refreshed = store.load(join(fixture.root, 'demo'))
+    expect(refreshed.kind).toBe('valid')
+    if (refreshed.kind !== 'valid') {
+      throw new Error('Expected a refreshed runtime record.')
+    }
+
+    store.write({
+      ...refreshed.record,
+      lastActivityAt: Date.now() - 5_000
+    })
+
+    const skipped = await manager.reapIdleRuntimes()
+    expect(skipped).toBe(0)
+    expect(manager.getProjectStatus('demo').status).toBe('running')
+
+    session.release()
+    const reaped = await manager.reapIdleRuntimes()
+    expect(reaped).toBe(1)
+    expect(manager.getProjectStatus('demo').status).toBe('stopped')
+  })
+
+  it('updates the last activity timestamp when project activity is noted', async () => {
+    const fixture = createFixture()
+    const manager = createRuntimeManager({
+      homeDir: fixture.homeDir,
+      config: fixture.config,
+      commandFactory: () => ({
+        command: process.execPath,
+        args: ['-e', 'setInterval(() => {}, 1000)']
+      })
+    })
+    runningManagers.push(manager)
+
+    await manager.startProject('demo')
+    const store = new RuntimeStore(fixture.homeDir)
+    const loaded = store.load(join(fixture.root, 'demo'))
+    expect(loaded.kind).toBe('valid')
+    if (loaded.kind !== 'valid') {
+      throw new Error('Expected a valid runtime record.')
+    }
+
+    store.write({
+      ...loaded.record,
+      lastActivityAt: loaded.record.startedAt - 1_000
+    })
+
+    const touched = manager.noteProjectActivity('demo')
+    expect(touched.lastActivityAt).toBeGreaterThan(loaded.record.startedAt - 1_000)
+    expect(touched.idleDeadlineAt).toBe(
+      touched.lastActivityAt === null
+        ? null
+        : touched.lastActivityAt + fixture.config.idleShutdown.timeoutMs
+    )
   })
 })


### PR DESCRIPTION
## Summary
- add persisted runtime activity metadata and idle-shutdown configuration for project app-servers
- reap only truly idle runtimes while protecting active proxied WebSocket sessions from shutdown
- document the new idle lifecycle behavior and configuration surface

## Why
Codori reused project app-servers indefinitely once started, which allowed unused runtimes to accumulate across many repositories. This change closes that lifecycle gap without changing the user workflow: idle runtimes stop automatically, and the next interaction transparently starts them again.

## Impact
- runtime status is more explicit and debuggable because it now includes `lastActivityAt`, `activeSessionCount`, and `idleDeadlineAt`
- operators can enable, disable, or tune idle shutdown through `~/.codori/config.json`
- active chats and proxied RPC sessions are protected from being reaped mid-use

## Validation
- `pnpm typecheck`
- `pnpm test`
