### PR TITLE
fix: correct context usage indicator behavior

### DIFF
--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -57,6 +57,7 @@ import {
   normalizeThreadTokenUsage,
   resolveContextWindowState,
   resolveEffortOptions,
+  shouldShowContextWindowIndicator,
   visibleModelOptions,
   type ReasoningEffort
 } from '~~/shared/chat-prompt-controls'
@@ -174,7 +175,6 @@ const starterPrompts = computed(() => {
   ]
 })
 
-const hasKnownThreadUsage = computed(() => !activeThreadId.value || tokenUsage.value !== null)
 const effectiveModelList = computed(() => {
   const withSelected = ensureModelOption(
     availableModels.value.length > 0 ? availableModels.value : FALLBACK_MODELS,
@@ -202,8 +202,9 @@ const effortSelectItems = computed(() =>
   }))
 )
 const contextWindowState = computed(() =>
-  resolveContextWindowState(tokenUsage.value, modelContextWindow.value, hasKnownThreadUsage.value)
+  resolveContextWindowState(tokenUsage.value, modelContextWindow.value)
 )
+const showContextIndicator = computed(() => shouldShowContextWindowIndicator(contextWindowState.value))
 const contextUsedPercent = computed(() => contextWindowState.value.usedPercent ?? 0)
 const contextIndicatorLabel = computed(() => {
   const remainingPercent = contextWindowState.value.remainingPercent
@@ -1695,6 +1696,7 @@ const sendMessage = async () => {
 
   try {
     const client = getClient(props.projectId)
+    tokenUsage.value = null
 
     if (submissionMethod === 'turn/steer') {
       const liveStream = await ensurePendingLiveStream()
@@ -2089,6 +2091,7 @@ watch([selectedModel, availableModels], () => {
 
                 <div class="ml-auto flex shrink-0 items-center">
                   <UPopover
+                    v-if="showContextIndicator"
                     :content="{ side: 'top', align: 'end' }"
                     arrow
                   >
@@ -2128,8 +2131,6 @@ watch([selectedModel, availableModels], () => {
                           {{ contextIndicatorLabel }}
                         </span>
                       </span>
-
-                      <span class="text-[11px] leading-none text-muted">context window</span>
                     </button>
 
                     <template #content>
@@ -2143,10 +2144,7 @@ watch([selectedModel, availableModels], () => {
                           </div>
                         </div>
 
-                        <div
-                          v-if="contextWindowState.contextWindow && contextWindowState.usedTokens !== null"
-                          class="grid grid-cols-2 gap-3 text-sm"
-                        >
+                        <div class="grid grid-cols-2 gap-3 text-sm">
                           <div class="rounded-2xl border border-default bg-elevated/35 px-3 py-2">
                             <div class="text-[11px] uppercase tracking-[0.18em] text-muted">
                               Remaining
@@ -2166,20 +2164,8 @@ watch([selectedModel, availableModels], () => {
                               {{ formatCompactTokenCount(contextWindowState.usedTokens ?? 0) }}
                             </div>
                             <div class="text-xs text-muted">
-                              of {{ formatCompactTokenCount(contextWindowState.contextWindow) }}
+                              of {{ formatCompactTokenCount(contextWindowState.contextWindow ?? 0) }}
                             </div>
-                          </div>
-                        </div>
-
-                        <div
-                          v-else
-                          class="rounded-2xl border border-default bg-elevated/35 px-3 py-2 text-sm text-muted"
-                        >
-                          <div v-if="contextWindowState.contextWindow">
-                            Live token usage will appear after the next turn completes.
-                          </div>
-                          <div v-else>
-                            Context window details are not available from the runtime yet.
                           </div>
                         </div>
 

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -1696,7 +1696,6 @@ const sendMessage = async () => {
 
   try {
     const client = getClient(props.projectId)
-    tokenUsage.value = null
 
     if (submissionMethod === 'turn/steer') {
       const liveStream = await ensurePendingLiveStream()
@@ -1710,6 +1709,7 @@ const sendMessage = async () => {
         input: buildTurnStartInput(text, uploadedAttachments),
         ...buildTurnOverrides(selectedModel.value, selectedEffort.value)
       })
+      tokenUsage.value = null
       return
     }
 
@@ -1727,6 +1727,7 @@ const sendMessage = async () => {
       ...buildTurnOverrides(selectedModel.value, selectedEffort.value)
     })
 
+    tokenUsage.value = null
     setLiveStreamTurnId(liveStream, turnStart.turn.id)
 
     for (const notification of liveStream.bufferedNotifications.splice(0, liveStream.bufferedNotifications.length)) {

--- a/packages/client/shared/chat-prompt-controls.ts
+++ b/packages/client/shared/chat-prompt-controls.ts
@@ -20,13 +20,23 @@ export type ModelOption = {
 }
 
 export type TokenUsageSnapshot = {
+  totalTokens: number | null
   totalInputTokens: number
   totalCachedInputTokens: number
   totalOutputTokens: number
+  lastTotalTokens: number | null
   lastInputTokens: number
   lastCachedInputTokens: number
   lastOutputTokens: number
   modelContextWindow: number | null
+}
+
+export type ContextWindowState = {
+  contextWindow: number | null
+  usedTokens: number | null
+  remainingTokens: number | null
+  usedPercent: number | null
+  remainingPercent: number | null
 }
 
 type ReasoningEffortOptionRecord = {
@@ -253,9 +263,11 @@ export const normalizeThreadTokenUsage = (value: unknown): TokenUsageSnapshot | 
   const last = isObjectRecord(tokenUsage.last) ? tokenUsage.last : {}
 
   return {
+    totalTokens: toFiniteNumber(total.totalTokens),
     totalInputTokens: toFiniteNumber(total.inputTokens) ?? 0,
     totalCachedInputTokens: toFiniteNumber(total.cachedInputTokens) ?? 0,
     totalOutputTokens: toFiniteNumber(total.outputTokens) ?? 0,
+    lastTotalTokens: toFiniteNumber(last.totalTokens),
     lastInputTokens: toFiniteNumber(last.inputTokens) ?? 0,
     lastCachedInputTokens: toFiniteNumber(last.cachedInputTokens) ?? 0,
     lastOutputTokens: toFiniteNumber(last.outputTokens) ?? 0,
@@ -306,15 +318,14 @@ export const formatCompactTokenCount = (value: number) => {
 
 export const resolveContextWindowState = (
   tokenUsage: TokenUsageSnapshot | null,
-  fallbackContextWindow: number | null,
-  usageKnown = true
-) => {
+  fallbackContextWindow: number | null
+): ContextWindowState => {
   const contextWindow = tokenUsage?.modelContextWindow ?? fallbackContextWindow
+  // App-server exposes cumulative thread totals separately; the latest turn total
+  // is the closest match to current context occupancy.
   const usedTokens = tokenUsage
-    ? tokenUsage.totalInputTokens + tokenUsage.totalOutputTokens
-    : usageKnown
-      ? 0
-      : null
+    ? (tokenUsage.lastTotalTokens ?? (tokenUsage.lastInputTokens + tokenUsage.lastOutputTokens))
+    : null
 
   if (!contextWindow || usedTokens == null) {
     return {
@@ -337,3 +348,6 @@ export const resolveContextWindowState = (
     remainingPercent: Math.max(0, 100 - usedPercent)
   }
 }
+
+export const shouldShowContextWindowIndicator = (state: ContextWindowState) =>
+  state.contextWindow !== null && state.usedTokens !== null

--- a/packages/client/shared/chat-prompt-controls.ts
+++ b/packages/client/shared/chat-prompt-controls.ts
@@ -24,6 +24,7 @@ export type TokenUsageSnapshot = {
   totalInputTokens: number
   totalCachedInputTokens: number
   totalOutputTokens: number
+  lastUsageKnown: boolean
   lastTotalTokens: number | null
   lastInputTokens: number
   lastCachedInputTokens: number
@@ -260,17 +261,18 @@ export const normalizeThreadTokenUsage = (value: unknown): TokenUsageSnapshot | 
   }
 
   const total = isObjectRecord(tokenUsage.total) ? tokenUsage.total : {}
-  const last = isObjectRecord(tokenUsage.last) ? tokenUsage.last : {}
+  const last = isObjectRecord(tokenUsage.last) ? tokenUsage.last : null
 
   return {
     totalTokens: toFiniteNumber(total.totalTokens),
     totalInputTokens: toFiniteNumber(total.inputTokens) ?? 0,
     totalCachedInputTokens: toFiniteNumber(total.cachedInputTokens) ?? 0,
     totalOutputTokens: toFiniteNumber(total.outputTokens) ?? 0,
-    lastTotalTokens: toFiniteNumber(last.totalTokens),
-    lastInputTokens: toFiniteNumber(last.inputTokens) ?? 0,
-    lastCachedInputTokens: toFiniteNumber(last.cachedInputTokens) ?? 0,
-    lastOutputTokens: toFiniteNumber(last.outputTokens) ?? 0,
+    lastUsageKnown: last !== null,
+    lastTotalTokens: toFiniteNumber(last?.totalTokens),
+    lastInputTokens: toFiniteNumber(last?.inputTokens) ?? 0,
+    lastCachedInputTokens: toFiniteNumber(last?.cachedInputTokens) ?? 0,
+    lastOutputTokens: toFiniteNumber(last?.outputTokens) ?? 0,
     modelContextWindow: toFiniteNumber(tokenUsage.modelContextWindow)
   }
 }
@@ -324,7 +326,9 @@ export const resolveContextWindowState = (
   // App-server exposes cumulative thread totals separately; the latest turn total
   // is the closest match to current context occupancy.
   const usedTokens = tokenUsage
-    ? (tokenUsage.lastTotalTokens ?? (tokenUsage.lastInputTokens + tokenUsage.lastOutputTokens))
+    ? tokenUsage.lastTotalTokens ?? (tokenUsage.lastUsageKnown
+        ? tokenUsage.lastInputTokens + tokenUsage.lastOutputTokens
+        : null)
     : null
 
   if (!contextWindow || usedTokens == null) {

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -25,7 +25,9 @@ import {
   formatCompactTokenCount,
   normalizeConfigDefaults,
   normalizeModelList,
+  normalizeThreadTokenUsage,
   resolveContextWindowState,
+  shouldShowContextWindowIndicator,
   resolveEffortOptions
 } from '../shared/chat-prompt-controls'
 import {
@@ -473,21 +475,78 @@ describe('client package', () => {
       effort: 'high'
     })
     expect(resolveContextWindowState({
+      totalTokens: 28000,
       totalInputTokens: 24000,
       totalCachedInputTokens: 6000,
       totalOutputTokens: 4000,
+      lastTotalTokens: 6400,
       lastInputTokens: 2000,
       lastCachedInputTokens: 500,
       lastOutputTokens: 700,
       modelContextWindow: 64000
     }, null)).toEqual({
       contextWindow: 64000,
-      usedTokens: 28000,
-      remainingTokens: 36000,
-      usedPercent: 43.75,
-      remainingPercent: 56.25
+      usedTokens: 6400,
+      remainingTokens: 57600,
+      usedPercent: 10,
+      remainingPercent: 90
     })
     expect(formatCompactTokenCount(12800)).toBe('13k')
+  })
+
+  it('normalizes live thread token usage notifications with last-turn totals intact', () => {
+    expect(normalizeThreadTokenUsage({
+      tokenUsage: {
+        total: {
+          totalTokens: 28000,
+          inputTokens: 24000,
+          cachedInputTokens: 6000,
+          outputTokens: 4000
+        },
+        last: {
+          totalTokens: 6400,
+          inputTokens: 2000,
+          cachedInputTokens: 500,
+          outputTokens: 700
+        },
+        modelContextWindow: 64000
+      }
+    })).toEqual({
+      totalTokens: 28000,
+      totalInputTokens: 24000,
+      totalCachedInputTokens: 6000,
+      totalOutputTokens: 4000,
+      lastTotalTokens: 6400,
+      lastInputTokens: 2000,
+      lastCachedInputTokens: 500,
+      lastOutputTokens: 700,
+      modelContextWindow: 64000
+    })
+  })
+
+  it('hides the context indicator until live token usage is known', () => {
+    const unknownUsage = resolveContextWindowState(null, 258000)
+    expect(unknownUsage).toEqual({
+      contextWindow: 258000,
+      usedTokens: null,
+      remainingTokens: null,
+      usedPercent: null,
+      remainingPercent: null
+    })
+    expect(shouldShowContextWindowIndicator(unknownUsage)).toBe(false)
+
+    const knownUsage = resolveContextWindowState({
+      totalTokens: 32000,
+      totalInputTokens: 28000,
+      totalCachedInputTokens: 6000,
+      totalOutputTokens: 4000,
+      lastTotalTokens: 12000,
+      lastInputTokens: 9000,
+      lastCachedInputTokens: 2000,
+      lastOutputTokens: 3000,
+      modelContextWindow: 258000
+    }, null)
+    expect(shouldShowContextWindowIndicator(knownUsage)).toBe(true)
   })
 
   it('keeps the subagent panel closed by default on mobile even with active agents', () => {

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -479,6 +479,7 @@ describe('client package', () => {
       totalInputTokens: 24000,
       totalCachedInputTokens: 6000,
       totalOutputTokens: 4000,
+      lastUsageKnown: true,
       lastTotalTokens: 6400,
       lastInputTokens: 2000,
       lastCachedInputTokens: 500,
@@ -516,6 +517,7 @@ describe('client package', () => {
       totalInputTokens: 24000,
       totalCachedInputTokens: 6000,
       totalOutputTokens: 4000,
+      lastUsageKnown: true,
       lastTotalTokens: 6400,
       lastInputTokens: 2000,
       lastCachedInputTokens: 500,
@@ -540,6 +542,7 @@ describe('client package', () => {
       totalInputTokens: 28000,
       totalCachedInputTokens: 6000,
       totalOutputTokens: 4000,
+      lastUsageKnown: true,
       lastTotalTokens: 12000,
       lastInputTokens: 9000,
       lastCachedInputTokens: 2000,
@@ -547,6 +550,45 @@ describe('client package', () => {
       modelContextWindow: 258000
     }, null)
     expect(shouldShowContextWindowIndicator(knownUsage)).toBe(true)
+  })
+
+  it('keeps context usage hidden when live notifications omit last-turn usage', () => {
+    expect(normalizeThreadTokenUsage({
+      tokenUsage: {
+        total: {
+          totalTokens: 28000,
+          inputTokens: 24000,
+          cachedInputTokens: 6000,
+          outputTokens: 4000
+        },
+        modelContextWindow: 64000
+      }
+    })).toEqual({
+      totalTokens: 28000,
+      totalInputTokens: 24000,
+      totalCachedInputTokens: 6000,
+      totalOutputTokens: 4000,
+      lastUsageKnown: false,
+      lastTotalTokens: null,
+      lastInputTokens: 0,
+      lastCachedInputTokens: 0,
+      lastOutputTokens: 0,
+      modelContextWindow: 64000
+    })
+
+    const unknownLastUsage = resolveContextWindowState({
+      totalTokens: 28000,
+      totalInputTokens: 24000,
+      totalCachedInputTokens: 6000,
+      totalOutputTokens: 4000,
+      lastUsageKnown: false,
+      lastTotalTokens: null,
+      lastInputTokens: 0,
+      lastCachedInputTokens: 0,
+      lastOutputTokens: 0,
+      modelContextWindow: 64000
+    }, null)
+    expect(shouldShowContextWindowIndicator(unknownLastUsage)).toBe(false)
   })
 
   it('keeps the subagent panel closed by default on mobile even with active agents', () => {


### PR DESCRIPTION
## Summary
- switch the context usage meter to derive occupancy from the latest live token-usage snapshot instead of cumulative thread totals
- hide the footer indicator until live token-usage data is available for the active response and remove the extra helper label
- keep the previously known token-usage snapshot when a submit fails so the indicator does not disappear permanently on request errors
- treat token-usage payloads without a `last` block as unknown instead of showing a bogus near-empty context meter

## Why
The UI could show a large context window as nearly full after relatively little activity because it was using cumulative totals for occupancy. It also rendered the indicator before live usage was known, and follow-up review found two edge cases: failed submits should preserve the previous snapshot, and runtimes that omit `tokenUsage.last` should not be interpreted as zero usage.

## Impact
Threads now show a quieter and more trustworthy context indicator: it appears only when there is real live usage data, uses the correct basis for occupancy, preserves the previous state across failed submits, and stays hidden when the runtime cannot provide enough data to compute the latest occupancy safely.

## Validation
- `pnpm --filter @codori/client test`
- `pnpm --filter @codori/client typecheck`

Closes #20
