### PR TITLE
feat: enhance live chat and project navigation UX

### DIFF
--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -19,7 +19,7 @@ import { useProjects } from '../composables/useProjects'
 import { useRpc } from '../composables/useRpc'
 import { useChatSubmitGuard } from '../composables/useChatSubmitGuard'
 import { resolveThreadSummaryTitle, useThreadSummaries } from '../composables/useThreadSummaries'
-import { resolveChatMessagesStatus } from '../utils/chat-messages-status'
+import { resolveChatMessagesStatus, shouldAwaitAssistantOutput } from '../utils/chat-messages-status'
 import {
   ITEM_PART,
   eventToMessage,
@@ -1799,7 +1799,7 @@ const sendMessage = async () => {
   const optimisticMessageId = optimisticMessage.id
   rememberOptimisticAttachments(optimisticMessageId, submittedAttachments)
   messages.value = [...messages.value, optimisticMessage]
-  markAwaitingAssistantOutput(true)
+  markAwaitingAssistantOutput(shouldAwaitAssistantOutput(submissionMethod))
   let startedLiveStream: LiveStream | null = null
   let executedSubmissionMethod = submissionMethod
 

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -18,14 +18,14 @@ import { useChatSession, type LiveStream, type SubagentPanelState } from '../com
 import { useProjects } from '../composables/useProjects'
 import { useRpc } from '../composables/useRpc'
 import { useChatSubmitGuard } from '../composables/useChatSubmitGuard'
+import { resolveThreadSummaryTitle, useThreadSummaries } from '../composables/useThreadSummaries'
+import { resolveChatMessagesStatus } from '../utils/chat-messages-status'
 import {
-  hideThinkingPlaceholder,
   ITEM_PART,
   eventToMessage,
   isSubagentActiveStatus,
   itemToMessages,
   replaceStreamingMessage,
-  showThinkingPlaceholder,
   threadToMessages,
   upsertStreamingMessage,
   type ChatMessage,
@@ -38,7 +38,9 @@ import { buildTurnStartInput, type PersistedProjectAttachment } from '~~/shared/
 import {
   type ConfigReadResponse,
   type ModelListResponse,
+  notificationThreadName,
   notificationThreadId,
+  notificationThreadUpdatedAt,
   notificationTurnId,
   type CodexRpcNotification,
   type CodexThread,
@@ -108,6 +110,7 @@ const input = ref('')
 const scrollViewport = ref<HTMLElement | null>(null)
 const pinnedToBottom = ref(true)
 const session = useChatSession(props.projectId)
+const { syncThreadSummary, updateThreadSummaryTitle } = useThreadSummaries(props.projectId)
 const {
   messages,
   subagentPanels,
@@ -131,6 +134,7 @@ const selectedProject = computed(() => getProject(props.projectId))
 const composerError = computed(() => attachmentError.value ?? error.value)
 const submitError = computed(() => composerError.value ? new Error(composerError.value) : undefined)
 const interruptRequested = ref(false)
+const awaitingAssistantOutput = ref(false)
 const isBusy = computed(() =>
   status.value === 'submitted'
   || status.value === 'streaming'
@@ -152,6 +156,9 @@ const promptSubmitStatus = computed(() =>
 )
 const routeThreadId = computed(() => props.threadId ?? null)
 const projectTitle = computed(() => selectedProject.value?.projectId ?? props.projectId)
+const chatMessagesStatus = computed(() =>
+  resolveChatMessagesStatus(status.value, awaitingAssistantOutput.value)
+)
 const showWelcomeState = computed(() =>
   !routeThreadId.value
   && !activeThreadId.value
@@ -540,17 +547,13 @@ const removeOptimisticMessage = (messageId: string) => {
   optimisticAttachmentSnapshots.delete(messageId)
 }
 
-const clearThinkingPlaceholder = () => {
-  messages.value = hideThinkingPlaceholder(messages.value)
+const markAwaitingAssistantOutput = (nextValue: boolean) => {
+  awaitingAssistantOutput.value = nextValue
 }
 
-const ensureThinkingPlaceholder = () => {
-  messages.value = showThinkingPlaceholder(messages.value)
-}
-
-const clearThinkingPlaceholderForVisibleItem = (item: CodexThreadItem) => {
+const markAssistantOutputStartedForItem = (item: CodexThreadItem) => {
   if (item.type !== 'userMessage') {
-    clearThinkingPlaceholder()
+    markAwaitingAssistantOutput(false)
   }
 }
 
@@ -643,11 +646,6 @@ const submitTurnStart = async (input: {
   tokenUsage.value = null
   setLiveStreamTurnId(liveStream, turnStart.turn.id)
   replayBufferedNotifications(liveStream)
-}
-
-const resolveThreadTitle = (thread: { name: string | null, preview: string, id: string }) => {
-  const nextTitle = thread.name?.trim() || thread.preview.trim()
-  return nextTitle || `Thread ${thread.id}`
 }
 
 const shortThreadId = (value: string) => value.slice(0, 8)
@@ -838,9 +836,11 @@ const hydrateThread = async (threadId: string) => {
         (resumeResponse.reasoningEffort as ReasoningEffort | null | undefined) ?? null
       )
       activeThreadId.value = response.thread.id
-      threadTitle.value = resolveThreadTitle(response.thread)
+      threadTitle.value = resolveThreadSummaryTitle(response.thread)
+      syncThreadSummary(response.thread)
       messages.value = threadToMessages(response.thread)
       rebuildSubagentPanelsFromThread(response.thread)
+      markAwaitingAssistantOutput(false)
       const activeTurn = [...response.thread.turns].reverse().find(turn => isActiveTurnStatus(turn.status))
 
       if (!activeTurn) {
@@ -895,6 +895,7 @@ const resetDraftThread = () => {
   subagentPanels.value = []
   error.value = null
   tokenUsage.value = null
+  markAwaitingAssistantOutput(false)
   status.value = 'ready'
 }
 
@@ -916,7 +917,8 @@ const ensureThread = async () => {
   })
 
   activeThreadId.value = response.thread.id
-  threadTitle.value = resolveThreadTitle(response.thread)
+  threadTitle.value = resolveThreadSummaryTitle(response.thread)
+  syncThreadSummary(response.thread)
   return {
     threadId: response.thread.id,
     created: true
@@ -1503,6 +1505,24 @@ const applyNotification = (notification: CodexRpcNotification) => {
       pendingThreadId.value = pendingThreadId.value ?? nextThreadId
       return
     }
+    case 'thread/name/updated': {
+      const nextThreadId = notificationThreadId(notification)
+      const nextThreadName = notificationThreadName(notification)
+      if (!nextThreadId || !nextThreadName) {
+        return
+      }
+      const nextTitle = nextThreadName.trim()
+      if (!nextTitle) {
+        return
+      }
+
+      if (activeThreadId.value === nextThreadId) {
+        threadTitle.value = nextTitle
+      }
+
+      updateThreadSummaryTitle(nextThreadId, nextTitle, notificationThreadUpdatedAt(notification))
+      return
+    }
     case 'turn/started': {
       if (liveStream) {
         setLiveStreamTurnId(liveStream, notificationTurnId(notification))
@@ -1532,7 +1552,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
         status.value = 'streaming'
         return
       }
-      clearThinkingPlaceholderForVisibleItem(params.item)
+      markAssistantOutputStartedForItem(params.item)
       seedStreamingMessage(params.item)
       status.value = 'streaming'
       return
@@ -1542,7 +1562,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
       if (params.item.type === 'collabAgentToolCall') {
         applySubagentActivityItem(params.item)
       }
-      clearThinkingPlaceholderForVisibleItem(params.item)
+      markAssistantOutputStartedForItem(params.item)
       for (const nextMessage of itemToMessages(params.item)) {
         const confirmedMessage = {
           ...nextMessage,
@@ -1559,7 +1579,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
     }
     case 'item/agentMessage/delta': {
       const params = notification.params as { itemId: string, delta: string }
-      clearThinkingPlaceholder()
+      markAwaitingAssistantOutput(false)
       appendTextPartDelta(params.itemId, params.delta, {
         id: params.itemId,
         role: 'assistant',
@@ -1575,7 +1595,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
     }
     case 'item/plan/delta': {
       const params = notification.params as { itemId: string, delta: string }
-      clearThinkingPlaceholder()
+      markAwaitingAssistantOutput(false)
       appendTextPartDelta(params.itemId, params.delta, {
         id: params.itemId,
         role: 'assistant',
@@ -1592,7 +1612,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
     case 'item/reasoning/textDelta':
     case 'item/reasoning/summaryTextDelta': {
       const params = notification.params as { itemId: string, delta: string }
-      clearThinkingPlaceholder()
+      markAwaitingAssistantOutput(false)
       updateMessage(params.itemId, {
         id: params.itemId,
         role: 'assistant',
@@ -1700,7 +1720,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
     case 'error': {
       const params = notification.params as { error?: { message?: string } }
       const messageText = params.error?.message ?? 'The stream failed.'
-      clearThinkingPlaceholder()
+      markAwaitingAssistantOutput(false)
       pushEventMessage('stream.error', messageText)
       clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
       clearLiveStream(new Error(messageText))
@@ -1711,7 +1731,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
     case 'turn/failed': {
       const params = notification.params as { error?: { message?: string } }
       const messageText = params.error?.message ?? 'The turn failed.'
-      clearThinkingPlaceholder()
+      markAwaitingAssistantOutput(false)
       pushEventMessage('turn.failed', messageText)
       clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
       clearLiveStream(new Error(messageText))
@@ -1722,7 +1742,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
     case 'stream/error': {
       const params = notification.params as { message?: string }
       const messageText = params.message ?? 'The stream failed.'
-      clearThinkingPlaceholder()
+      markAwaitingAssistantOutput(false)
       pushEventMessage('stream.error', messageText)
       clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
       clearLiveStream(new Error(messageText))
@@ -1731,7 +1751,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
       return
     }
     case 'turn/completed': {
-      clearThinkingPlaceholder()
+      markAwaitingAssistantOutput(false)
       clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
       error.value = null
       status.value = 'ready'
@@ -1779,7 +1799,7 @@ const sendMessage = async () => {
   const optimisticMessageId = optimisticMessage.id
   rememberOptimisticAttachments(optimisticMessageId, submittedAttachments)
   messages.value = [...messages.value, optimisticMessage]
-  ensureThinkingPlaceholder()
+  markAwaitingAssistantOutput(true)
   let startedLiveStream: LiveStream | null = null
   let executedSubmissionMethod = submissionMethod
 
@@ -1839,7 +1859,7 @@ const sendMessage = async () => {
   } catch (caughtError) {
     const messageText = caughtError instanceof Error ? caughtError.message : String(caughtError)
 
-    clearThinkingPlaceholder()
+    markAwaitingAssistantOutput(false)
     untrackPendingUserMessage(optimisticMessageId)
     removeOptimisticMessage(optimisticMessageId)
 
@@ -2031,7 +2051,7 @@ watch([selectedModel, availableModels], () => {
       <UChatMessages
         v-else
         :messages="messages"
-        :status="status"
+        :status="chatMessagesStatus"
         :should-auto-scroll="false"
         :should-scroll-to-bottom="false"
         :auto-scroll="false"
@@ -2055,6 +2075,21 @@ watch([selectedModel, availableModels], () => {
             :message="message as ChatMessage"
             :project-id="projectId"
           />
+        </template>
+        <template #indicator>
+          <div
+            v-if="awaitingAssistantOutput"
+            class="flex items-center gap-3 px-1 py-2 text-sm text-muted"
+          >
+            <UIcon
+              name="i-lucide-loader-circle"
+              class="size-4 animate-spin text-primary"
+            />
+            <div class="flex flex-col gap-1">
+              <UChatShimmer text="Waiting for response…" />
+              <span class="text-xs text-toned">Real reasoning will appear separately when streaming starts.</span>
+            </div>
+          </div>
         </template>
       </UChatMessages>
     </div>

--- a/packages/client/app/components/ProjectSidebar.vue
+++ b/packages/client/app/components/ProjectSidebar.vue
@@ -3,6 +3,7 @@ import type { NavigationMenuItem } from '@nuxt/ui'
 import { useRoute } from '#imports'
 import { computed, onMounted } from 'vue'
 import { useProjects } from '../composables/useProjects'
+import { sortSidebarProjects } from '../utils/project-sidebar-order'
 import { toProjectRoute } from '~~/shared/codori'
 
 const props = defineProps<{
@@ -38,7 +39,7 @@ onMounted(() => {
 })
 
 const projectItems = computed<ProjectNavigationItem[][]>(() => [
-  projects.value.map(project => ({
+  sortSidebarProjects(projects.value, activeProjectId.value).map(project => ({
     label: project.projectId,
     icon: 'i-lucide-folder-git-2',
     to: toProjectRoute(project.projectId),

--- a/packages/client/app/components/ThreadList.vue
+++ b/packages/client/app/components/ThreadList.vue
@@ -1,10 +1,15 @@
 <script setup lang="ts">
 import type { NavigationMenuItem } from '@nuxt/ui'
 import { useRoute } from '#imports'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, watch } from 'vue'
 import { useProjects } from '../composables/useProjects'
 import { useRpc } from '../composables/useRpc'
 import { useThreadPanel } from '../composables/useThreadPanel'
+import {
+  resolveThreadSummaryTitle,
+  useThreadSummaries,
+  type ThreadSummary
+} from '../composables/useThreadSummaries'
 import type { ThreadListResponse } from '~~/shared/codex-rpc'
 import { toProjectThreadRoute } from '~~/shared/codori'
 
@@ -12,12 +17,6 @@ const props = defineProps<{
   projectId: string | null
   autoCloseOnSelect?: boolean
 }>()
-
-type ThreadSummary = {
-  id: string
-  title: string
-  updatedAt: number
-}
 
 type ThreadNavigationItem = NavigationMenuItem & {
   updatedAt: number
@@ -27,20 +26,21 @@ const route = useRoute()
 const { loaded, refreshProjects, startProject, getProject } = useProjects()
 const { getClient } = useRpc()
 const { closePanel } = useThreadPanel()
-
-const threads = ref<ThreadSummary[]>([])
-const loading = ref(false)
-const error = ref<string | null>(null)
+const currentThreadSummaries = () => useThreadSummaries(props.projectId ?? '__missing-project__')
+const threads = computed(() => currentThreadSummaries().threads.value)
+const loading = computed(() => currentThreadSummaries().loading.value)
+const error = computed(() => currentThreadSummaries().error.value)
 
 const project = computed(() => getProject(props.projectId))
 
 const fetchThreads = async () => {
-  if (!props.projectId || loading.value) {
+  const threadSummaries = currentThreadSummaries()
+  if (!props.projectId || threadSummaries.loading.value) {
     return
   }
 
-  loading.value = true
-  error.value = null
+  threadSummaries.setLoading(true)
+  threadSummaries.setError(null)
 
   try {
     if (!loaded.value) {
@@ -57,17 +57,17 @@ const fetchThreads = async () => {
       cwd: project.value?.projectPath ?? null
     })
 
-    threads.value = response.data
+    threadSummaries.setThreads(response.data
       .map(thread => ({
         id: thread.id,
-        title: (thread.name ?? thread.preview.trim()) || thread.id,
+        title: resolveThreadSummaryTitle(thread),
         updatedAt: thread.updatedAt
       }))
-      .sort((left, right) => right.updatedAt - left.updatedAt)
+    )
   } catch (caughtError) {
-    error.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
+    threadSummaries.setError(caughtError instanceof Error ? caughtError.message : String(caughtError))
   } finally {
-    loading.value = false
+    threadSummaries.setLoading(false)
   }
 }
 const activeThreadId = computed(() => {
@@ -80,7 +80,7 @@ const threadItems = computed<ThreadNavigationItem[][]>(() => {
     return [[]]
   }
 
-  return [threads.value.map(thread => ({
+  return [threads.value.map((thread: ThreadSummary) => ({
     label: thread.title,
     icon: 'i-lucide-message-square-text',
     to: toProjectThreadRoute(props.projectId!, thread.id),
@@ -104,7 +104,7 @@ onMounted(() => {
 })
 
 watch(() => props.projectId, () => {
-  threads.value = []
+  currentThreadSummaries().setThreads([])
   void fetchThreads()
 }, { immediate: true })
 

--- a/packages/client/app/composables/useThreadSummaries.ts
+++ b/packages/client/app/composables/useThreadSummaries.ts
@@ -1,0 +1,99 @@
+import { ref, type Ref } from 'vue'
+import type { CodexThread } from '~~/shared/codex-rpc'
+
+export type ThreadSummary = {
+  id: string
+  title: string
+  updatedAt: number
+}
+
+type ThreadSummariesState = {
+  threads: Ref<ThreadSummary[]>
+  loading: Ref<boolean>
+  error: Ref<string | null>
+}
+
+type UseThreadSummariesResult = ThreadSummariesState & {
+  setThreads: (nextThreads: ThreadSummary[]) => void
+  setLoading: (nextLoading: boolean) => void
+  setError: (nextError: string | null) => void
+  syncThreadSummary: (thread: Pick<CodexThread, 'id' | 'name' | 'preview' | 'updatedAt'>) => void
+  updateThreadSummaryTitle: (threadId: string, title: string, updatedAt?: number) => void
+}
+
+const states = new Map<string, ThreadSummariesState>()
+
+export const resolveThreadSummaryTitle = (thread: Pick<CodexThread, 'id' | 'name' | 'preview'>) => {
+  const nextTitle = thread.name?.trim() || thread.preview.trim()
+  return nextTitle || `Thread ${thread.id}`
+}
+
+export const mergeThreadSummary = (threads: ThreadSummary[], nextThread: ThreadSummary) => {
+  const filtered = threads.filter(thread => thread.id !== nextThread.id)
+  return [...filtered, nextThread].sort((left, right) => right.updatedAt - left.updatedAt)
+}
+
+export const renameThreadSummary = (
+  threads: ThreadSummary[],
+  input: {
+    threadId: string
+    title: string
+    updatedAt?: number
+  }
+) => {
+  const nextTitle = input.title.trim()
+  if (!nextTitle) {
+    return threads
+  }
+
+  const existing = threads.find(thread => thread.id === input.threadId)
+  return mergeThreadSummary(threads, {
+    id: input.threadId,
+    title: nextTitle,
+    updatedAt: input.updatedAt ?? existing?.updatedAt ?? Date.now()
+  })
+}
+
+const createState = (): ThreadSummariesState => ({
+  threads: ref<ThreadSummary[]>([]),
+  loading: ref(false),
+  error: ref<string | null>(null)
+})
+
+const createApi = (state: ThreadSummariesState): UseThreadSummariesResult => ({
+  ...state,
+  setThreads: (nextThreads: ThreadSummary[]) => {
+    state.threads.value = [...nextThreads].sort((left, right) => right.updatedAt - left.updatedAt)
+  },
+  setLoading: (nextLoading: boolean) => {
+    state.loading.value = nextLoading
+  },
+  setError: (nextError: string | null) => {
+    state.error.value = nextError
+  },
+  syncThreadSummary: (thread: Pick<CodexThread, 'id' | 'name' | 'preview' | 'updatedAt'>) => {
+    state.threads.value = mergeThreadSummary(state.threads.value, {
+      id: thread.id,
+      title: resolveThreadSummaryTitle(thread),
+      updatedAt: thread.updatedAt
+    })
+  },
+  updateThreadSummaryTitle: (threadId: string, title: string, updatedAt?: number) => {
+    state.threads.value = renameThreadSummary(state.threads.value, {
+      threadId,
+      title,
+      updatedAt
+    })
+  }
+})
+
+export const useThreadSummaries = (projectId: string): UseThreadSummariesResult => {
+  const existing = states.get(projectId)
+  if (existing) {
+    return createApi(existing)
+  }
+
+  const state = createState()
+  states.set(projectId, state)
+  return createApi(state)
+}

--- a/packages/client/app/utils/chat-messages-status.ts
+++ b/packages/client/app/utils/chat-messages-status.ts
@@ -1,5 +1,9 @@
 import type { ChatStatus } from '../composables/useChatSession'
 
+export const shouldAwaitAssistantOutput = (
+  submissionMethod: 'turn/start' | 'turn/steer'
+) => submissionMethod === 'turn/start'
+
 export const resolveChatMessagesStatus = (
   status: ChatStatus,
   awaitingAssistantOutput: boolean

--- a/packages/client/app/utils/chat-messages-status.ts
+++ b/packages/client/app/utils/chat-messages-status.ts
@@ -1,0 +1,12 @@
+import type { ChatStatus } from '../composables/useChatSession'
+
+export const resolveChatMessagesStatus = (
+  status: ChatStatus,
+  awaitingAssistantOutput: boolean
+): ChatStatus => {
+  if (status === 'ready' || status === 'error') {
+    return status
+  }
+
+  return awaitingAssistantOutput ? 'submitted' : 'streaming'
+}

--- a/packages/client/app/utils/project-sidebar-order.ts
+++ b/packages/client/app/utils/project-sidebar-order.ts
@@ -16,5 +16,9 @@ export const sortSidebarProjects = <T extends { projectId: string }>(
   }
 
   const [activeProject] = alphabeticalProjects.splice(activeIndex, 1)
+  if (!activeProject) {
+    return alphabeticalProjects
+  }
+
   return [activeProject, ...alphabeticalProjects]
 }

--- a/packages/client/app/utils/project-sidebar-order.ts
+++ b/packages/client/app/utils/project-sidebar-order.ts
@@ -1,0 +1,20 @@
+export const sortSidebarProjects = <T extends { projectId: string }>(
+  projects: T[],
+  activeProjectId: string | null
+) => {
+  const alphabeticalProjects = [...projects].sort((left, right) =>
+    left.projectId.localeCompare(right.projectId)
+  )
+
+  if (!activeProjectId) {
+    return alphabeticalProjects
+  }
+
+  const activeIndex = alphabeticalProjects.findIndex(project => project.projectId === activeProjectId)
+  if (activeIndex < 0) {
+    return alphabeticalProjects
+  }
+
+  const [activeProject] = alphabeticalProjects.splice(activeIndex, 1)
+  return [activeProject, ...alphabeticalProjects]
+}

--- a/packages/client/shared/codex-chat.ts
+++ b/packages/client/shared/codex-chat.ts
@@ -2,7 +2,6 @@ import type { CodexThread, CodexThreadItem, CodexUserInput } from './codex-rpc'
 
 export const EVENT_PART = 'data-thread-event' as const
 export const ITEM_PART = 'data-thread-item' as const
-export const THINKING_PLACEHOLDER_MESSAGE_ID = 'assistant-thinking-placeholder'
 
 export type ThreadEventData =
   | {
@@ -375,31 +374,5 @@ export const replaceStreamingMessage = (messages: ChatMessage[], nextMessage: Ch
   }
 
   nextMessages.splice(existingIndex, 1, normalizedMessage)
-  return nextMessages
-}
-
-export const buildThinkingPlaceholderMessage = (): ChatMessage => ({
-  id: THINKING_PLACEHOLDER_MESSAGE_ID,
-  role: 'assistant',
-  pending: true,
-  parts: [{
-    type: 'reasoning',
-    summary: ['Thinking...'],
-    content: [],
-    state: 'streaming'
-  }]
-})
-
-export const showThinkingPlaceholder = (messages: ChatMessage[]) =>
-  upsertStreamingMessage(messages, buildThinkingPlaceholderMessage())
-
-export const hideThinkingPlaceholder = (messages: ChatMessage[]) => {
-  const index = messages.findIndex(message => message.id === THINKING_PLACEHOLDER_MESSAGE_ID)
-  if (index === -1) {
-    return messages
-  }
-
-  const nextMessages = messages.slice()
-  nextMessages.splice(index, 1)
   return nextMessages
 }

--- a/packages/client/shared/codex-rpc.ts
+++ b/packages/client/shared/codex-rpc.ts
@@ -259,6 +259,22 @@ export const notificationTurnId = (notification: CodexRpcNotification) => {
   return null
 }
 
+export const notificationThreadName = (notification: CodexRpcNotification) => {
+  const params = isObjectRecord(notification.params) ? notification.params : null
+  const thread = isObjectRecord(params?.thread) ? params.thread : null
+  const directName = thread?.name ?? params?.name ?? params?.title
+
+  return typeof directName === 'string' ? directName : null
+}
+
+export const notificationThreadUpdatedAt = (notification: CodexRpcNotification) => {
+  const params = isObjectRecord(notification.params) ? notification.params : null
+  const thread = isObjectRecord(params?.thread) ? params.thread : null
+  const directUpdatedAt = thread?.updatedAt ?? params?.updatedAt
+
+  return typeof directUpdatedAt === 'number' ? directUpdatedAt : undefined
+}
+
 export class CodexRpcClient {
   private readonly url: string
 

--- a/packages/client/test/chat-transcript.test.ts
+++ b/packages/client/test/chat-transcript.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
-  hideThinkingPlaceholder,
   replaceStreamingMessage,
-  showThinkingPlaceholder,
   upsertStreamingMessage,
   type ChatMessage
 } from '../shared/codex-chat'
+import { mergeThreadSummary, renameThreadSummary } from '../app/composables/useThreadSummaries'
+import { resolveChatMessagesStatus } from '../app/utils/chat-messages-status'
 
 describe('chat transcript stability', () => {
   it('replaces a streamed text message with the completed server payload', () => {
@@ -82,84 +82,54 @@ describe('chat transcript stability', () => {
     }])
   })
 
-  it('adds a single thinking placeholder while the assistant has not produced content yet', () => {
-    const withPlaceholder = showThinkingPlaceholder([{
-      id: 'user-1',
-      role: 'user',
-      pending: false,
-      parts: [{
-        type: 'text',
-        text: 'Investigate the bug.',
-        state: 'done'
-      }]
-    }])
-
-    expect(showThinkingPlaceholder(withPlaceholder)).toEqual(withPlaceholder)
-    expect(withPlaceholder.at(-1)).toEqual<ChatMessage>({
-      id: 'assistant-thinking-placeholder',
-      role: 'assistant',
-      pending: true,
-      parts: [{
-        type: 'reasoning',
-        summary: ['Thinking...'],
-        content: [],
-        state: 'streaming'
-      }]
-    })
+  it('keeps chat loading state in submitted mode until real assistant output appears', () => {
+    expect(resolveChatMessagesStatus('submitted', true)).toBe('submitted')
+    expect(resolveChatMessagesStatus('streaming', true)).toBe('submitted')
+    expect(resolveChatMessagesStatus('streaming', false)).toBe('streaming')
+    expect(resolveChatMessagesStatus('ready', true)).toBe('ready')
   })
 
-  it('removes the thinking placeholder once real assistant content starts', () => {
-    expect(hideThinkingPlaceholder(showThinkingPlaceholder([{
-      id: 'user-1',
-      role: 'user',
-      pending: false,
-      parts: [{
-        type: 'text',
-        text: 'Investigate the bug.',
-        state: 'done'
-      }]
+  it('updates cached thread summaries in place when a live title arrives', () => {
+    expect(renameThreadSummary([{
+      id: 'thread-1',
+      title: 'Thread abc123',
+      updatedAt: 1
     }, {
-      id: 'agent-1',
-      role: 'assistant',
-      pending: true,
-      parts: [{
-        type: 'text',
-        text: 'Looking into it',
-        state: 'streaming'
-      }]
-    }]))).toEqual<ChatMessage[]>([{
-      id: 'user-1',
-      role: 'user',
-      pending: false,
-      parts: [{
-        type: 'text',
-        text: 'Investigate the bug.',
-        state: 'done'
-      }]
+      id: 'thread-2',
+      title: 'Older thread',
+      updatedAt: 0
+    }], {
+      threadId: 'thread-1',
+      title: 'Investigate optimistic submit bug',
+      updatedAt: 2
+    })).toEqual([{
+      id: 'thread-1',
+      title: 'Investigate optimistic submit bug',
+      updatedAt: 2
     }, {
-      id: 'agent-1',
-      role: 'assistant',
-      pending: true,
-      parts: [{
-        type: 'text',
-        text: 'Looking into it',
-        state: 'streaming'
-      }]
+      id: 'thread-2',
+      title: 'Older thread',
+      updatedAt: 0
     }])
   })
 
-  it('returns the original message array when no thinking placeholder is present', () => {
-    const messages: ChatMessage[] = [{
-      id: 'agent-1',
-      role: 'assistant',
-      pending: true,
-      parts: [{
-        type: 'text',
-        text: 'Working on it',
-        state: 'streaming'
-      }]
-    }]
-
-    expect(hideThinkingPlaceholder(messages)).toBe(messages)
+  it('keeps thread summaries ordered by recency when inserting new threads', () => {
+    expect(mergeThreadSummary([{
+      id: 'thread-1',
+      title: 'Existing thread',
+      updatedAt: 1
+    }], {
+      id: 'thread-2',
+      title: 'Newest thread',
+      updatedAt: 3
+    })).toEqual([{
+      id: 'thread-2',
+      title: 'Newest thread',
+      updatedAt: 3
+    }, {
+      id: 'thread-1',
+      title: 'Existing thread',
+      updatedAt: 1
+    }])
   })
 })

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -10,7 +10,7 @@ import {
   shouldRetrySteerWithTurnStart,
   shouldIgnoreNotificationAfterInterrupt
 } from '../app/utils/chat-turn-engagement'
-import { resolveChatMessagesStatus } from '../app/utils/chat-messages-status'
+import { resolveChatMessagesStatus, shouldAwaitAssistantOutput } from '../app/utils/chat-messages-status'
 import {
   ITEM_PART,
   isSubagentActiveStatus,
@@ -96,6 +96,8 @@ describe('client package', () => {
   it('keeps waiting indicators separate from transcript streaming state', () => {
     expect(resolveChatMessagesStatus('submitted', true)).toBe('submitted')
     expect(resolveChatMessagesStatus('streaming', false)).toBe('streaming')
+    expect(shouldAwaitAssistantOutput('turn/start')).toBe(true)
+    expect(shouldAwaitAssistantOutput('turn/steer')).toBe(false)
   })
 
   it('resolves standalone proxy mode and websocket protocol correctly', () => {

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -10,6 +10,7 @@ import {
   shouldRetrySteerWithTurnStart,
   shouldIgnoreNotificationAfterInterrupt
 } from '../app/utils/chat-turn-engagement'
+import { resolveChatMessagesStatus } from '../app/utils/chat-messages-status'
 import {
   ITEM_PART,
   isSubagentActiveStatus,
@@ -90,6 +91,11 @@ describe('client package', () => {
       'beta-web',
       'gamma-worker'
     ])
+  })
+
+  it('keeps waiting indicators separate from transcript streaming state', () => {
+    expect(resolveChatMessagesStatus('submitted', true)).toBe('submitted')
+    expect(resolveChatMessagesStatus('streaming', false)).toBe('streaming')
   })
 
   it('resolves standalone proxy mode and websocket protocol correctly', () => {

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -48,6 +48,7 @@ import {
   toProjectRoute,
   toProjectThreadRoute
 } from '../shared/codori'
+import { sortSidebarProjects } from '../app/utils/project-sidebar-order'
 import { resolveApiUrl, resolveWsBase, shouldUseServerProxy } from '../shared/network'
 
 describe('client package', () => {
@@ -63,6 +64,32 @@ describe('client package', () => {
       color: 'success',
       label: 'Running'
     })
+  })
+
+  it('orders the active project first while preserving alphabetical order for the rest', () => {
+    expect(sortSidebarProjects([
+      { projectId: 'gamma-worker' },
+      { projectId: 'alpha-api' },
+      { projectId: 'zeta-service' },
+      { projectId: 'beta-web' }
+    ], 'zeta-service').map(project => project.projectId)).toEqual([
+      'zeta-service',
+      'alpha-api',
+      'beta-web',
+      'gamma-worker'
+    ])
+  })
+
+  it('keeps alphabetical order when no active project is present', () => {
+    expect(sortSidebarProjects([
+      { projectId: 'gamma-worker' },
+      { projectId: 'alpha-api' },
+      { projectId: 'beta-web' }
+    ], null).map(project => project.projectId)).toEqual([
+      'alpha-api',
+      'beta-web',
+      'gamma-worker'
+    ])
   })
 
   it('resolves standalone proxy mode and websocket protocol correctly', () => {


### PR DESCRIPTION
## Summary
- pin the active project to the top of the sidebar while keeping the remaining projects alphabetically ordered
- update active thread titles and cached thread list labels immediately when `thread/name/updated` arrives
- move the generic waiting indicator out of the transcript and render it through `UChatMessages` while keeping real reasoning items unchanged

## Commits
- `2bb69fc` feat: pin active project to top of sidebar
- `c4c1026` feat: sync live thread titles and chat loading state

## Verification
- `pnpm --dir packages/client exec vitest run test/chat-transcript.test.ts test/smoke.test.ts`
- `pnpm --dir packages/client typecheck`
- `pnpm --dir packages/client lint`

Closes #16
Closes #24
Closes #25
