### PR TITLE
fix: determine steer submission correctly

### DIFF
--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -8,6 +8,7 @@ import {
   removePendingUserMessageId,
   resolvePromptSubmitStatus,
   resolveTurnSubmissionMethod,
+  shouldApplyNotificationToCurrentTurn,
   shouldSubmitViaTurnSteer,
   shouldAwaitThreadHydration,
   shouldRetrySteerWithTurnStart,
@@ -467,7 +468,11 @@ const ensurePendingLiveStream = async () => {
       }
 
       const turnId = notificationTurnId(notification)
-      if (turnId && turnId !== liveStream.turnId) {
+      if (!shouldApplyNotificationToCurrentTurn({
+        liveStreamTurnId: liveStream.turnId,
+        notificationMethod: notification.method,
+        notificationTurnId: turnId
+      })) {
         return
       }
 
@@ -806,7 +811,11 @@ const hydrateThread = async (threadId: string) => {
           }
 
           const turnId = notificationTurnId(notification)
-          if (turnId && turnId !== nextLiveStream.turnId) {
+          if (!shouldApplyNotificationToCurrentTurn({
+            liveStreamTurnId: nextLiveStream.turnId,
+            notificationMethod: notification.method,
+            notificationTurnId: turnId
+          })) {
             return
           }
 

--- a/packages/client/app/utils/chat-turn-engagement.ts
+++ b/packages/client/app/utils/chat-turn-engagement.ts
@@ -31,9 +31,10 @@ export const shouldSubmitViaTurnSteer = (input: {
   liveStreamTurnId: string | null
   status: PromptSubmitStatus
 }) =>
-  input.activeThreadId !== null
-  && input.liveStreamThreadId === input.activeThreadId
-  && (input.liveStreamTurnId !== null || input.status === 'submitted' || input.status === 'streaming')
+  (input.activeThreadId !== null
+    && input.liveStreamThreadId === input.activeThreadId
+    && input.status === 'submitted')
+  || hasSteerableTurn(input)
 
 export const shouldAwaitThreadHydration = (input: {
   hasPendingThreadHydration: boolean
@@ -43,7 +44,17 @@ export const shouldAwaitThreadHydration = (input: {
   && input.routeThreadId !== null
 
 export const shouldRetrySteerWithTurnStart = (message: string) =>
-  /no active turn to steer/i.test(message)
+  /no active turn to steer|active turn is no longer available/i.test(message)
+
+export const shouldApplyNotificationToCurrentTurn = (input: {
+  liveStreamTurnId: string | null
+  notificationMethod: string
+  notificationTurnId: string | null
+}) =>
+  input.liveStreamTurnId === null
+  || input.notificationTurnId === null
+  || input.notificationTurnId === input.liveStreamTurnId
+  || input.notificationMethod === 'turn/started'
 
 export const resolvePromptSubmitStatus = (input: {
   status: PromptSubmitStatus

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -5,6 +5,7 @@ import {
   removePendingUserMessageId,
   resolvePromptSubmitStatus,
   resolveTurnSubmissionMethod,
+  shouldApplyNotificationToCurrentTurn,
   shouldSubmitViaTurnSteer,
   shouldAwaitThreadHydration,
   shouldRetrySteerWithTurnStart,
@@ -376,7 +377,7 @@ describe('client package', () => {
     })).toBe(false)
   })
 
-  it('routes follow-up sends through turn/steer while the current turn is still being submitted', () => {
+  it('uses turn/steer while the current thread is still being submitted', () => {
     expect(shouldSubmitViaTurnSteer({
       activeThreadId: 'thread-1',
       liveStreamThreadId: 'thread-1',
@@ -390,11 +391,39 @@ describe('client package', () => {
       liveStreamTurnId: null,
       status: 'ready'
     })).toBe(false)
+
+    expect(shouldSubmitViaTurnSteer({
+      activeThreadId: 'thread-1',
+      liveStreamThreadId: 'thread-1',
+      liveStreamTurnId: 'turn-1',
+      status: 'streaming'
+    })).toBe(true)
   })
 
-  it('retries with turn/start only for steer rejection messages from the server', () => {
+  it('retries with turn/start for steer rejection messages from the server', () => {
     expect(shouldRetrySteerWithTurnStart('no active turn to steer')).toBe(true)
-    expect(shouldRetrySteerWithTurnStart('The active turn is no longer available.')).toBe(false)
+    expect(shouldRetrySteerWithTurnStart('The active turn is no longer available.')).toBe(true)
+    expect(shouldRetrySteerWithTurnStart('permission denied')).toBe(false)
+  })
+
+  it('allows turn/started to advance the tracked turn id before later deltas arrive', () => {
+    expect(shouldApplyNotificationToCurrentTurn({
+      liveStreamTurnId: 'turn-1',
+      notificationMethod: 'turn/started',
+      notificationTurnId: 'turn-2'
+    })).toBe(true)
+
+    expect(shouldApplyNotificationToCurrentTurn({
+      liveStreamTurnId: 'turn-1',
+      notificationMethod: 'item/agentMessage/delta',
+      notificationTurnId: 'turn-2'
+    })).toBe(false)
+
+    expect(shouldApplyNotificationToCurrentTurn({
+      liveStreamTurnId: 'turn-1',
+      notificationMethod: 'item/agentMessage/delta',
+      notificationTurnId: 'turn-1'
+    })).toBe(true)
   })
 
   it('keeps the prompt submit button in send mode while a draft exists', () => {


### PR DESCRIPTION
## What changed
- restore steer submission while the current turn is still in the submitted state
- keep new turn-start notifications flowing so the client updates to the next turn id before filtering later deltas
- expand client regression coverage for steer fallback and turn-start routing

## Why it changed
Recent chat changes broke the boundary between `turn/start` and `turn/steer`. Follow-up messages sent before the current turn id was known could be misrouted, and steer responses could start server-side while the UI filtered out the new turn's stream.

## Impact
This restores the intended chat behavior for first-send startup, in-flight steering, and assistant stream rendering without duplicating user bubbles or leaking stale active-turn errors to the UI.

## Validation
- `pnpm --filter @codori/client test`
- `pnpm --filter @codori/client typecheck`
