### PR TITLE
Fix first-send steering detection and fallback recovery

### DIFF
--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -9,6 +9,7 @@ import {
   removePendingUserMessageId,
   resolvePromptSubmitStatus,
   resolveTurnSubmissionMethod,
+  shouldAwaitThreadHydration,
   shouldIgnoreNotificationAfterInterrupt
 } from '../utils/chat-turn-engagement'
 import { useChatAttachments, type DraftAttachment } from '../composables/useChatAttachments'
@@ -304,6 +305,7 @@ const loadPromptControls = async () => {
 const subagentBootstrapPromises = new Map<string, Promise<void>>()
 const optimisticAttachmentSnapshots = new Map<string, DraftAttachment[]>()
 let promptControlsPromise: Promise<void> | null = null
+let pendingThreadHydration: Promise<void> | null = null
 
 const isActiveTurnStatus = (value: string | null | undefined) => {
   if (!value) {
@@ -765,106 +767,118 @@ const ensureProjectRuntime = async () => {
 }
 
 const hydrateThread = async (threadId: string) => {
-  const requestVersion = loadVersion.value + 1
-  loadVersion.value = requestVersion
-  error.value = null
-  tokenUsage.value = null
+  const hydratePromise = (async () => {
+    const requestVersion = loadVersion.value + 1
+    loadVersion.value = requestVersion
+    error.value = null
+    tokenUsage.value = null
 
-  try {
-    await ensureProjectRuntime()
-    const client = getClient(props.projectId)
-    activeThreadId.value = threadId
+    try {
+      await ensureProjectRuntime()
+      const client = getClient(props.projectId)
+      activeThreadId.value = threadId
 
-    const existingLiveStream = session.liveStream
+      const existingLiveStream = session.liveStream
 
-    if (existingLiveStream && existingLiveStream.threadId !== threadId) {
-      clearLiveStream()
-    }
+      if (existingLiveStream && existingLiveStream.threadId !== threadId) {
+        clearLiveStream()
+      }
 
-    if (!session.liveStream) {
-      const nextLiveStream = createLiveStreamState(threadId)
+      if (!session.liveStream) {
+        const nextLiveStream = createLiveStreamState(threadId)
 
-      nextLiveStream.unsubscribe = client.subscribe((notification) => {
-        const targetThreadId = notificationThreadId(notification)
-        if (!targetThreadId) {
-          return
-        }
-
-        if (targetThreadId !== threadId) {
-          if (nextLiveStream.observedSubagentThreadIds.has(targetThreadId)) {
-            applySubagentNotification(targetThreadId, notification)
+        nextLiveStream.unsubscribe = client.subscribe((notification) => {
+          const targetThreadId = notificationThreadId(notification)
+          if (!targetThreadId) {
+            return
           }
-          return
-        }
 
-        if (!nextLiveStream.turnId) {
-          nextLiveStream.bufferedNotifications.push(notification)
-          return
-        }
+          if (targetThreadId !== threadId) {
+            if (nextLiveStream.observedSubagentThreadIds.has(targetThreadId)) {
+              applySubagentNotification(targetThreadId, notification)
+            }
+            return
+          }
 
+          if (!nextLiveStream.turnId) {
+            nextLiveStream.bufferedNotifications.push(notification)
+            return
+          }
+
+          const turnId = notificationTurnId(notification)
+          if (turnId && turnId !== nextLiveStream.turnId) {
+            return
+          }
+
+          applyNotification(notification)
+        })
+
+        setSessionLiveStream(nextLiveStream)
+      }
+
+      const resumeResponse = await client.request<ThreadResumeResponse>('thread/resume', {
+        threadId,
+        cwd: selectedProject.value?.projectPath ?? null,
+        approvalPolicy: 'never',
+        persistExtendedHistory: true
+      })
+      const response = await client.request<ThreadReadResponse>('thread/read', {
+        threadId,
+        includeTurns: true
+      })
+
+      if (loadVersion.value !== requestVersion) {
+        return
+      }
+
+      syncPromptSelectionFromThread(
+        resumeResponse.model ?? null,
+        (resumeResponse.reasoningEffort as ReasoningEffort | null | undefined) ?? null
+      )
+      activeThreadId.value = response.thread.id
+      threadTitle.value = resolveThreadTitle(response.thread)
+      messages.value = threadToMessages(response.thread)
+      rebuildSubagentPanelsFromThread(response.thread)
+      const activeTurn = [...response.thread.turns].reverse().find(turn => isActiveTurnStatus(turn.status))
+
+      if (!activeTurn) {
+        clearLiveStream()
+        status.value = 'ready'
+        return
+      }
+
+      if (!session.liveStream) {
+        status.value = 'streaming'
+        return
+      }
+
+      setLiveStreamTurnId(session.liveStream, activeTurn.id)
+      status.value = 'streaming'
+
+      const pendingNotifications = session.liveStream.bufferedNotifications.splice(0, session.liveStream.bufferedNotifications.length)
+      for (const notification of pendingNotifications) {
         const turnId = notificationTurnId(notification)
-        if (turnId && turnId !== nextLiveStream.turnId) {
-          return
+        if (turnId && turnId !== activeTurn.id) {
+          continue
         }
 
         applyNotification(notification)
-      })
-
-      setSessionLiveStream(nextLiveStream)
-    }
-
-    const resumeResponse = await client.request<ThreadResumeResponse>('thread/resume', {
-      threadId,
-      cwd: selectedProject.value?.projectPath ?? null,
-      approvalPolicy: 'never',
-      persistExtendedHistory: true
-    })
-    const response = await client.request<ThreadReadResponse>('thread/read', {
-      threadId,
-      includeTurns: true
-    })
-
-    if (loadVersion.value !== requestVersion) {
-      return
-    }
-
-    syncPromptSelectionFromThread(
-      resumeResponse.model ?? null,
-      (resumeResponse.reasoningEffort as ReasoningEffort | null | undefined) ?? null
-    )
-    activeThreadId.value = response.thread.id
-    threadTitle.value = resolveThreadTitle(response.thread)
-    messages.value = threadToMessages(response.thread)
-    rebuildSubagentPanelsFromThread(response.thread)
-    const activeTurn = [...response.thread.turns].reverse().find(turn => isActiveTurnStatus(turn.status))
-
-    if (!activeTurn) {
-      clearLiveStream()
-      status.value = 'ready'
-      return
-    }
-
-    if (!session.liveStream) {
-      status.value = 'streaming'
-      return
-    }
-
-    setLiveStreamTurnId(session.liveStream, activeTurn.id)
-    status.value = 'streaming'
-
-    const pendingNotifications = session.liveStream.bufferedNotifications.splice(0, session.liveStream.bufferedNotifications.length)
-    for (const notification of pendingNotifications) {
-      const turnId = notificationTurnId(notification)
-      if (turnId && turnId !== activeTurn.id) {
-        continue
       }
-
-      applyNotification(notification)
+    } catch (caughtError) {
+      clearLiveStream()
+      error.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
+      status.value = 'error'
     }
-  } catch (caughtError) {
-    clearLiveStream()
-    error.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
-    status.value = 'error'
+  })()
+
+  pendingThreadHydration = hydratePromise
+
+  try {
+    await hydratePromise
+  } finally {
+    if (pendingThreadHydration === hydratePromise) {
+      pendingThreadHydration = null
+    }
   }
 }
 
@@ -1741,6 +1755,14 @@ const sendMessage = async () => {
     error.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
     status.value = 'error'
     return
+  }
+
+  if (pendingThreadHydration && shouldAwaitThreadHydration({
+    hasPendingThreadHydration: true,
+    routeThreadId: routeThreadId.value,
+    activeThreadId: activeThreadId.value
+  })) {
+    await pendingThreadHydration
   }
 
   pinnedToBottom.value = true

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -3,6 +3,7 @@ import { useRouter } from '#imports'
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import MessageContent from './MessageContent.vue'
 import {
+  hasSteerableTurn,
   reconcileOptimisticUserMessage,
   removeChatMessage,
   removePendingUserMessageId,
@@ -320,6 +321,16 @@ const currentLiveStream = () =>
 const hasActiveTurnEngagement = () =>
   Boolean(currentLiveStream() || session.pendingLiveStream)
 
+const hasSteerableActiveTurn = () =>
+  hasSteerableTurn({
+    activeThreadId: activeThreadId.value,
+    liveStreamThreadId: session.liveStream?.threadId ?? null,
+    liveStreamTurnId: session.liveStream?.turnId ?? null
+  })
+
+const shouldRetryTurnStart = (error: Error) =>
+  /no active turn to steer|active turn is no longer available/i.test(error.message)
+
 const rejectLiveStreamTurnWaiters = (liveStream: LiveStream, error: Error) => {
   const waiters = liveStream.turnIdWaiters.splice(0, liveStream.turnIdWaiters.length)
   for (const waiter of waiters) {
@@ -377,6 +388,25 @@ const waitForLiveStreamTurnId = async (liveStream: LiveStream) => {
   return await new Promise<string>((resolve, reject) => {
     liveStream.turnIdWaiters.push({ resolve, reject })
   })
+}
+
+const queuePendingUserMessage = (liveStream: LiveStream, messageId: string) => {
+  if (liveStream.pendingUserMessageIds.includes(messageId)) {
+    return
+  }
+
+  liveStream.pendingUserMessageIds.push(messageId)
+}
+
+const replayBufferedNotifications = (liveStream: LiveStream) => {
+  for (const notification of liveStream.bufferedNotifications.splice(0, liveStream.bufferedNotifications.length)) {
+    const turnId = notificationTurnId(notification)
+    if (turnId && turnId !== liveStream.turnId) {
+      continue
+    }
+
+    applyNotification(notification)
+  }
 }
 
 const clearLiveStream = (reason?: Error) => {
@@ -574,6 +604,41 @@ const clearPendingOptimisticMessages = (liveStream: LiveStream | null, options?:
   }
 
   liveStream.pendingUserMessageIds = []
+}
+
+const submitTurnStart = async (input: {
+  client: ReturnType<typeof getClient>
+  liveStream: LiveStream
+  text: string
+  submittedAttachments: DraftAttachment[]
+  optimisticMessageId: string
+  queueOptimisticMessage?: boolean
+}) => {
+  const {
+    client,
+    liveStream,
+    text,
+    submittedAttachments,
+    optimisticMessageId,
+    queueOptimisticMessage: shouldQueueOptimisticMessage = true
+  } = input
+
+  if (shouldQueueOptimisticMessage) {
+    queuePendingUserMessage(liveStream, optimisticMessageId)
+  }
+
+  const uploadedAttachments = await uploadAttachments(liveStream.threadId, submittedAttachments)
+  const turnStart = await client.request<TurnStartResponse>('turn/start', {
+    threadId: liveStream.threadId,
+    input: buildTurnStartInput(text, uploadedAttachments),
+    cwd: selectedProject.value?.projectPath ?? null,
+    approvalPolicy: 'never',
+    ...buildTurnOverrides(selectedModel.value, selectedEffort.value)
+  })
+
+  tokenUsage.value = null
+  setLiveStreamTurnId(liveStream, turnStart.turn.id)
+  replayBufferedNotifications(liveStream)
 }
 
 const resolveThreadTitle = (thread: { name: string | null, preview: string, id: string }) => {
@@ -1681,7 +1746,7 @@ const sendMessage = async () => {
   pinnedToBottom.value = true
   error.value = null
   attachmentError.value = null
-  const submissionMethod = resolveTurnSubmissionMethod(hasActiveTurnEngagement())
+  const submissionMethod = resolveTurnSubmissionMethod(hasSteerableActiveTurn())
   if (submissionMethod === 'turn/start') {
     status.value = 'submitted'
   }
@@ -1693,51 +1758,59 @@ const sendMessage = async () => {
   messages.value = [...messages.value, optimisticMessage]
   ensureThinkingPlaceholder()
   let startedLiveStream: LiveStream | null = null
+  let executedSubmissionMethod = submissionMethod
 
   try {
     const client = getClient(props.projectId)
 
     if (submissionMethod === 'turn/steer') {
       const liveStream = await ensurePendingLiveStream()
-      const uploadedAttachments = await uploadAttachments(liveStream.threadId, submittedAttachments)
-      liveStream.pendingUserMessageIds.push(optimisticMessageId)
-      const turnId = await waitForLiveStreamTurnId(liveStream)
+      queuePendingUserMessage(liveStream, optimisticMessageId)
 
-      await client.request<TurnStartResponse>('turn/steer', {
-        threadId: liveStream.threadId,
-        expectedTurnId: turnId,
-        input: buildTurnStartInput(text, uploadedAttachments),
-        ...buildTurnOverrides(selectedModel.value, selectedEffort.value)
-      })
-      tokenUsage.value = null
+      try {
+        const uploadedAttachments = await uploadAttachments(liveStream.threadId, submittedAttachments)
+        const turnId = await waitForLiveStreamTurnId(liveStream)
+
+        await client.request<TurnStartResponse>('turn/steer', {
+          threadId: liveStream.threadId,
+          expectedTurnId: turnId,
+          input: buildTurnStartInput(text, uploadedAttachments),
+          ...buildTurnOverrides(selectedModel.value, selectedEffort.value)
+        })
+        tokenUsage.value = null
+      } catch (caughtError) {
+        const errorToHandle = caughtError instanceof Error ? caughtError : new Error(String(caughtError))
+        if (!shouldRetryTurnStart(errorToHandle)) {
+          throw errorToHandle
+        }
+
+        executedSubmissionMethod = 'turn/start'
+        startedLiveStream = liveStream
+        status.value = 'submitted'
+        setLiveStreamTurnId(liveStream, null)
+        setLiveStreamInterruptRequested(liveStream, false)
+
+        await submitTurnStart({
+          client,
+          liveStream,
+          text,
+          submittedAttachments,
+          optimisticMessageId,
+          queueOptimisticMessage: false
+        })
+      }
       return
     }
 
     const liveStream = await ensurePendingLiveStream()
     startedLiveStream = liveStream
-    const threadId = liveStream.threadId
-    const uploadedAttachments = await uploadAttachments(threadId, submittedAttachments)
-    liveStream.pendingUserMessageIds.push(optimisticMessageId)
-
-    const turnStart = await client.request<TurnStartResponse>('turn/start', {
-      threadId,
-      input: buildTurnStartInput(text, uploadedAttachments),
-      cwd: selectedProject.value?.projectPath ?? null,
-      approvalPolicy: 'never',
-      ...buildTurnOverrides(selectedModel.value, selectedEffort.value)
+    await submitTurnStart({
+      client,
+      liveStream,
+      text,
+      submittedAttachments,
+      optimisticMessageId
     })
-
-    tokenUsage.value = null
-    setLiveStreamTurnId(liveStream, turnStart.turn.id)
-
-    for (const notification of liveStream.bufferedNotifications.splice(0, liveStream.bufferedNotifications.length)) {
-      const turnId = notificationTurnId(notification)
-      if (turnId && turnId !== liveStream.turnId) {
-        continue
-      }
-
-      applyNotification(notification)
-    }
   } catch (caughtError) {
     const messageText = caughtError instanceof Error ? caughtError.message : String(caughtError)
 
@@ -1745,7 +1818,7 @@ const sendMessage = async () => {
     untrackPendingUserMessage(optimisticMessageId)
     removeOptimisticMessage(optimisticMessageId)
 
-    if (submissionMethod === 'turn/start') {
+    if (executedSubmissionMethod === 'turn/start') {
       if (startedLiveStream && session.liveStream === startedLiveStream) {
         clearPendingOptimisticMessages(clearLiveStream(new Error(messageText)))
       }

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -34,7 +34,7 @@ import {
   type ItemData,
   type McpToolCallItem
 } from '~~/shared/codex-chat'
-import { buildTurnStartInput } from '~~/shared/chat-attachments'
+import { buildTurnStartInput, type PersistedProjectAttachment } from '~~/shared/chat-attachments'
 import {
   type ConfigReadResponse,
   type ModelListResponse,
@@ -611,6 +611,7 @@ const submitTurnStart = async (input: {
   liveStream: LiveStream
   text: string
   submittedAttachments: DraftAttachment[]
+  uploadedAttachments?: PersistedProjectAttachment[]
   optimisticMessageId: string
   queueOptimisticMessage?: boolean
 }) => {
@@ -619,6 +620,7 @@ const submitTurnStart = async (input: {
     liveStream,
     text,
     submittedAttachments,
+    uploadedAttachments: existingUploadedAttachments,
     optimisticMessageId,
     queueOptimisticMessage: shouldQueueOptimisticMessage = true
   } = input
@@ -627,7 +629,8 @@ const submitTurnStart = async (input: {
     queuePendingUserMessage(liveStream, optimisticMessageId)
   }
 
-  const uploadedAttachments = await uploadAttachments(liveStream.threadId, submittedAttachments)
+  const uploadedAttachments = existingUploadedAttachments
+    ?? await uploadAttachments(liveStream.threadId, submittedAttachments)
   const turnStart = await client.request<TurnStartResponse>('turn/start', {
     threadId: liveStream.threadId,
     input: buildTurnStartInput(text, uploadedAttachments),
@@ -1786,9 +1789,10 @@ const sendMessage = async () => {
     if (submissionMethod === 'turn/steer') {
       const liveStream = await ensurePendingLiveStream()
       queuePendingUserMessage(liveStream, optimisticMessageId)
+      let uploadedAttachments: PersistedProjectAttachment[] | undefined
 
       try {
-        const uploadedAttachments = await uploadAttachments(liveStream.threadId, submittedAttachments)
+        uploadedAttachments = await uploadAttachments(liveStream.threadId, submittedAttachments)
         const turnId = await waitForLiveStreamTurnId(liveStream)
 
         await client.request<TurnStartResponse>('turn/steer', {
@@ -1815,6 +1819,7 @@ const sendMessage = async () => {
           liveStream,
           text,
           submittedAttachments,
+          uploadedAttachments,
           optimisticMessageId,
           queueOptimisticMessage: false
         })

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -10,6 +10,7 @@ import {
   resolvePromptSubmitStatus,
   resolveTurnSubmissionMethod,
   shouldAwaitThreadHydration,
+  shouldRetrySteerWithTurnStart,
   shouldIgnoreNotificationAfterInterrupt
 } from '../utils/chat-turn-engagement'
 import { useChatAttachments, type DraftAttachment } from '../composables/useChatAttachments'
@@ -329,9 +330,6 @@ const hasSteerableActiveTurn = () =>
     liveStreamThreadId: session.liveStream?.threadId ?? null,
     liveStreamTurnId: session.liveStream?.turnId ?? null
   })
-
-const shouldRetryTurnStart = (error: Error) =>
-  /no active turn to steer|active turn is no longer available/i.test(error.message)
 
 const rejectLiveStreamTurnWaiters = (liveStream: LiveStream, error: Error) => {
   const waiters = liveStream.turnIdWaiters.splice(0, liveStream.turnIdWaiters.length)
@@ -1802,7 +1800,7 @@ const sendMessage = async () => {
         tokenUsage.value = null
       } catch (caughtError) {
         const errorToHandle = caughtError instanceof Error ? caughtError : new Error(String(caughtError))
-        if (!shouldRetryTurnStart(errorToHandle)) {
+        if (!shouldRetrySteerWithTurnStart(errorToHandle.message)) {
           throw errorToHandle
         }
 

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -3,12 +3,12 @@ import { useRouter } from '#imports'
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import MessageContent from './MessageContent.vue'
 import {
-  hasSteerableTurn,
   reconcileOptimisticUserMessage,
   removeChatMessage,
   removePendingUserMessageId,
   resolvePromptSubmitStatus,
   resolveTurnSubmissionMethod,
+  shouldSubmitViaTurnSteer,
   shouldAwaitThreadHydration,
   shouldRetrySteerWithTurnStart,
   shouldIgnoreNotificationAfterInterrupt
@@ -324,11 +324,12 @@ const currentLiveStream = () =>
 const hasActiveTurnEngagement = () =>
   Boolean(currentLiveStream() || session.pendingLiveStream)
 
-const hasSteerableActiveTurn = () =>
-  hasSteerableTurn({
+const shouldSubmitWithTurnSteer = () =>
+  shouldSubmitViaTurnSteer({
     activeThreadId: activeThreadId.value,
     liveStreamThreadId: session.liveStream?.threadId ?? null,
-    liveStreamTurnId: session.liveStream?.turnId ?? null
+    liveStreamTurnId: session.liveStream?.turnId ?? null,
+    status: status.value
   })
 
 const rejectLiveStreamTurnWaiters = (liveStream: LiveStream, error: Error) => {
@@ -1760,8 +1761,7 @@ const sendMessage = async () => {
 
   if (pendingThreadHydration && shouldAwaitThreadHydration({
     hasPendingThreadHydration: true,
-    routeThreadId: routeThreadId.value,
-    activeThreadId: activeThreadId.value
+    routeThreadId: routeThreadId.value
   })) {
     await pendingThreadHydration
   }
@@ -1769,7 +1769,7 @@ const sendMessage = async () => {
   pinnedToBottom.value = true
   error.value = null
   attachmentError.value = null
-  const submissionMethod = resolveTurnSubmissionMethod(hasSteerableActiveTurn())
+  const submissionMethod = resolveTurnSubmissionMethod(shouldSubmitWithTurnSteer())
   if (submissionMethod === 'turn/start') {
     status.value = 'submitted'
   }

--- a/packages/client/app/utils/chat-turn-engagement.ts
+++ b/packages/client/app/utils/chat-turn-engagement.ts
@@ -34,6 +34,9 @@ export const shouldAwaitThreadHydration = (input: {
   && input.routeThreadId !== null
   && input.activeThreadId === input.routeThreadId
 
+export const shouldRetrySteerWithTurnStart = (message: string) =>
+  /no active turn to steer/i.test(message)
+
 export const resolvePromptSubmitStatus = (input: {
   status: PromptSubmitStatus
   hasDraftContent: boolean

--- a/packages/client/app/utils/chat-turn-engagement.ts
+++ b/packages/client/app/utils/chat-turn-engagement.ts
@@ -25,14 +25,22 @@ export const hasSteerableTurn = (input: {
   && input.liveStreamThreadId === input.activeThreadId
   && input.liveStreamTurnId !== null
 
+export const shouldSubmitViaTurnSteer = (input: {
+  activeThreadId: string | null
+  liveStreamThreadId: string | null
+  liveStreamTurnId: string | null
+  status: PromptSubmitStatus
+}) =>
+  input.activeThreadId !== null
+  && input.liveStreamThreadId === input.activeThreadId
+  && (input.liveStreamTurnId !== null || input.status === 'submitted' || input.status === 'streaming')
+
 export const shouldAwaitThreadHydration = (input: {
   hasPendingThreadHydration: boolean
   routeThreadId: string | null
-  activeThreadId: string | null
 }) =>
   input.hasPendingThreadHydration
   && input.routeThreadId !== null
-  && input.activeThreadId === input.routeThreadId
 
 export const shouldRetrySteerWithTurnStart = (message: string) =>
   /no active turn to steer/i.test(message)

--- a/packages/client/app/utils/chat-turn-engagement.ts
+++ b/packages/client/app/utils/chat-turn-engagement.ts
@@ -16,6 +16,15 @@ const interruptIgnoredMethods = new Set([
 export const resolveTurnSubmissionMethod = (hasActiveTurn: boolean) =>
   hasActiveTurn ? 'turn/steer' : 'turn/start'
 
+export const hasSteerableTurn = (input: {
+  activeThreadId: string | null
+  liveStreamThreadId: string | null
+  liveStreamTurnId: string | null
+}) =>
+  input.activeThreadId !== null
+  && input.liveStreamThreadId === input.activeThreadId
+  && input.liveStreamTurnId !== null
+
 export const resolvePromptSubmitStatus = (input: {
   status: PromptSubmitStatus
   hasDraftContent: boolean
@@ -30,12 +39,50 @@ export const removeChatMessage = (messages: ChatMessage[], messageId: string) =>
 export const removePendingUserMessageId = (messageIds: string[], messageId: string) =>
   messageIds.filter(candidateId => candidateId !== messageId)
 
+const isEquivalentUserMessagePart = (
+  currentPart: ChatMessage['parts'][number],
+  confirmedPart: ChatMessage['parts'][number]
+) => {
+  if (currentPart.type === 'text' && confirmedPart.type === 'text') {
+    return currentPart.text === confirmedPart.text
+  }
+
+  if (currentPart.type === 'attachment' && confirmedPart.type === 'attachment') {
+    return currentPart.attachment.kind === confirmedPart.attachment.kind
+      && currentPart.attachment.name === confirmedPart.attachment.name
+  }
+
+  return false
+}
+
+const findOptimisticUserMessageIndex = (
+  messages: ChatMessage[],
+  optimisticMessageId: string,
+  confirmedMessage: ChatMessage
+) => {
+  const directIndex = messages.findIndex(message => message.id === optimisticMessageId)
+  if (directIndex !== -1) {
+    return directIndex
+  }
+
+  if (confirmedMessage.role !== 'user') {
+    return -1
+  }
+
+  return messages.findIndex(message =>
+    message.role === 'user'
+    && message.pending === true
+    && message.parts.length === confirmedMessage.parts.length
+    && message.parts.every((part, index) => isEquivalentUserMessagePart(part, confirmedMessage.parts[index]!))
+  )
+}
+
 export const reconcileOptimisticUserMessage = (
   messages: ChatMessage[],
   optimisticMessageId: string,
   confirmedMessage: ChatMessage
 ) => {
-  const index = messages.findIndex(message => message.id === optimisticMessageId)
+  const index = findOptimisticUserMessageIndex(messages, optimisticMessageId, confirmedMessage)
   if (index === -1) {
     return upsertStreamingMessage(messages, confirmedMessage)
   }

--- a/packages/client/app/utils/chat-turn-engagement.ts
+++ b/packages/client/app/utils/chat-turn-engagement.ts
@@ -25,6 +25,15 @@ export const hasSteerableTurn = (input: {
   && input.liveStreamThreadId === input.activeThreadId
   && input.liveStreamTurnId !== null
 
+export const shouldAwaitThreadHydration = (input: {
+  hasPendingThreadHydration: boolean
+  routeThreadId: string | null
+  activeThreadId: string | null
+}) =>
+  input.hasPendingThreadHydration
+  && input.routeThreadId !== null
+  && input.activeThreadId === input.routeThreadId
+
 export const resolvePromptSubmitStatus = (input: {
   status: PromptSubmitStatus
   hasDraftContent: boolean

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -5,6 +5,7 @@ import {
   removePendingUserMessageId,
   resolvePromptSubmitStatus,
   resolveTurnSubmissionMethod,
+  shouldSubmitViaTurnSteer,
   shouldAwaitThreadHydration,
   shouldRetrySteerWithTurnStart,
   shouldIgnoreNotificationAfterInterrupt
@@ -326,20 +327,33 @@ describe('client package', () => {
   it('waits for thread hydration before deciding the submission mode on a resumed thread', () => {
     expect(shouldAwaitThreadHydration({
       hasPendingThreadHydration: true,
-      routeThreadId: 'thread-1',
-      activeThreadId: 'thread-1'
+      routeThreadId: 'thread-1'
     })).toBe(true)
 
     expect(shouldAwaitThreadHydration({
       hasPendingThreadHydration: true,
-      routeThreadId: null,
-      activeThreadId: 'thread-1'
+      routeThreadId: null
     })).toBe(false)
 
     expect(shouldAwaitThreadHydration({
       hasPendingThreadHydration: false,
-      routeThreadId: 'thread-1',
-      activeThreadId: 'thread-1'
+      routeThreadId: 'thread-1'
+    })).toBe(false)
+  })
+
+  it('routes follow-up sends through turn/steer while the current turn is still being submitted', () => {
+    expect(shouldSubmitViaTurnSteer({
+      activeThreadId: 'thread-1',
+      liveStreamThreadId: 'thread-1',
+      liveStreamTurnId: null,
+      status: 'submitted'
+    })).toBe(true)
+
+    expect(shouldSubmitViaTurnSteer({
+      activeThreadId: 'thread-1',
+      liveStreamThreadId: 'thread-1',
+      liveStreamTurnId: null,
+      status: 'ready'
     })).toBe(false)
   })
 

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -5,6 +5,7 @@ import {
   removePendingUserMessageId,
   resolvePromptSubmitStatus,
   resolveTurnSubmissionMethod,
+  shouldAwaitThreadHydration,
   shouldIgnoreNotificationAfterInterrupt
 } from '../app/utils/chat-turn-engagement'
 import {
@@ -319,6 +320,26 @@ describe('client package', () => {
       liveStreamThreadId: 'thread-1',
       liveStreamTurnId: 'turn-1'
     }))).toBe('turn/steer')
+  })
+
+  it('waits for thread hydration before deciding the submission mode on a resumed thread', () => {
+    expect(shouldAwaitThreadHydration({
+      hasPendingThreadHydration: true,
+      routeThreadId: 'thread-1',
+      activeThreadId: 'thread-1'
+    })).toBe(true)
+
+    expect(shouldAwaitThreadHydration({
+      hasPendingThreadHydration: true,
+      routeThreadId: null,
+      activeThreadId: 'thread-1'
+    })).toBe(false)
+
+    expect(shouldAwaitThreadHydration({
+      hasPendingThreadHydration: false,
+      routeThreadId: 'thread-1',
+      activeThreadId: 'thread-1'
+    })).toBe(false)
   })
 
   it('keeps the prompt submit button in send mode while a draft exists', () => {

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -6,6 +6,7 @@ import {
   resolvePromptSubmitStatus,
   resolveTurnSubmissionMethod,
   shouldAwaitThreadHydration,
+  shouldRetrySteerWithTurnStart,
   shouldIgnoreNotificationAfterInterrupt
 } from '../app/utils/chat-turn-engagement'
 import {
@@ -340,6 +341,11 @@ describe('client package', () => {
       routeThreadId: 'thread-1',
       activeThreadId: 'thread-1'
     })).toBe(false)
+  })
+
+  it('retries with turn/start only for steer rejection messages from the server', () => {
+    expect(shouldRetrySteerWithTurnStart('no active turn to steer')).toBe(true)
+    expect(shouldRetrySteerWithTurnStart('The active turn is no longer available.')).toBe(false)
   })
 
   it('keeps the prompt submit button in send mode while a draft exists', () => {

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  hasSteerableTurn,
   reconcileOptimisticUserMessage,
   removePendingUserMessageId,
   resolvePromptSubmitStatus,
@@ -281,6 +282,45 @@ describe('client package', () => {
     expect(resolveTurnSubmissionMethod(true)).toBe('turn/steer')
   })
 
+  it('uses turn/start for the first send in a new thread', () => {
+    expect(hasSteerableTurn({
+      activeThreadId: null,
+      liveStreamThreadId: null,
+      liveStreamTurnId: null
+    })).toBe(false)
+    expect(resolveTurnSubmissionMethod(hasSteerableTurn({
+      activeThreadId: null,
+      liveStreamThreadId: null,
+      liveStreamTurnId: null
+    }))).toBe('turn/start')
+  })
+
+  it('uses turn/start for the first send after resuming a thread with no active turn', () => {
+    expect(hasSteerableTurn({
+      activeThreadId: 'thread-1',
+      liveStreamThreadId: 'thread-1',
+      liveStreamTurnId: null
+    })).toBe(false)
+    expect(resolveTurnSubmissionMethod(hasSteerableTurn({
+      activeThreadId: 'thread-1',
+      liveStreamThreadId: 'thread-1',
+      liveStreamTurnId: null
+    }))).toBe('turn/start')
+  })
+
+  it('uses turn/steer only when an active turn id is known for the current thread', () => {
+    expect(hasSteerableTurn({
+      activeThreadId: 'thread-1',
+      liveStreamThreadId: 'thread-1',
+      liveStreamTurnId: 'turn-1'
+    })).toBe(true)
+    expect(resolveTurnSubmissionMethod(hasSteerableTurn({
+      activeThreadId: 'thread-1',
+      liveStreamThreadId: 'thread-1',
+      liveStreamTurnId: 'turn-1'
+    }))).toBe('turn/steer')
+  })
+
   it('keeps the prompt submit button in send mode while a draft exists', () => {
     expect(resolvePromptSubmitStatus({
       status: 'streaming',
@@ -336,6 +376,80 @@ describe('client package', () => {
         type: 'text',
         text: 'Working on it',
         state: 'streaming'
+      }]
+    }])
+  })
+
+  it('reconciles a matching optimistic user message even when the pending id queue is stale', () => {
+    expect(reconcileOptimisticUserMessage([{
+      id: 'local-user-1',
+      role: 'user',
+      pending: true,
+      parts: [{
+        type: 'text',
+        text: 'Start a fresh turn.',
+        state: 'done'
+      }]
+    }], 'missing-optimistic-id', {
+      id: 'user-1',
+      role: 'user',
+      pending: false,
+      parts: [{
+        type: 'text',
+        text: 'Start a fresh turn.',
+        state: 'done'
+      }]
+    })).toEqual([{
+      id: 'user-1',
+      role: 'user',
+      pending: false,
+      parts: [{
+        type: 'text',
+        text: 'Start a fresh turn.',
+        state: 'done'
+      }]
+    }])
+  })
+
+  it('reconciles attachment-only optimistic user messages by attachment identity', () => {
+    expect(reconcileOptimisticUserMessage([{
+      id: 'local-user-1',
+      role: 'user',
+      pending: true,
+      parts: [{
+        type: 'attachment',
+        attachment: {
+          kind: 'image',
+          name: 'diagram.png',
+          mediaType: 'image/png',
+          url: 'blob:diagram'
+        }
+      }]
+    }], 'missing-optimistic-id', {
+      id: 'user-1',
+      role: 'user',
+      pending: false,
+      parts: [{
+        type: 'attachment',
+        attachment: {
+          kind: 'image',
+          name: 'diagram.png',
+          mediaType: 'image/*',
+          localPath: '/tmp/diagram.png'
+        }
+      }]
+    })).toEqual([{
+      id: 'user-1',
+      role: 'user',
+      pending: false,
+      parts: [{
+        type: 'attachment',
+        attachment: {
+          kind: 'image',
+          name: 'diagram.png',
+          mediaType: 'image/*',
+          localPath: '/tmp/diagram.png'
+        }
       }]
     }])
   })


### PR DESCRIPTION
## Summary

- tighten first-send steering detection so same-turn steering is used only when the client knows the current thread has an active turn id
- preserve a single optimistic user bubble by hardening reconciliation and adding a safe `turn/start` fallback for false steer attempts
- address review follow-ups by waiting for resumed-thread hydration before submit, routing pre-turn follow-up sends through `turn/steer`, narrowing retry conditions, and reusing uploaded attachments during steer fallback

## Why

Issue #23 was caused by treating live-stream shell state as proof that a steerable turn existed. That misrouted first sends and some resumed-thread sends to `turn/steer`, surfaced `no active turn to steer`, and could duplicate user bubbles. The follow-up fixes close the hydration race, preserve same-turn steering while a turn is still being submitted, prevent stale-thread retries after teardown, and avoid duplicate attachment uploads in the fallback path.

## User Impact

- first send in a new or resumed non-streaming thread now consistently uses `turn/start`
- resumed threads that are already streaming, or are still finalizing their initial `turn/start`, keep same-turn steering available
- mistaken steering paths no longer leave duplicate user bubbles or orphan extra attachment uploads

## Validation

- `pnpm --filter @codori/client test`
- `pnpm --filter @codori/client typecheck`

## Latest Follow-up Commits

- `7fccbae` `fix: address review feedback on turn submission`
