### PR TITLE
Handle pending user input requests in chat workspace

### DIFF
--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -108,13 +108,6 @@ const {
   onDrop,
   uploadAttachments
 } = useChatAttachments(props.projectId)
-const {
-  pendingRequest,
-  hasPendingRequest,
-  handleServerRequest,
-  resolveCurrentRequest
-} = usePendingUserRequest(props.projectId)
-
 const input = ref('')
 const scrollViewport = ref<HTMLElement | null>(null)
 const pinnedToBottom = ref(true)
@@ -138,6 +131,12 @@ const {
   modelContextWindow,
   tokenUsage
 } = session
+const {
+  pendingRequest,
+  hasPendingRequest,
+  handleServerRequest,
+  resolveCurrentRequest
+} = usePendingUserRequest(props.projectId, activeThreadId)
 
 const selectedProject = computed(() => getProject(props.projectId))
 const composerError = computed(() => attachmentError.value ?? error.value)

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { useRouter } from '#imports'
-import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import MessageContent from './MessageContent.vue'
+import PendingUserRequestDrawer from './PendingUserRequestDrawer.vue'
 import {
   reconcileOptimisticUserMessage,
   removeChatMessage,
@@ -15,6 +16,7 @@ import {
   shouldIgnoreNotificationAfterInterrupt
 } from '../utils/chat-turn-engagement'
 import { useChatAttachments, type DraftAttachment } from '../composables/useChatAttachments'
+import { usePendingUserRequest } from '../composables/usePendingUserRequest'
 import { useChatSession, type LiveStream, type SubagentPanelState } from '../composables/useChatSession'
 import { useProjects } from '../composables/useProjects'
 import { useRpc } from '../composables/useRpc'
@@ -106,6 +108,12 @@ const {
   onDrop,
   uploadAttachments
 } = useChatAttachments(props.projectId)
+const {
+  pendingRequest,
+  hasPendingRequest,
+  handleServerRequest,
+  resolveCurrentRequest
+} = usePendingUserRequest(props.projectId)
 
 const input = ref('')
 const scrollViewport = ref<HTMLElement | null>(null)
@@ -149,6 +157,12 @@ const hasDraftContent = computed(() =>
 const isComposerDisabled = computed(() =>
   isUploading.value
   || interruptRequested.value
+  || hasPendingRequest.value
+)
+const composerPlaceholder = computed(() =>
+  hasPendingRequest.value
+    ? 'Respond to the pending request below to let Codex continue'
+    : 'Describe the change you want Codex to make'
 )
 const promptSubmitStatus = computed(() =>
   resolvePromptSubmitStatus({
@@ -316,6 +330,7 @@ const subagentBootstrapPromises = new Map<string, Promise<void>>()
 const optimisticAttachmentSnapshots = new Map<string, DraftAttachment[]>()
 let promptControlsPromise: Promise<void> | null = null
 let pendingThreadHydration: Promise<void> | null = null
+let releaseServerRequestHandler: (() => void) | null = null
 
 const isActiveTurnStatus = (value: string | null | undefined) => {
   if (!value) {
@@ -1774,7 +1789,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
 }
 
 const sendMessage = async () => {
-  if (sendMessageLocked.value) {
+  if (sendMessageLocked.value || hasPendingRequest.value) {
     return
   }
 
@@ -1933,12 +1948,17 @@ const stopActiveTurn = async () => {
 }
 
 const sendStarterPrompt = async (text: string) => {
-  if (isBusy.value) {
+  if (isBusy.value || hasPendingRequest.value) {
     return
   }
 
   input.value = text
   await sendMessage()
+}
+
+const respondToPendingRequest = (response: unknown) => {
+  error.value = null
+  resolveCurrentRequest(response)
 }
 
 const onPromptEnter = (event: KeyboardEvent) => {
@@ -1951,12 +1971,18 @@ const onPromptEnter = (event: KeyboardEvent) => {
 }
 
 onMounted(() => {
+  releaseServerRequestHandler = getClient(props.projectId).setServerRequestHandler(handleServerRequest)
   if (!loaded.value) {
     void refreshProjects()
   }
 
   void loadPromptControls()
   void scheduleScrollToBottom('auto')
+})
+
+onBeforeUnmount(() => {
+  releaseServerRequestHandler?.()
+  releaseServerRequestHandler = null
 })
 
 watch(() => props.threadId ?? null, (threadId) => {
@@ -2121,6 +2147,13 @@ watch([selectedModel, availableModels], () => {
         />
 
         <div
+          v-if="pendingRequest"
+          class="mb-3 rounded-2xl border border-primary/30 bg-primary/8 px-4 py-3 text-sm text-default"
+        >
+          Codex is waiting for the response in the drawer below. Normal chat sending is paused until you answer it.
+        </div>
+
+        <div
           class="relative"
           @dragenter="onDragEnter"
           @dragleave="onDragLeave"
@@ -2136,7 +2169,7 @@ watch([selectedModel, availableModels], () => {
 
           <UChatPrompt
             v-model="input"
-            placeholder="Describe the change you want Codex to make"
+            :placeholder="composerPlaceholder"
             :error="submitError"
             :disabled="isComposerDisabled"
             autoresize
@@ -2353,4 +2386,9 @@ watch([selectedModel, availableModels], () => {
       </div>
     </div>
   </section>
+
+  <PendingUserRequestDrawer
+    :request="pendingRequest"
+    @respond="respondToPendingRequest"
+  />
 </template>

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -135,7 +135,8 @@ const {
   pendingRequest,
   hasPendingRequest,
   handleServerRequest,
-  resolveCurrentRequest
+  resolveCurrentRequest,
+  cancelAllPendingRequests
 } = usePendingUserRequest(props.projectId, activeThreadId)
 
 const selectedProject = computed(() => getProject(props.projectId))
@@ -1980,6 +1981,7 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  cancelAllPendingRequests()
   releaseServerRequestHandler?.()
   releaseServerRequestHandler = null
 })

--- a/packages/client/app/components/PendingUserRequestDrawer.vue
+++ b/packages/client/app/components/PendingUserRequestDrawer.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import {
   buildMcpElicitationResponse,
+  buildPendingUserRequestDismissResponse,
   buildRequestUserInputResponse,
   type PendingUserRequest
 } from '../../shared/pending-user-request'
@@ -42,11 +43,11 @@ const description = computed(() => {
 })
 
 const handleOpenChange = (nextOpen: boolean) => {
-  if (nextOpen || !props.request || props.request.kind === 'requestUserInput') {
+  if (nextOpen || !props.request) {
     return
   }
 
-  emit('respond', buildMcpElicitationResponse('cancel'))
+  emit('respond', buildPendingUserRequestDismissResponse(props.request))
 }
 </script>
 

--- a/packages/client/app/components/PendingUserRequestDrawer.vue
+++ b/packages/client/app/components/PendingUserRequestDrawer.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import {
+  buildMcpElicitationResponse,
+  buildRequestUserInputResponse,
+  type PendingUserRequest
+} from '../../shared/pending-user-request'
+import McpElicitationForm from './pending-request/McpElicitationForm.vue'
+import McpElicitationUrlPrompt from './pending-request/McpElicitationUrlPrompt.vue'
+import RequestUserInputForm from './pending-request/RequestUserInputForm.vue'
+
+const props = defineProps<{
+  request: PendingUserRequest | null
+}>()
+
+const emit = defineEmits<{
+  respond: [response: unknown]
+}>()
+
+const title = computed(() => {
+  switch (props.request?.kind) {
+    case 'requestUserInput':
+      return 'Codex needs your input'
+    case 'mcpElicitationForm':
+      return 'Tool confirmation required'
+    case 'mcpElicitationUrl':
+      return 'Complete a browser step'
+    default:
+      return ''
+  }
+})
+
+const description = computed(() => {
+  switch (props.request?.kind) {
+    case 'requestUserInput':
+      return 'This reply will be sent back to the in-flight Codex request, not as a new chat message.'
+    case 'mcpElicitationForm':
+      return props.request.message ?? 'A connected MCP server asked for structured input.'
+    case 'mcpElicitationUrl':
+      return props.request.message ?? 'A connected MCP server asked you to finish a step outside the chat.'
+    default:
+      return ''
+  }
+})
+
+const handleOpenChange = (nextOpen: boolean) => {
+  if (nextOpen || !props.request || props.request.kind === 'requestUserInput') {
+    return
+  }
+
+  emit('respond', buildMcpElicitationResponse('cancel'))
+}
+</script>
+
+<template>
+  <UDrawer
+    :open="Boolean(request)"
+    direction="bottom"
+    :handle="true"
+    :ui="{
+      content: 'max-h-[88dvh] rounded-t-3xl',
+      container: 'gap-0 p-0',
+      header: 'px-4 pb-2 pt-4 md:px-6',
+      body: 'px-4 pb-5 pt-1 md:px-6',
+      footer: 'hidden'
+    }"
+    @update:open="handleOpenChange"
+  >
+    <template #header>
+      <div
+        v-if="request"
+        class="flex items-start justify-between gap-4"
+      >
+        <div class="space-y-1">
+          <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary">
+            Pending request
+          </p>
+          <h2 class="text-base font-semibold text-highlighted">
+            {{ title }}
+          </h2>
+          <p class="text-sm leading-6 text-muted">
+            {{ description }}
+          </p>
+        </div>
+      </div>
+    </template>
+
+    <template #body>
+      <RequestUserInputForm
+        v-if="request?.kind === 'requestUserInput'"
+        :request="request"
+        @submit="emit('respond', buildRequestUserInputResponse($event))"
+      />
+
+      <McpElicitationForm
+        v-else-if="request?.kind === 'mcpElicitationForm'"
+        :request="request"
+        @accept="emit('respond', buildMcpElicitationResponse('accept', $event))"
+        @decline="emit('respond', buildMcpElicitationResponse('decline'))"
+        @cancel="emit('respond', buildMcpElicitationResponse('cancel'))"
+      />
+
+      <McpElicitationUrlPrompt
+        v-else-if="request?.kind === 'mcpElicitationUrl'"
+        :request="request"
+        @accept="emit('respond', buildMcpElicitationResponse('accept'))"
+        @decline="emit('respond', buildMcpElicitationResponse('decline'))"
+        @cancel="emit('respond', buildMcpElicitationResponse('cancel'))"
+      />
+    </template>
+  </UDrawer>
+</template>

--- a/packages/client/app/components/PendingUserRequestDrawer.vue
+++ b/packages/client/app/components/PendingUserRequestDrawer.vue
@@ -56,11 +56,11 @@ const handleOpenChange = (nextOpen: boolean) => {
     direction="bottom"
     :handle="true"
     :ui="{
-      content: 'inset-x-auto right-auto bottom-0 left-1/2 w-[calc(100vw-0.75rem)] max-w-[52rem] -translate-x-1/2 rounded-t-2xl rounded-b-none border-x border-t border-default bg-default shadow-2xl md:w-[min(50vw,52rem)]',
+      content: 'inset-x-auto right-auto bottom-0 left-1/2 w-[90vw] max-w-[52rem] -translate-x-1/2 rounded-t-2xl rounded-b-none border-x border-t border-default bg-default shadow-2xl md:w-[min(50vw,52rem)]',
       container: 'gap-0 p-0',
       handle: 'mt-2 !h-1 !w-10 rounded-full',
       header: isRequestUserInput ? 'hidden' : 'px-4 pb-1 pt-3 md:px-5',
-      body: isRequestUserInput ? 'px-4 pb-4 pt-4 md:px-5' : 'px-4 pb-4 pt-2 md:px-5',
+      body: isRequestUserInput ? 'px-3 pb-3 pt-3 md:px-4 md:pb-4 md:pt-4' : 'px-4 pb-4 pt-2 md:px-5',
       footer: 'hidden'
     }"
     @update:open="handleOpenChange"

--- a/packages/client/app/components/PendingUserRequestDrawer.vue
+++ b/packages/client/app/components/PendingUserRequestDrawer.vue
@@ -17,10 +17,10 @@ const emit = defineEmits<{
   respond: [response: unknown]
 }>()
 
+const isRequestUserInput = computed(() => props.request?.kind === 'requestUserInput')
+
 const title = computed(() => {
   switch (props.request?.kind) {
-    case 'requestUserInput':
-      return 'Codex needs your input'
     case 'mcpElicitationForm':
       return 'Tool confirmation required'
     case 'mcpElicitationUrl':
@@ -32,8 +32,6 @@ const title = computed(() => {
 
 const description = computed(() => {
   switch (props.request?.kind) {
-    case 'requestUserInput':
-      return 'This reply will be sent back to the in-flight Codex request, not as a new chat message.'
     case 'mcpElicitationForm':
       return props.request.message ?? 'A connected MCP server asked for structured input.'
     case 'mcpElicitationUrl':
@@ -61,20 +59,17 @@ const handleOpenChange = (nextOpen: boolean) => {
       content: 'inset-x-auto right-auto bottom-0 left-1/2 w-[calc(100vw-0.75rem)] max-w-[52rem] -translate-x-1/2 rounded-t-2xl rounded-b-none border-x border-t border-default bg-default shadow-2xl md:w-[min(50vw,52rem)]',
       container: 'gap-0 p-0',
       handle: 'mt-2 !h-1 !w-10 rounded-full',
-      header: 'px-4 pb-1 pt-3 md:px-5',
-      body: 'px-4 pb-4 pt-2 md:px-5',
+      header: isRequestUserInput ? 'hidden' : 'px-4 pb-1 pt-3 md:px-5',
+      body: isRequestUserInput ? 'px-4 pb-4 pt-4 md:px-5' : 'px-4 pb-4 pt-2 md:px-5',
       footer: 'hidden'
     }"
     @update:open="handleOpenChange"
   >
     <template #header>
       <div
-        v-if="request"
+        v-if="request && !isRequestUserInput"
         class="space-y-1.5"
       >
-        <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary">
-          Pending request
-        </p>
         <h2 class="text-sm font-semibold text-highlighted md:text-base">
           {{ title }}
         </h2>
@@ -87,6 +82,7 @@ const handleOpenChange = (nextOpen: boolean) => {
     <template #body>
       <RequestUserInputForm
         v-if="request?.kind === 'requestUserInput'"
+        :key="request.requestId"
         :request="request"
         @submit="emit('respond', buildRequestUserInputResponse($event))"
       />

--- a/packages/client/app/components/PendingUserRequestDrawer.vue
+++ b/packages/client/app/components/PendingUserRequestDrawer.vue
@@ -89,6 +89,7 @@ const handleOpenChange = (nextOpen: boolean) => {
 
       <McpElicitationForm
         v-else-if="request?.kind === 'mcpElicitationForm'"
+        :key="request.requestId"
         :request="request"
         @accept="emit('respond', buildMcpElicitationResponse('accept', $event))"
         @decline="emit('respond', buildMcpElicitationResponse('decline'))"

--- a/packages/client/app/components/PendingUserRequestDrawer.vue
+++ b/packages/client/app/components/PendingUserRequestDrawer.vue
@@ -58,10 +58,11 @@ const handleOpenChange = (nextOpen: boolean) => {
     direction="bottom"
     :handle="true"
     :ui="{
-      content: 'max-h-[88dvh] rounded-t-3xl',
+      content: 'inset-x-auto right-auto bottom-0 left-1/2 w-[calc(100vw-0.75rem)] max-w-[52rem] -translate-x-1/2 rounded-t-2xl rounded-b-none border-x border-t border-default bg-default shadow-2xl md:w-[min(50vw,52rem)]',
       container: 'gap-0 p-0',
-      header: 'px-4 pb-2 pt-4 md:px-6',
-      body: 'px-4 pb-5 pt-1 md:px-6',
+      handle: 'mt-2 !h-1 !w-10 rounded-full',
+      header: 'px-4 pb-1 pt-3 md:px-5',
+      body: 'px-4 pb-4 pt-2 md:px-5',
       footer: 'hidden'
     }"
     @update:open="handleOpenChange"
@@ -69,19 +70,17 @@ const handleOpenChange = (nextOpen: boolean) => {
     <template #header>
       <div
         v-if="request"
-        class="flex items-start justify-between gap-4"
+        class="space-y-1.5"
       >
-        <div class="space-y-1">
-          <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary">
-            Pending request
-          </p>
-          <h2 class="text-base font-semibold text-highlighted">
-            {{ title }}
-          </h2>
-          <p class="text-sm leading-6 text-muted">
-            {{ description }}
-          </p>
-        </div>
+        <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary">
+          Pending request
+        </p>
+        <h2 class="text-sm font-semibold text-highlighted md:text-base">
+          {{ title }}
+        </h2>
+        <p class="text-sm leading-5 text-muted">
+          {{ description }}
+        </p>
       </div>
     </template>
 

--- a/packages/client/app/components/pending-request/McpElicitationForm.vue
+++ b/packages/client/app/components/pending-request/McpElicitationForm.vue
@@ -99,7 +99,9 @@ const buildContent = () => {
 
     switch (field.kind) {
       case 'boolean':
-        content[field.key] = rawValue === true
+        if (field.required || field.defaultValue === true || rawValue === true) {
+          content[field.key] = rawValue === true
+        }
         break
       case 'string': {
         const value = typeof rawValue === 'string' ? rawValue.trim() : ''

--- a/packages/client/app/components/pending-request/McpElicitationForm.vue
+++ b/packages/client/app/components/pending-request/McpElicitationForm.vue
@@ -145,60 +145,61 @@ const submit = () => {
 
 <template>
   <form
-    class="space-y-4"
+    class="space-y-3"
     @submit.prevent="submit"
   >
-    <section
+    <div
       v-for="field in request.fields"
       :key="field.key"
-      class="rounded-3xl border border-default bg-elevated/30 p-4"
+      class="rounded-lg border border-default/70 bg-elevated/20 p-3"
     >
-      <div class="space-y-1">
-        <h3 class="text-sm font-semibold text-highlighted">
-          {{ field.label }}
-        </h3>
-        <p
-          v-if="field.description"
-          class="text-sm text-muted"
-        >
-          {{ field.description }}
-        </p>
-      </div>
-
-      <div class="mt-4">
-        <textarea
-          v-if="field.kind === 'string' && (field.maxLength == null || field.maxLength > 120)"
+      <UFormField
+        :name="field.key"
+        :label="field.label"
+        :description="field.description ?? undefined"
+        :required="field.required"
+        :error="attemptedSubmit ? (resolveFieldError(field) ?? undefined) : undefined"
+        size="sm"
+        :ui="{
+          root: 'space-y-2',
+          container: 'mt-2',
+          label: 'text-sm font-semibold text-highlighted',
+          description: 'text-xs text-muted',
+          error: 'mt-2 text-xs font-medium text-error'
+        }"
+      >
+        <UInput
+          v-if="field.kind === 'string'"
           :id="`elicitation-field-${field.key}`"
-          :value="String(values[field.key] ?? '')"
-          rows="4"
-          class="min-h-28 w-full rounded-2xl border border-default bg-default px-3 py-2 text-sm text-default outline-none transition focus:border-primary/50"
-          @input="values[field.key] = ($event.target as HTMLTextAreaElement).value"
+          :model-value="String(values[field.key] ?? '')"
+          color="neutral"
+          variant="subtle"
+          size="sm"
+          class="w-full"
+          :type="field.format === 'email' ? 'email' : field.format === 'uri' ? 'url' : field.format === 'date' ? 'date' : field.format === 'date-time' ? 'datetime-local' : 'text'"
+          :ui="{ base: 'rounded-lg' }"
+          @update:model-value="values[field.key] = String($event ?? '')"
         />
 
-        <input
-          v-else-if="field.kind === 'string'"
-          :id="`elicitation-field-${field.key}`"
-          :value="String(values[field.key] ?? '')"
-          class="w-full rounded-2xl border border-default bg-default px-3 py-2 text-sm text-default outline-none transition focus:border-primary/50"
-          :type="field.format === 'email' ? 'email' : field.format === 'uri' ? 'url' : field.format === 'date' ? 'date' : field.format === 'date-time' ? 'datetime-local' : 'text'"
-          @input="values[field.key] = ($event.target as HTMLInputElement).value"
-        >
-
-        <input
+        <UInput
           v-else-if="field.kind === 'number'"
           :id="`elicitation-field-${field.key}`"
-          :value="String(values[field.key] ?? '')"
-          class="w-full rounded-2xl border border-default bg-default px-3 py-2 text-sm text-default outline-none transition focus:border-primary/50"
+          :model-value="String(values[field.key] ?? '')"
+          color="neutral"
+          variant="subtle"
+          size="sm"
+          class="w-full"
           :step="field.numericType === 'integer' ? '1' : 'any'"
           type="number"
-          @input="values[field.key] = ($event.target as HTMLInputElement).value"
-        >
+          :ui="{ base: 'rounded-lg' }"
+          @update:model-value="values[field.key] = String($event ?? '')"
+        />
 
         <select
           v-else-if="field.kind === 'enum'"
           :id="`elicitation-field-${field.key}`"
           :value="String(values[field.key] ?? '')"
-          class="w-full rounded-2xl border border-default bg-default px-3 py-2 text-sm text-default outline-none transition focus:border-primary/50"
+          class="w-full rounded-lg border border-default/70 bg-elevated px-3 py-2 text-sm text-default outline-none transition focus:border-primary/50"
           @change="values[field.key] = ($event.target as HTMLSelectElement).value"
         >
           <option value="">
@@ -215,7 +216,7 @@ const submit = () => {
 
         <label
           v-else
-          class="flex items-center gap-3 rounded-2xl border border-default bg-default px-3 py-2 text-sm text-default"
+          class="flex items-center gap-2 rounded-lg border border-default/70 bg-elevated px-3 py-2 text-sm text-default"
         >
           <input
             :checked="values[field.key] === true"
@@ -224,37 +225,38 @@ const submit = () => {
           >
           <span>Enabled</span>
         </label>
-      </div>
+      </UFormField>
+    </div>
 
-      <p
-        v-if="attemptedSubmit && resolveFieldError(field)"
-        class="mt-2 text-xs font-medium text-error"
-      >
-        {{ resolveFieldError(field) }}
-      </p>
-    </section>
-
-    <div class="flex flex-wrap items-center justify-end gap-2">
-      <button
+    <div class="flex flex-wrap items-center justify-end gap-2 pt-1">
+      <UButton
         type="button"
-        class="rounded-full border border-default px-4 py-2 text-sm font-medium text-default transition hover:border-error/40 hover:text-error"
+        color="error"
+        variant="ghost"
+        size="sm"
+        class="rounded-lg"
         @click="emit('decline')"
       >
         Decline
-      </button>
-      <button
+      </UButton>
+      <UButton
         type="button"
-        class="rounded-full border border-default px-4 py-2 text-sm font-medium text-default transition hover:border-default/80 hover:text-highlighted"
+        color="neutral"
+        variant="ghost"
+        size="sm"
+        class="rounded-lg"
         @click="emit('cancel')"
       >
         Cancel
-      </button>
-      <button
+      </UButton>
+      <UButton
         type="submit"
-        class="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-inverted transition"
+        color="primary"
+        size="sm"
+        class="rounded-lg"
       >
         Continue
-      </button>
+      </UButton>
     </div>
   </form>
 </template>

--- a/packages/client/app/components/pending-request/McpElicitationForm.vue
+++ b/packages/client/app/components/pending-request/McpElicitationForm.vue
@@ -1,0 +1,260 @@
+<script setup lang="ts">
+import { computed, reactive, ref } from 'vue'
+import type {
+  PendingElicitationField,
+  PendingElicitationEnumField,
+  PendingMcpElicitationForm
+} from '../../../shared/pending-user-request'
+
+const props = defineProps<{
+  request: PendingMcpElicitationForm
+}>()
+
+const emit = defineEmits<{
+  accept: [content: Record<string, string | number | boolean>]
+  decline: []
+  cancel: []
+}>()
+
+const attemptedSubmit = ref(false)
+const values = reactive<Record<string, string | boolean>>(
+  Object.fromEntries(props.request.fields.map((field) => {
+    switch (field.kind) {
+      case 'boolean':
+        return [field.key, field.defaultValue]
+      case 'number':
+        return [field.key, field.defaultValue == null ? '' : String(field.defaultValue)]
+      case 'enum':
+        return [field.key, field.defaultValue == null ? '' : String(field.defaultValue)]
+      case 'string':
+        return [field.key, field.defaultValue ?? '']
+    }
+  }))
+)
+
+const enumValueFromInput = (field: PendingElicitationEnumField, rawValue: string) => {
+  const match = field.options.find(option => String(option.value) === rawValue)
+  return match?.value ?? null
+}
+
+const resolveFieldError = (field: PendingElicitationField) => {
+  const rawValue = values[field.key]
+
+  switch (field.kind) {
+    case 'boolean':
+      return null
+    case 'string': {
+      const value = typeof rawValue === 'string' ? rawValue.trim() : ''
+      if (field.required && value.length === 0) {
+        return 'This field is required.'
+      }
+      if (field.minLength != null && value.length > 0 && value.length < field.minLength) {
+        return `Enter at least ${field.minLength} characters.`
+      }
+      if (field.maxLength != null && value.length > field.maxLength) {
+        return `Keep this under ${field.maxLength} characters.`
+      }
+      return null
+    }
+    case 'number': {
+      const value = typeof rawValue === 'string' ? rawValue.trim() : ''
+      if (value.length === 0) {
+        return field.required ? 'This field is required.' : null
+      }
+
+      const numericValue = Number(value)
+      if (!Number.isFinite(numericValue)) {
+        return 'Enter a valid number.'
+      }
+      if (field.numericType === 'integer' && !Number.isInteger(numericValue)) {
+        return 'Enter a whole number.'
+      }
+      if (field.minimum != null && numericValue < field.minimum) {
+        return `Enter a value greater than or equal to ${field.minimum}.`
+      }
+      if (field.maximum != null && numericValue > field.maximum) {
+        return `Enter a value less than or equal to ${field.maximum}.`
+      }
+      return null
+    }
+    case 'enum': {
+      const value = typeof rawValue === 'string' ? rawValue : ''
+      if (value.length === 0) {
+        return field.required ? 'Select a value.' : null
+      }
+      return enumValueFromInput(field, value) == null ? 'Select a valid value.' : null
+    }
+  }
+}
+
+const hasErrors = computed(() =>
+  props.request.fields.some(field => resolveFieldError(field) !== null)
+)
+
+const buildContent = () => {
+  const content: Record<string, string | number | boolean> = {}
+
+  for (const field of props.request.fields) {
+    const rawValue = values[field.key]
+
+    switch (field.kind) {
+      case 'boolean':
+        content[field.key] = rawValue === true
+        break
+      case 'string': {
+        const value = typeof rawValue === 'string' ? rawValue.trim() : ''
+        if (value.length > 0 || field.required) {
+          content[field.key] = value
+        }
+        break
+      }
+      case 'number': {
+        const value = typeof rawValue === 'string' ? rawValue.trim() : ''
+        if (value.length === 0) {
+          break
+        }
+        content[field.key] = Number(value)
+        break
+      }
+      case 'enum': {
+        const value = typeof rawValue === 'string' ? rawValue : ''
+        if (value.length === 0) {
+          break
+        }
+        const parsedValue = enumValueFromInput(field, value)
+        if (parsedValue != null) {
+          content[field.key] = parsedValue
+        }
+        break
+      }
+    }
+  }
+
+  return content
+}
+
+const submit = () => {
+  attemptedSubmit.value = true
+  if (hasErrors.value) {
+    return
+  }
+
+  emit('accept', buildContent())
+}
+</script>
+
+<template>
+  <form
+    class="space-y-4"
+    @submit.prevent="submit"
+  >
+    <section
+      v-for="field in request.fields"
+      :key="field.key"
+      class="rounded-3xl border border-default bg-elevated/30 p-4"
+    >
+      <div class="space-y-1">
+        <h3 class="text-sm font-semibold text-highlighted">
+          {{ field.label }}
+        </h3>
+        <p
+          v-if="field.description"
+          class="text-sm text-muted"
+        >
+          {{ field.description }}
+        </p>
+      </div>
+
+      <div class="mt-4">
+        <textarea
+          v-if="field.kind === 'string' && (field.maxLength == null || field.maxLength > 120)"
+          :id="`elicitation-field-${field.key}`"
+          :value="String(values[field.key] ?? '')"
+          rows="4"
+          class="min-h-28 w-full rounded-2xl border border-default bg-default px-3 py-2 text-sm text-default outline-none transition focus:border-primary/50"
+          @input="values[field.key] = ($event.target as HTMLTextAreaElement).value"
+        />
+
+        <input
+          v-else-if="field.kind === 'string'"
+          :id="`elicitation-field-${field.key}`"
+          :value="String(values[field.key] ?? '')"
+          class="w-full rounded-2xl border border-default bg-default px-3 py-2 text-sm text-default outline-none transition focus:border-primary/50"
+          :type="field.format === 'email' ? 'email' : field.format === 'uri' ? 'url' : field.format === 'date' ? 'date' : field.format === 'date-time' ? 'datetime-local' : 'text'"
+          @input="values[field.key] = ($event.target as HTMLInputElement).value"
+        >
+
+        <input
+          v-else-if="field.kind === 'number'"
+          :id="`elicitation-field-${field.key}`"
+          :value="String(values[field.key] ?? '')"
+          class="w-full rounded-2xl border border-default bg-default px-3 py-2 text-sm text-default outline-none transition focus:border-primary/50"
+          :step="field.numericType === 'integer' ? '1' : 'any'"
+          type="number"
+          @input="values[field.key] = ($event.target as HTMLInputElement).value"
+        >
+
+        <select
+          v-else-if="field.kind === 'enum'"
+          :id="`elicitation-field-${field.key}`"
+          :value="String(values[field.key] ?? '')"
+          class="w-full rounded-2xl border border-default bg-default px-3 py-2 text-sm text-default outline-none transition focus:border-primary/50"
+          @change="values[field.key] = ($event.target as HTMLSelectElement).value"
+        >
+          <option value="">
+            {{ field.required ? 'Select a value' : 'Leave blank' }}
+          </option>
+          <option
+            v-for="option in field.options"
+            :key="`${field.key}-${String(option.value)}`"
+            :value="String(option.value)"
+          >
+            {{ option.label }}
+          </option>
+        </select>
+
+        <label
+          v-else
+          class="flex items-center gap-3 rounded-2xl border border-default bg-default px-3 py-2 text-sm text-default"
+        >
+          <input
+            :checked="values[field.key] === true"
+            type="checkbox"
+            @change="values[field.key] = ($event.target as HTMLInputElement).checked"
+          >
+          <span>Enabled</span>
+        </label>
+      </div>
+
+      <p
+        v-if="attemptedSubmit && resolveFieldError(field)"
+        class="mt-2 text-xs font-medium text-error"
+      >
+        {{ resolveFieldError(field) }}
+      </p>
+    </section>
+
+    <div class="flex flex-wrap items-center justify-end gap-2">
+      <button
+        type="button"
+        class="rounded-full border border-default px-4 py-2 text-sm font-medium text-default transition hover:border-error/40 hover:text-error"
+        @click="emit('decline')"
+      >
+        Decline
+      </button>
+      <button
+        type="button"
+        class="rounded-full border border-default px-4 py-2 text-sm font-medium text-default transition hover:border-default/80 hover:text-highlighted"
+        @click="emit('cancel')"
+      >
+        Cancel
+      </button>
+      <button
+        type="submit"
+        class="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-inverted transition"
+      >
+        Continue
+      </button>
+    </div>
+  </form>
+</template>

--- a/packages/client/app/components/pending-request/McpElicitationUrlPrompt.vue
+++ b/packages/client/app/components/pending-request/McpElicitationUrlPrompt.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { PendingMcpElicitationUrl } from '../../../shared/pending-user-request'
+
+const props = defineProps<{
+  request: PendingMcpElicitationUrl
+}>()
+
+const emit = defineEmits<{
+  accept: []
+  decline: []
+  cancel: []
+}>()
+
+const urlHostname = computed(() => {
+  try {
+    return new URL(props.request.url).hostname
+  } catch {
+    return props.request.url
+  }
+})
+
+const openUrl = () => {
+  if (typeof window !== 'undefined') {
+    window.open(props.request.url, '_blank', 'noopener,noreferrer')
+  }
+
+  emit('accept')
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <section class="rounded-3xl border border-default bg-elevated/30 p-4">
+      <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary">
+        External action
+      </p>
+      <h3 class="mt-2 text-sm font-semibold text-highlighted">
+        Open {{ urlHostname }}
+      </h3>
+      <p class="mt-2 text-sm leading-6 text-muted">
+        {{ request.message ?? 'Codex needs you to complete a step in the browser before it can continue.' }}
+      </p>
+
+      <div class="mt-4 rounded-2xl border border-default bg-default px-3 py-2 text-sm text-default">
+        {{ request.url }}
+      </div>
+    </section>
+
+    <div class="flex flex-wrap items-center justify-end gap-2">
+      <button
+        type="button"
+        class="rounded-full border border-default px-4 py-2 text-sm font-medium text-default transition hover:border-error/40 hover:text-error"
+        @click="emit('decline')"
+      >
+        Decline
+      </button>
+      <button
+        type="button"
+        class="rounded-full border border-default px-4 py-2 text-sm font-medium text-default transition hover:border-default/80 hover:text-highlighted"
+        @click="emit('cancel')"
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        class="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-inverted transition"
+        @click="openUrl"
+      >
+        Open link
+      </button>
+    </div>
+  </div>
+</template>

--- a/packages/client/app/components/pending-request/McpElicitationUrlPrompt.vue
+++ b/packages/client/app/components/pending-request/McpElicitationUrlPrompt.vue
@@ -20,9 +20,27 @@ const urlHostname = computed(() => {
   }
 })
 
+const safeUrl = computed(() => {
+  try {
+    const parsed = new URL(props.request.url)
+    if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
+      return parsed.toString()
+    }
+
+    return null
+  } catch {
+    return null
+  }
+})
+
 const openUrl = () => {
+  if (!safeUrl.value) {
+    emit('cancel')
+    return
+  }
+
   if (typeof window !== 'undefined') {
-    window.open(props.request.url, '_blank', 'noopener,noreferrer')
+    window.open(safeUrl.value, '_blank', 'noopener,noreferrer')
   }
 
   emit('accept')

--- a/packages/client/app/components/pending-request/McpElicitationUrlPrompt.vue
+++ b/packages/client/app/components/pending-request/McpElicitationUrlPrompt.vue
@@ -30,45 +30,53 @@ const openUrl = () => {
 </script>
 
 <template>
-  <div class="space-y-4">
-    <section class="rounded-3xl border border-default bg-elevated/30 p-4">
+  <div class="space-y-3">
+    <section class="rounded-lg border border-default/70 bg-elevated/20 p-3">
       <p class="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary">
         External action
       </p>
-      <h3 class="mt-2 text-sm font-semibold text-highlighted">
+      <h3 class="mt-1.5 text-sm font-semibold text-highlighted">
         Open {{ urlHostname }}
       </h3>
-      <p class="mt-2 text-sm leading-6 text-muted">
+      <p class="mt-1.5 text-sm leading-5 text-muted">
         {{ request.message ?? 'Codex needs you to complete a step in the browser before it can continue.' }}
       </p>
 
-      <div class="mt-4 rounded-2xl border border-default bg-default px-3 py-2 text-sm text-default">
+      <div class="mt-3 rounded-lg border border-default/70 bg-elevated px-3 py-2 text-sm text-default">
         {{ request.url }}
       </div>
     </section>
 
-    <div class="flex flex-wrap items-center justify-end gap-2">
-      <button
+    <div class="flex flex-wrap items-center justify-end gap-2 pt-1">
+      <UButton
         type="button"
-        class="rounded-full border border-default px-4 py-2 text-sm font-medium text-default transition hover:border-error/40 hover:text-error"
+        color="error"
+        variant="ghost"
+        size="sm"
+        class="rounded-lg"
         @click="emit('decline')"
       >
         Decline
-      </button>
-      <button
+      </UButton>
+      <UButton
         type="button"
-        class="rounded-full border border-default px-4 py-2 text-sm font-medium text-default transition hover:border-default/80 hover:text-highlighted"
+        color="neutral"
+        variant="ghost"
+        size="sm"
+        class="rounded-lg"
         @click="emit('cancel')"
       >
         Cancel
-      </button>
-      <button
+      </UButton>
+      <UButton
         type="button"
-        class="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-inverted transition"
+        color="primary"
+        size="sm"
+        class="rounded-lg"
         @click="openUrl"
       >
         Open link
-      </button>
+      </UButton>
     </div>
   </div>
 </template>

--- a/packages/client/app/components/pending-request/RequestUserInputForm.vue
+++ b/packages/client/app/components/pending-request/RequestUserInputForm.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import { computed, reactive } from 'vue'
+import type { PendingRequestUserInput, PendingRequestUserInputQuestion } from '../../../shared/pending-user-request'
+
+const props = defineProps<{
+  request: PendingRequestUserInput
+}>()
+
+const emit = defineEmits<{
+  submit: [answers: Record<string, string[]>]
+}>()
+
+const selectedAnswers = reactive<Record<string, string[]>>({})
+const customAnswers = reactive<Record<string, string>>({})
+
+const questionAllowsCustomAnswer = (question: PendingRequestUserInputQuestion) =>
+  question.isOther || question.options.length === 0
+
+const resolveSelectedAnswers = (questionId: string) => selectedAnswers[questionId] ?? []
+
+const toggleOption = (questionId: string, label: string) => {
+  const current = resolveSelectedAnswers(questionId)
+  selectedAnswers[questionId] = current.includes(label)
+    ? current.filter(option => option !== label)
+    : [...current, label]
+}
+
+const resolveAnswerList = (question: PendingRequestUserInputQuestion) => {
+  const selected = resolveSelectedAnswers(question.id)
+  const custom = customAnswers[question.id]?.trim()
+
+  return custom ? [...selected, custom] : selected
+}
+
+const canSubmit = computed(() =>
+  props.request.questions.every(question => resolveAnswerList(question).length > 0)
+)
+
+const submit = () => {
+  if (!canSubmit.value) {
+    return
+  }
+
+  emit('submit', Object.fromEntries(
+    props.request.questions.map(question => [question.id, resolveAnswerList(question)])
+  ))
+}
+</script>
+
+<template>
+  <form
+    class="space-y-4"
+    @submit.prevent="submit"
+  >
+    <section
+      v-for="question in request.questions"
+      :key="question.id"
+      class="rounded-3xl border border-default bg-elevated/30 p-4"
+    >
+      <div class="space-y-2">
+        <p
+          v-if="question.header"
+          class="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary"
+        >
+          {{ question.header }}
+        </p>
+        <h3 class="text-sm font-semibold text-highlighted">
+          {{ question.question }}
+        </h3>
+        <p
+          v-if="question.isSecret"
+          class="text-xs text-muted"
+        >
+          The response will be treated as sensitive input.
+        </p>
+      </div>
+
+      <div
+        v-if="question.options.length"
+        class="mt-4 flex flex-wrap gap-2"
+      >
+        <button
+          v-for="option in question.options"
+          :key="option.label"
+          type="button"
+          class="rounded-full border px-3 py-2 text-left text-sm transition"
+          :class="resolveSelectedAnswers(question.id).includes(option.label)
+            ? 'border-primary bg-primary/10 text-primary'
+            : 'border-default bg-default text-default hover:border-primary/40 hover:text-highlighted'"
+          @click="toggleOption(question.id, option.label)"
+        >
+          <span class="font-medium">{{ option.label }}</span>
+          <span
+            v-if="option.description"
+            class="block text-xs text-muted"
+          >
+            {{ option.description }}
+          </span>
+        </button>
+      </div>
+
+      <div
+        v-if="questionAllowsCustomAnswer(question)"
+        class="mt-4"
+      >
+        <label
+          :for="`request-user-input-${question.id}`"
+          class="mb-2 block text-xs font-medium uppercase tracking-[0.16em] text-muted"
+        >
+          {{ question.options.length ? 'Custom answer' : 'Answer' }}
+        </label>
+
+        <textarea
+          v-if="!question.isSecret && question.options.length === 0"
+          :id="`request-user-input-${question.id}`"
+          v-model="customAnswers[question.id]"
+          rows="4"
+          class="min-h-28 w-full rounded-2xl border border-default bg-default px-3 py-2 text-sm text-default outline-none transition focus:border-primary/50"
+          :placeholder="question.options.length ? 'Add anything else Codex should know' : 'Type your answer'"
+        />
+
+        <input
+          v-else
+          :id="`request-user-input-${question.id}`"
+          v-model="customAnswers[question.id]"
+          class="w-full rounded-2xl border border-default bg-default px-3 py-2 text-sm text-default outline-none transition focus:border-primary/50"
+          :type="question.isSecret ? 'password' : 'text'"
+          :placeholder="question.options.length ? 'Add anything else Codex should know' : 'Type your answer'"
+        >
+      </div>
+    </section>
+
+    <div class="flex items-center justify-end">
+      <button
+        type="submit"
+        class="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-inverted transition disabled:cursor-not-allowed disabled:opacity-50"
+        :disabled="!canSubmit"
+      >
+        Send response
+      </button>
+    </div>
+  </form>
+</template>

--- a/packages/client/app/components/pending-request/RequestUserInputForm.vue
+++ b/packages/client/app/components/pending-request/RequestUserInputForm.vue
@@ -34,13 +34,6 @@ const questionAllowsCustomAnswer = (question: PendingRequestUserInputQuestion) =
 
 const resolveSelectedAnswers = (questionId: string) => selectedAnswers[questionId] ?? []
 
-const toggleOption = (questionId: string, label: string) => {
-  const current = resolveSelectedAnswers(questionId)
-  selectedAnswers[questionId] = current.includes(label)
-    ? current.filter(option => option !== label)
-    : [...current, label]
-}
-
 const resolveAnswerList = (question: PendingRequestUserInputQuestion) => {
   const selected = resolveSelectedAnswers(question.id)
   const custom = customAnswers[question.id]?.trim()

--- a/packages/client/app/components/pending-request/RequestUserInputForm.vue
+++ b/packages/client/app/components/pending-request/RequestUserInputForm.vue
@@ -50,15 +50,7 @@ const resolveAnswerList = (question: PendingRequestUserInputQuestion) => {
 
 const totalQuestions = computed(() => props.request.questions.length)
 const currentQuestion = computed(() => props.request.questions[activeQuestionIndex.value] ?? null)
-const isReviewStep = computed(() => activeQuestionIndex.value >= totalQuestions.value)
 const isLastQuestion = computed(() => activeQuestionIndex.value === totalQuestions.value - 1)
-const reviewItems = computed(() =>
-  props.request.questions.map(question => ({
-    id: question.id,
-    question: question.question,
-    answers: resolveAnswerList(question)
-  }))
-)
 
 const questionOptionItems = (question: PendingRequestUserInputQuestion): NavigationMenuItem[] =>
   question.options.map(option => ({
@@ -69,7 +61,12 @@ const questionOptionItems = (question: PendingRequestUserInputQuestion): Navigat
       event.preventDefault()
       selectedAnswers[question.id] = [option.label]
       delete customAnswers[question.id]
-      activeQuestionIndex.value = isLastQuestion.value ? totalQuestions.value : activeQuestionIndex.value + 1
+      if (isLastQuestion.value) {
+        submit()
+        return
+      }
+
+      activeQuestionIndex.value += 1
     }
   }))
 
@@ -87,11 +84,6 @@ const canSubmit = computed(() =>
 )
 
 const goBack = () => {
-  if (isReviewStep.value) {
-    activeQuestionIndex.value = Math.max(totalQuestions.value - 1, 0)
-    return
-  }
-
   activeQuestionIndex.value = Math.max(activeQuestionIndex.value - 1, 0)
 }
 
@@ -107,7 +99,12 @@ const continueWithCustomAnswer = () => {
 
   selectedAnswers[currentQuestion.value.id] = []
   customAnswers[currentQuestion.value.id] = customAnswer
-  activeQuestionIndex.value = isLastQuestion.value ? totalQuestions.value : activeQuestionIndex.value + 1
+  if (isLastQuestion.value) {
+    submit()
+    return
+  }
+
+  activeQuestionIndex.value += 1
 }
 
 const submit = () => {
@@ -123,14 +120,14 @@ const submit = () => {
 
 <template>
   <form
-    class="space-y-3"
-    @submit.prevent="isReviewStep ? submit() : continueWithCustomAnswer()"
+    class="space-y-2"
+    @submit.prevent="continueWithCustomAnswer()"
   >
     <div
       v-if="currentQuestion"
-      class="rounded-lg border border-default/70 bg-elevated/20 p-3"
+      class="space-y-2"
     >
-      <div class="mb-3 flex items-center justify-between gap-3">
+      <div class="flex items-center justify-between gap-3">
         <p class="text-xs text-muted">
           {{ activeQuestionIndex + 1 }} / {{ totalQuestions }}
         </p>
@@ -148,19 +145,17 @@ const submit = () => {
         </UButton>
       </div>
 
-      <div class="space-y-3">
-        <div class="space-y-1.5">
-          <h3 class="text-base font-semibold text-highlighted">
-            {{ currentQuestion.question }}
-          </h3>
+      <div class="space-y-2">
+        <h3 class="text-base font-semibold text-highlighted">
+          {{ currentQuestion.question }}
+        </h3>
 
-          <p
-            v-if="currentQuestion.isSecret"
-            class="text-xs text-muted"
-          >
-            The response will be treated as sensitive input.
-          </p>
-        </div>
+        <p
+          v-if="currentQuestion.isSecret"
+          class="text-xs text-muted"
+        >
+          The response will be treated as sensitive input.
+        </p>
 
         <UNavigationMenu
           v-if="currentQuestion.options.length"
@@ -175,7 +170,7 @@ const submit = () => {
             root: 'w-full',
             list: 'gap-1',
             item: 'w-full',
-            link: 'w-full min-h-11 items-start rounded-lg px-3 py-2 text-left text-sm',
+            link: 'w-full min-h-10 items-start rounded-lg px-3 py-2 text-left text-sm',
             linkLabel: 'min-w-0 flex-1',
             linkTrailing: 'ms-2 shrink-0',
             linkLeadingIcon: 'hidden'
@@ -222,7 +217,7 @@ const submit = () => {
             size="sm"
             class="w-full"
             :ui="{
-              base: 'min-h-11 rounded-lg px-3 text-sm'
+              base: 'min-h-10 rounded-lg px-3 text-sm'
             }"
           />
         </UFormField>
@@ -238,63 +233,9 @@ const submit = () => {
             class="rounded-lg"
             :disabled="!canAdvanceWithCustom"
           >
-            {{ isLastQuestion ? 'Review answers' : 'Continue' }}
+            {{ isLastQuestion ? 'Send response' : 'Continue' }}
           </UButton>
         </div>
-      </div>
-    </div>
-
-    <div
-      v-else
-      class="space-y-3"
-    >
-      <div class="rounded-lg border border-default/70 bg-elevated/20 p-3">
-        <div class="space-y-1.5">
-          <h3 class="text-base font-semibold text-highlighted">
-            Ready to send
-          </h3>
-          <p class="text-sm leading-5 text-muted">
-            Review the answers below, then send them back to Codex.
-          </p>
-        </div>
-
-        <div class="mt-3 space-y-2">
-          <div
-            v-for="item in reviewItems"
-            :key="item.id"
-            class="rounded-lg border border-default/60 bg-default/60 px-3 py-2"
-          >
-            <p class="text-sm font-medium text-highlighted">
-              {{ item.question }}
-            </p>
-            <p class="mt-1 text-sm text-muted">
-              {{ item.answers.join(', ') }}
-            </p>
-          </div>
-        </div>
-      </div>
-
-      <div class="flex items-center justify-between gap-2">
-        <UButton
-          type="button"
-          color="neutral"
-          variant="ghost"
-          size="sm"
-          class="rounded-lg"
-          @click="goBack"
-        >
-          Back
-        </UButton>
-
-      <UButton
-        type="submit"
-        color="primary"
-        size="sm"
-        class="rounded-lg"
-        :disabled="!canSubmit"
-      >
-        Send response
-      </UButton>
       </div>
     </div>
   </form>

--- a/packages/client/app/components/pending-request/RequestUserInputForm.vue
+++ b/packages/client/app/components/pending-request/RequestUserInputForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, reactive } from 'vue'
+import { computed, reactive, ref, watch } from 'vue'
 import type { NavigationMenuItem } from '@nuxt/ui'
 import type { PendingRequestUserInput, PendingRequestUserInputQuestion } from '../../../shared/pending-user-request'
 
@@ -13,6 +13,21 @@ const emit = defineEmits<{
 
 const selectedAnswers = reactive<Record<string, string[]>>({})
 const customAnswers = reactive<Record<string, string>>({})
+const activeQuestionIndex = ref(0)
+
+const resetState = () => {
+  activeQuestionIndex.value = 0
+
+  for (const questionId of Object.keys(selectedAnswers)) {
+    delete selectedAnswers[questionId]
+  }
+
+  for (const questionId of Object.keys(customAnswers)) {
+    delete customAnswers[questionId]
+  }
+}
+
+watch(() => props.request.requestId, resetState, { immediate: true })
 
 const questionAllowsCustomAnswer = (question: PendingRequestUserInputQuestion) =>
   question.isOther || question.options.length === 0
@@ -33,6 +48,18 @@ const resolveAnswerList = (question: PendingRequestUserInputQuestion) => {
   return custom ? [...selected, custom] : selected
 }
 
+const totalQuestions = computed(() => props.request.questions.length)
+const currentQuestion = computed(() => props.request.questions[activeQuestionIndex.value] ?? null)
+const isReviewStep = computed(() => activeQuestionIndex.value >= totalQuestions.value)
+const isLastQuestion = computed(() => activeQuestionIndex.value === totalQuestions.value - 1)
+const reviewItems = computed(() =>
+  props.request.questions.map(question => ({
+    id: question.id,
+    question: question.question,
+    answers: resolveAnswerList(question)
+  }))
+)
+
 const questionOptionItems = (question: PendingRequestUserInputQuestion): NavigationMenuItem[] =>
   question.options.map(option => ({
     label: option.label,
@@ -40,13 +67,48 @@ const questionOptionItems = (question: PendingRequestUserInputQuestion): Navigat
     active: resolveSelectedAnswers(question.id).includes(option.label),
     onSelect: (event: Event) => {
       event.preventDefault()
-      toggleOption(question.id, option.label)
+      selectedAnswers[question.id] = [option.label]
+      delete customAnswers[question.id]
+      activeQuestionIndex.value = isLastQuestion.value ? totalQuestions.value : activeQuestionIndex.value + 1
     }
   }))
 
+const canAdvanceWithCustom = computed(() => {
+  if (!currentQuestion.value || !questionAllowsCustomAnswer(currentQuestion.value)) {
+    return false
+  }
+
+  return Boolean(customAnswers[currentQuestion.value.id]?.trim())
+})
+
 const canSubmit = computed(() =>
-  props.request.questions.every(question => resolveAnswerList(question).length > 0)
+  props.request.questions.length > 0
+  && props.request.questions.every(question => resolveAnswerList(question).length > 0)
 )
+
+const goBack = () => {
+  if (isReviewStep.value) {
+    activeQuestionIndex.value = Math.max(totalQuestions.value - 1, 0)
+    return
+  }
+
+  activeQuestionIndex.value = Math.max(activeQuestionIndex.value - 1, 0)
+}
+
+const continueWithCustomAnswer = () => {
+  if (!currentQuestion.value) {
+    return
+  }
+
+  const customAnswer = customAnswers[currentQuestion.value.id]?.trim()
+  if (!customAnswer) {
+    return
+  }
+
+  selectedAnswers[currentQuestion.value.id] = []
+  customAnswers[currentQuestion.value.id] = customAnswer
+  activeQuestionIndex.value = isLastQuestion.value ? totalQuestions.value : activeQuestionIndex.value + 1
+}
 
 const submit = () => {
   if (!canSubmit.value) {
@@ -62,29 +124,47 @@ const submit = () => {
 <template>
   <form
     class="space-y-3"
-    @submit.prevent="submit"
+    @submit.prevent="isReviewStep ? submit() : continueWithCustomAnswer()"
   >
     <div
-      v-for="question in request.questions"
-      :key="question.id"
+      v-if="currentQuestion"
       class="rounded-lg border border-default/70 bg-elevated/20 p-3"
     >
-      <UFormField
-        :label="question.question"
-        :description="question.header ?? undefined"
-        :help="question.isSecret ? 'The response will be treated as sensitive input.' : undefined"
-        size="sm"
-        :ui="{
-          root: 'space-y-2',
-          container: 'mt-2',
-          label: 'text-sm font-semibold text-highlighted',
-          description: 'text-[11px] font-semibold uppercase tracking-[0.16em] text-primary',
-          help: 'mt-2 text-xs text-muted'
-        }"
+      <div class="mb-3 flex items-center justify-between gap-3">
+        <p class="text-xs text-muted">
+          {{ activeQuestionIndex + 1 }} / {{ totalQuestions }}
+        </p>
+
+        <UButton
+          v-if="activeQuestionIndex > 0"
+          type="button"
+          color="neutral"
+          variant="ghost"
+          size="xs"
+          class="rounded-lg"
+          @click="goBack"
         >
+          Back
+        </UButton>
+      </div>
+
+      <div class="space-y-3">
+        <div class="space-y-1.5">
+          <h3 class="text-base font-semibold text-highlighted">
+            {{ currentQuestion.question }}
+          </h3>
+
+          <p
+            v-if="currentQuestion.isSecret"
+            class="text-xs text-muted"
+          >
+            The response will be treated as sensitive input.
+          </p>
+        </div>
+
         <UNavigationMenu
-          v-if="question.options.length"
-          :items="questionOptionItems(question)"
+          v-if="currentQuestion.options.length"
+          :items="questionOptionItems(currentQuestion)"
           orientation="vertical"
           variant="pill"
           color="neutral"
@@ -95,20 +175,20 @@ const submit = () => {
             root: 'w-full',
             list: 'gap-1',
             item: 'w-full',
-            link: 'w-full rounded-lg px-3 py-2 text-sm',
+            link: 'w-full min-h-11 items-start rounded-lg px-3 py-2 text-left text-sm',
             linkLabel: 'min-w-0 flex-1',
             linkTrailing: 'ms-2 shrink-0',
             linkLeadingIcon: 'hidden'
           }"
         >
           <template #item-label="{ item }">
-            <div class="min-w-0">
-              <div class="truncate font-medium text-highlighted">
+            <div class="min-w-0 text-left">
+              <div class="font-medium text-highlighted">
                 {{ item.label }}
               </div>
               <div
                 v-if="item.description"
-                class="truncate text-xs text-muted"
+                class="text-xs text-muted"
               >
                 {{ item.description }}
               </div>
@@ -125,35 +205,87 @@ const submit = () => {
         </UNavigationMenu>
 
         <UFormField
-          v-if="questionAllowsCustomAnswer(question)"
-          :label="question.options.length ? 'Custom answer' : 'Answer'"
+          v-if="questionAllowsCustomAnswer(currentQuestion)"
           size="sm"
           :ui="{
-            root: question.options.length ? 'pt-2' : '',
-            container: 'mt-1.5',
-            label: 'text-xs font-medium uppercase tracking-[0.14em] text-muted'
+            root: '',
+            container: 'mt-0'
           }"
         >
           <UInput
-            :id="`request-user-input-${question.id}`"
-            v-model="customAnswers[question.id]"
-            :type="question.isSecret ? 'password' : 'text'"
-            :placeholder="question.options.length ? 'Add anything else Codex should know' : 'Type your answer'"
+            :id="`request-user-input-${currentQuestion.id}`"
+            v-model="customAnswers[currentQuestion.id]"
+            :type="currentQuestion.isSecret ? 'password' : 'text'"
+            :placeholder="currentQuestion.options.length ? 'Type a custom response' : 'Type your response'"
             color="neutral"
             variant="subtle"
             size="sm"
             class="w-full"
             :ui="{
-              base: 'rounded-lg'
+              base: 'min-h-11 rounded-lg px-3 text-sm'
             }"
           />
         </UFormField>
-      </UFormField>
+
+        <div
+          v-if="questionAllowsCustomAnswer(currentQuestion)"
+          class="flex justify-end"
+        >
+          <UButton
+            type="submit"
+            color="primary"
+            size="sm"
+            class="rounded-lg"
+            :disabled="!canAdvanceWithCustom"
+          >
+            {{ isLastQuestion ? 'Review answers' : 'Continue' }}
+          </UButton>
+        </div>
+      </div>
     </div>
 
     <div
-      class="flex items-center justify-end pt-1"
+      v-else
+      class="space-y-3"
     >
+      <div class="rounded-lg border border-default/70 bg-elevated/20 p-3">
+        <div class="space-y-1.5">
+          <h3 class="text-base font-semibold text-highlighted">
+            Ready to send
+          </h3>
+          <p class="text-sm leading-5 text-muted">
+            Review the answers below, then send them back to Codex.
+          </p>
+        </div>
+
+        <div class="mt-3 space-y-2">
+          <div
+            v-for="item in reviewItems"
+            :key="item.id"
+            class="rounded-lg border border-default/60 bg-default/60 px-3 py-2"
+          >
+            <p class="text-sm font-medium text-highlighted">
+              {{ item.question }}
+            </p>
+            <p class="mt-1 text-sm text-muted">
+              {{ item.answers.join(', ') }}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="flex items-center justify-between gap-2">
+        <UButton
+          type="button"
+          color="neutral"
+          variant="ghost"
+          size="sm"
+          class="rounded-lg"
+          @click="goBack"
+        >
+          Back
+        </UButton>
+
       <UButton
         type="submit"
         color="primary"
@@ -163,6 +295,7 @@ const submit = () => {
       >
         Send response
       </UButton>
+      </div>
     </div>
   </form>
 </template>

--- a/packages/client/app/components/pending-request/RequestUserInputForm.vue
+++ b/packages/client/app/components/pending-request/RequestUserInputForm.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, reactive } from 'vue'
+import type { NavigationMenuItem } from '@nuxt/ui'
 import type { PendingRequestUserInput, PendingRequestUserInputQuestion } from '../../../shared/pending-user-request'
 
 const props = defineProps<{
@@ -32,6 +33,17 @@ const resolveAnswerList = (question: PendingRequestUserInputQuestion) => {
   return custom ? [...selected, custom] : selected
 }
 
+const questionOptionItems = (question: PendingRequestUserInputQuestion): NavigationMenuItem[] =>
+  question.options.map(option => ({
+    label: option.label,
+    description: option.description ?? undefined,
+    active: resolveSelectedAnswers(question.id).includes(option.label),
+    onSelect: (event: Event) => {
+      event.preventDefault()
+      toggleOption(question.id, option.label)
+    }
+  }))
+
 const canSubmit = computed(() =>
   props.request.questions.every(question => resolveAnswerList(question).length > 0)
 )
@@ -49,95 +61,108 @@ const submit = () => {
 
 <template>
   <form
-    class="space-y-4"
+    class="space-y-3"
     @submit.prevent="submit"
   >
-    <section
+    <div
       v-for="question in request.questions"
       :key="question.id"
-      class="rounded-3xl border border-default bg-elevated/30 p-4"
+      class="rounded-lg border border-default/70 bg-elevated/20 p-3"
     >
-      <div class="space-y-2">
-        <p
-          v-if="question.header"
-          class="text-[11px] font-semibold uppercase tracking-[0.18em] text-primary"
+      <UFormField
+        :label="question.question"
+        :description="question.header ?? undefined"
+        :help="question.isSecret ? 'The response will be treated as sensitive input.' : undefined"
+        size="sm"
+        :ui="{
+          root: 'space-y-2',
+          container: 'mt-2',
+          label: 'text-sm font-semibold text-highlighted',
+          description: 'text-[11px] font-semibold uppercase tracking-[0.16em] text-primary',
+          help: 'mt-2 text-xs text-muted'
+        }"
         >
-          {{ question.header }}
-        </p>
-        <h3 class="text-sm font-semibold text-highlighted">
-          {{ question.question }}
-        </h3>
-        <p
-          v-if="question.isSecret"
-          class="text-xs text-muted"
+        <UNavigationMenu
+          v-if="question.options.length"
+          :items="questionOptionItems(question)"
+          orientation="vertical"
+          variant="pill"
+          color="neutral"
+          :highlight="false"
+          :popover="false"
+          class="w-full"
+          :ui="{
+            root: 'w-full',
+            list: 'gap-1',
+            item: 'w-full',
+            link: 'w-full rounded-lg px-3 py-2 text-sm',
+            linkLabel: 'min-w-0 flex-1',
+            linkTrailing: 'ms-2 shrink-0',
+            linkLeadingIcon: 'hidden'
+          }"
         >
-          The response will be treated as sensitive input.
-        </p>
-      </div>
+          <template #item-label="{ item }">
+            <div class="min-w-0">
+              <div class="truncate font-medium text-highlighted">
+                {{ item.label }}
+              </div>
+              <div
+                v-if="item.description"
+                class="truncate text-xs text-muted"
+              >
+                {{ item.description }}
+              </div>
+            </div>
+          </template>
 
-      <div
-        v-if="question.options.length"
-        class="mt-4 flex flex-wrap gap-2"
-      >
-        <button
-          v-for="option in question.options"
-          :key="option.label"
-          type="button"
-          class="rounded-full border px-3 py-2 text-left text-sm transition"
-          :class="resolveSelectedAnswers(question.id).includes(option.label)
-            ? 'border-primary bg-primary/10 text-primary'
-            : 'border-default bg-default text-default hover:border-primary/40 hover:text-highlighted'"
-          @click="toggleOption(question.id, option.label)"
+          <template #item-trailing="{ item }">
+            <UIcon
+              v-if="item.active"
+              name="i-lucide-check"
+              class="size-4 text-primary"
+            />
+          </template>
+        </UNavigationMenu>
+
+        <UFormField
+          v-if="questionAllowsCustomAnswer(question)"
+          :label="question.options.length ? 'Custom answer' : 'Answer'"
+          size="sm"
+          :ui="{
+            root: question.options.length ? 'pt-2' : '',
+            container: 'mt-1.5',
+            label: 'text-xs font-medium uppercase tracking-[0.14em] text-muted'
+          }"
         >
-          <span class="font-medium">{{ option.label }}</span>
-          <span
-            v-if="option.description"
-            class="block text-xs text-muted"
-          >
-            {{ option.description }}
-          </span>
-        </button>
-      </div>
+          <UInput
+            :id="`request-user-input-${question.id}`"
+            v-model="customAnswers[question.id]"
+            :type="question.isSecret ? 'password' : 'text'"
+            :placeholder="question.options.length ? 'Add anything else Codex should know' : 'Type your answer'"
+            color="neutral"
+            variant="subtle"
+            size="sm"
+            class="w-full"
+            :ui="{
+              base: 'rounded-lg'
+            }"
+          />
+        </UFormField>
+      </UFormField>
+    </div>
 
-      <div
-        v-if="questionAllowsCustomAnswer(question)"
-        class="mt-4"
-      >
-        <label
-          :for="`request-user-input-${question.id}`"
-          class="mb-2 block text-xs font-medium uppercase tracking-[0.16em] text-muted"
-        >
-          {{ question.options.length ? 'Custom answer' : 'Answer' }}
-        </label>
-
-        <textarea
-          v-if="!question.isSecret && question.options.length === 0"
-          :id="`request-user-input-${question.id}`"
-          v-model="customAnswers[question.id]"
-          rows="4"
-          class="min-h-28 w-full rounded-2xl border border-default bg-default px-3 py-2 text-sm text-default outline-none transition focus:border-primary/50"
-          :placeholder="question.options.length ? 'Add anything else Codex should know' : 'Type your answer'"
-        />
-
-        <input
-          v-else
-          :id="`request-user-input-${question.id}`"
-          v-model="customAnswers[question.id]"
-          class="w-full rounded-2xl border border-default bg-default px-3 py-2 text-sm text-default outline-none transition focus:border-primary/50"
-          :type="question.isSecret ? 'password' : 'text'"
-          :placeholder="question.options.length ? 'Add anything else Codex should know' : 'Type your answer'"
-        >
-      </div>
-    </section>
-
-    <div class="flex items-center justify-end">
-      <button
+    <div
+      class="flex items-center justify-end pt-1"
+    >
+      <UButton
         type="submit"
-        class="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-inverted transition disabled:cursor-not-allowed disabled:opacity-50"
+        color="primary"
+        size="sm"
+        class="rounded-lg"
         :disabled="!canSubmit"
       >
         Send response
-      </button>
+      </UButton>
     </div>
   </form>
 </template>

--- a/packages/client/app/composables/usePendingUserRequest.ts
+++ b/packages/client/app/composables/usePendingUserRequest.ts
@@ -15,8 +15,12 @@ type PendingUserRequestSession = {
 
 const sessions = new Map<string, PendingUserRequestSession>()
 
-const getSession = (projectId: string): PendingUserRequestSession => {
-  const existing = sessions.get(projectId)
+const sessionKey = (projectId: string, threadId: string | null) =>
+  `${projectId}::${threadId ?? '__draft__'}`
+
+const getSession = (projectId: string, threadId: string | null): PendingUserRequestSession => {
+  const key = sessionKey(projectId, threadId)
+  const existing = sessions.get(key)
   if (existing) {
     return existing
   }
@@ -25,7 +29,7 @@ const getSession = (projectId: string): PendingUserRequestSession => {
     current: ref<PendingUserRequest | null>(null),
     queue: []
   }
-  sessions.set(projectId, session)
+  sessions.set(key, session)
   return session
 }
 
@@ -33,14 +37,16 @@ const promoteNextRequest = (session: PendingUserRequestSession) => {
   session.current.value = session.queue[0]?.request ?? null
 }
 
-export const usePendingUserRequest = (projectId: string) => {
-  const session = getSession(projectId)
+export const usePendingUserRequest = (projectId: string, activeThreadId: Ref<string | null>) => {
+  const resolveSession = (threadId: string | null) => getSession(projectId, threadId)
 
   const handleServerRequest = async (request: CodexRpcServerRequest) => {
     const normalized = parsePendingUserRequest(request)
     if (!normalized) {
       return null
     }
+
+    const session = resolveSession(normalized.threadId ?? activeThreadId.value)
 
     return await new Promise((resolve, reject) => {
       session.queue.push({
@@ -56,6 +62,7 @@ export const usePendingUserRequest = (projectId: string) => {
   }
 
   const resolveCurrentRequest = (response: unknown) => {
+    const session = resolveSession(activeThreadId.value)
     const current = session.queue.shift()
     if (!current) {
       return
@@ -66,6 +73,7 @@ export const usePendingUserRequest = (projectId: string) => {
   }
 
   const rejectCurrentRequest = (error: unknown) => {
+    const session = resolveSession(activeThreadId.value)
     const current = session.queue.shift()
     if (!current) {
       return
@@ -76,8 +84,8 @@ export const usePendingUserRequest = (projectId: string) => {
   }
 
   return {
-    pendingRequest: session.current,
-    hasPendingRequest: computed(() => session.current.value !== null),
+    pendingRequest: computed(() => resolveSession(activeThreadId.value).current.value),
+    hasPendingRequest: computed(() => resolveSession(activeThreadId.value).current.value !== null),
     handleServerRequest,
     resolveCurrentRequest,
     rejectCurrentRequest

--- a/packages/client/app/composables/usePendingUserRequest.ts
+++ b/packages/client/app/composables/usePendingUserRequest.ts
@@ -1,0 +1,85 @@
+import { computed, ref, type Ref } from 'vue'
+import type { CodexRpcServerRequest } from '../../shared/codex-rpc'
+import { parsePendingUserRequest, type PendingUserRequest } from '../../shared/pending-user-request'
+
+type PendingUserRequestQueueEntry = {
+  request: PendingUserRequest
+  resolve: (value: unknown) => void
+  reject: (error: unknown) => void
+}
+
+type PendingUserRequestSession = {
+  current: Ref<PendingUserRequest | null>
+  queue: PendingUserRequestQueueEntry[]
+}
+
+const sessions = new Map<string, PendingUserRequestSession>()
+
+const getSession = (projectId: string): PendingUserRequestSession => {
+  const existing = sessions.get(projectId)
+  if (existing) {
+    return existing
+  }
+
+  const session: PendingUserRequestSession = {
+    current: ref<PendingUserRequest | null>(null),
+    queue: []
+  }
+  sessions.set(projectId, session)
+  return session
+}
+
+const promoteNextRequest = (session: PendingUserRequestSession) => {
+  session.current.value = session.queue[0]?.request ?? null
+}
+
+export const usePendingUserRequest = (projectId: string) => {
+  const session = getSession(projectId)
+
+  const handleServerRequest = async (request: CodexRpcServerRequest) => {
+    const normalized = parsePendingUserRequest(request)
+    if (!normalized) {
+      return null
+    }
+
+    return await new Promise((resolve, reject) => {
+      session.queue.push({
+        request: normalized,
+        resolve,
+        reject
+      })
+
+      if (!session.current.value) {
+        promoteNextRequest(session)
+      }
+    })
+  }
+
+  const resolveCurrentRequest = (response: unknown) => {
+    const current = session.queue.shift()
+    if (!current) {
+      return
+    }
+
+    current.resolve(response)
+    promoteNextRequest(session)
+  }
+
+  const rejectCurrentRequest = (error: unknown) => {
+    const current = session.queue.shift()
+    if (!current) {
+      return
+    }
+
+    current.reject(error)
+    promoteNextRequest(session)
+  }
+
+  return {
+    pendingRequest: session.current,
+    hasPendingRequest: computed(() => session.current.value !== null),
+    handleServerRequest,
+    resolveCurrentRequest,
+    rejectCurrentRequest
+  }
+}

--- a/packages/client/app/composables/usePendingUserRequest.ts
+++ b/packages/client/app/composables/usePendingUserRequest.ts
@@ -1,6 +1,10 @@
 import { computed, ref, type Ref } from 'vue'
 import type { CodexRpcServerRequest } from '../../shared/codex-rpc'
-import { parsePendingUserRequest, type PendingUserRequest } from '../../shared/pending-user-request'
+import {
+  buildPendingUserRequestDismissResponse,
+  parsePendingUserRequest,
+  type PendingUserRequest
+} from '../../shared/pending-user-request'
 
 type PendingUserRequestQueueEntry = {
   request: PendingUserRequest
@@ -35,6 +39,19 @@ const getSession = (projectId: string, threadId: string | null): PendingUserRequ
 
 const promoteNextRequest = (session: PendingUserRequestSession) => {
   session.current.value = session.queue[0]?.request ?? null
+}
+
+const resolveQueuedRequest = (session: PendingUserRequestSession, responseFactory: (request: PendingUserRequest) => unknown) => {
+  while (session.queue.length > 0) {
+    const entry = session.queue.shift()
+    if (!entry) {
+      continue
+    }
+
+    entry.resolve(responseFactory(entry.request))
+  }
+
+  session.current.value = null
 }
 
 export const usePendingUserRequest = (projectId: string, activeThreadId: Ref<string | null>) => {
@@ -83,11 +100,25 @@ export const usePendingUserRequest = (projectId: string, activeThreadId: Ref<str
     promoteNextRequest(session)
   }
 
+  const cancelAllPendingRequests = () => {
+    const projectSessionPrefix = `${projectId}::`
+
+    for (const [key, session] of sessions.entries()) {
+      if (!key.startsWith(projectSessionPrefix)) {
+        continue
+      }
+
+      resolveQueuedRequest(session, buildPendingUserRequestDismissResponse)
+      sessions.delete(key)
+    }
+  }
+
   return {
     pendingRequest: computed(() => resolveSession(activeThreadId.value).current.value),
     hasPendingRequest: computed(() => resolveSession(activeThreadId.value).current.value !== null),
     handleServerRequest,
     resolveCurrentRequest,
-    rejectCurrentRequest
+    rejectCurrentRequest,
+    cancelAllPendingRequests
   }
 }

--- a/packages/client/shared/codex-rpc.ts
+++ b/packages/client/shared/codex-rpc.ts
@@ -24,12 +24,16 @@ type JsonRpcNotification = {
   params?: unknown
 }
 
-type JsonRpcServerRequest = JsonRpcRequest
+export type CodexRpcServerRequest = JsonRpcRequest
+
+type JsonRpcServerRequest = CodexRpcServerRequest
 
 type PendingRequest = {
   resolve: (value: unknown) => void
   reject: (error: unknown) => void
 }
+
+export type CodexRpcServerRequestHandler = (request: CodexRpcServerRequest) => Promise<unknown> | unknown
 
 export type CodexUserInput =
   | {
@@ -209,7 +213,12 @@ const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
 const asError = (value: unknown) =>
   value instanceof Error ? value : new Error(typeof value === 'string' ? value : 'Unknown RPC error.')
 
-const toServerRequestResponse = async (request: JsonRpcServerRequest) => {
+export const toServerRequestResponse = async (
+  request: JsonRpcServerRequest,
+  options?: {
+    handler?: CodexRpcServerRequestHandler | null
+  }
+) => {
   switch (request.method) {
     case 'item/commandExecution/requestApproval':
     case 'item/fileChange/requestApproval':
@@ -217,8 +226,20 @@ const toServerRequestResponse = async (request: JsonRpcServerRequest) => {
     case 'item/permissions/requestApproval':
       return { permissions: {}, scope: 'turn' }
     case 'item/tool/requestUserInput':
+      if (options?.handler) {
+        const handled = await options.handler(request)
+        if (handled != null) {
+          return handled
+        }
+      }
       return { answers: {} }
     case 'mcpServer/elicitation/request':
+      if (options?.handler) {
+        const handled = await options.handler(request)
+        if (handled != null) {
+          return handled
+        }
+      }
       return { action: 'decline', content: null, _meta: null }
     case 'applyPatchApproval':
     case 'execCommandApproval':
@@ -290,6 +311,8 @@ export class CodexRpcClient {
 
   private listeners = new Set<(notification: CodexRpcNotification) => void>()
 
+  private serverRequestHandler: CodexRpcServerRequestHandler | null = null
+
   constructor(url: string) {
     this.url = url
   }
@@ -298,6 +321,16 @@ export class CodexRpcClient {
     this.listeners.add(listener)
     return () => {
       this.listeners.delete(listener)
+    }
+  }
+
+  setServerRequestHandler(handler: CodexRpcServerRequestHandler | null) {
+    this.serverRequestHandler = handler
+
+    return () => {
+      if (this.serverRequestHandler === handler) {
+        this.serverRequestHandler = null
+      }
     }
   }
 
@@ -389,7 +422,9 @@ export class CodexRpcClient {
     }
 
     if ('id' in payload && 'method' in payload) {
-      const result = await toServerRequestResponse(payload)
+      const result = await toServerRequestResponse(payload, {
+        handler: this.serverRequestHandler
+      })
       this.sendRaw({
         id: payload.id,
         result

--- a/packages/client/shared/pending-user-request.ts
+++ b/packages/client/shared/pending-user-request.ts
@@ -1,0 +1,360 @@
+import type { CodexRpcServerRequest } from './codex-rpc'
+
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const asTrimmedString = (value: unknown) => {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const asBoolean = (value: unknown) => value === true
+
+const asStringArray = (value: unknown) =>
+  Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : []
+
+export type PendingRequestUserInputOption = {
+  label: string
+  description: string | null
+}
+
+export type PendingRequestUserInputQuestion = {
+  header: string | null
+  id: string
+  question: string
+  options: PendingRequestUserInputOption[]
+  isOther: boolean
+  isSecret: boolean
+}
+
+export type PendingRequestUserInput = {
+  kind: 'requestUserInput'
+  requestId: number
+  threadId: string | null
+  turnId: string | null
+  itemId: string | null
+  questions: PendingRequestUserInputQuestion[]
+}
+
+type BaseElicitationField = {
+  key: string
+  label: string
+  description: string | null
+  required: boolean
+}
+
+export type PendingElicitationStringField = BaseElicitationField & {
+  kind: 'string'
+  minLength: number | null
+  maxLength: number | null
+  format: 'email' | 'uri' | 'date' | 'date-time' | null
+  defaultValue: string | null
+}
+
+export type PendingElicitationNumberField = BaseElicitationField & {
+  kind: 'number'
+  numericType: 'number' | 'integer'
+  minimum: number | null
+  maximum: number | null
+  defaultValue: number | null
+}
+
+export type PendingElicitationBooleanField = BaseElicitationField & {
+  kind: 'boolean'
+  defaultValue: boolean
+}
+
+export type PendingElicitationEnumField = BaseElicitationField & {
+  kind: 'enum'
+  valueType: 'string' | 'number' | 'integer' | 'boolean'
+  options: Array<{
+    label: string
+    value: string | number | boolean
+  }>
+  defaultValue: string | number | boolean | null
+}
+
+export type PendingElicitationField =
+  | PendingElicitationStringField
+  | PendingElicitationNumberField
+  | PendingElicitationBooleanField
+  | PendingElicitationEnumField
+
+export type PendingMcpElicitationForm = {
+  kind: 'mcpElicitationForm'
+  requestId: number
+  message: string | null
+  fields: PendingElicitationField[]
+}
+
+export type PendingMcpElicitationUrl = {
+  kind: 'mcpElicitationUrl'
+  requestId: number
+  message: string | null
+  url: string
+  elicitationId: string | null
+}
+
+export type PendingUserRequest =
+  | PendingRequestUserInput
+  | PendingMcpElicitationForm
+  | PendingMcpElicitationUrl
+
+const parseRequestUserInputOption = (value: unknown): PendingRequestUserInputOption | null => {
+  if (!isObjectRecord(value)) {
+    return null
+  }
+
+  const label = asTrimmedString(value.label)
+  if (!label) {
+    return null
+  }
+
+  return {
+    label,
+    description: asTrimmedString(value.description)
+  }
+}
+
+const parseRequestUserInputQuestion = (value: unknown): PendingRequestUserInputQuestion | null => {
+  if (!isObjectRecord(value)) {
+    return null
+  }
+
+  const id = asTrimmedString(value.id)
+  const question = asTrimmedString(value.question)
+  if (!id || !question) {
+    return null
+  }
+
+  const options = Array.isArray(value.options)
+    ? value.options
+      .map(parseRequestUserInputOption)
+      .filter((option): option is PendingRequestUserInputOption => option !== null)
+    : []
+
+  return {
+    header: asTrimmedString(value.header),
+    id,
+    question,
+    options,
+    isOther: asBoolean(value.isOther),
+    isSecret: asBoolean(value.isSecret)
+  }
+}
+
+const parseNumber = (value: unknown) =>
+  typeof value === 'number' && Number.isFinite(value) ? value : null
+
+const parseEnumValueType = (values: Array<string | number | boolean>) => {
+  if (values.every(value => typeof value === 'string')) {
+    return 'string'
+  }
+
+  if (values.every(value => typeof value === 'boolean')) {
+    return 'boolean'
+  }
+
+  if (values.every(value => typeof value === 'number' && Number.isInteger(value))) {
+    return 'integer'
+  }
+
+  if (values.every(value => typeof value === 'number')) {
+    return 'number'
+  }
+
+  return null
+}
+
+const parseElicitationField = (
+  key: string,
+  value: unknown,
+  requiredKeys: Set<string>
+): PendingElicitationField | null => {
+  if (!isObjectRecord(value)) {
+    return null
+  }
+
+  const label = asTrimmedString(value.title) ?? key
+  const description = asTrimmedString(value.description)
+  const required = requiredKeys.has(key)
+  const enumValues = Array.isArray(value.enum)
+    ? value.enum.filter((entry): entry is string | number | boolean =>
+      typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean')
+    : []
+
+  if (enumValues.length > 0) {
+    const valueType = parseEnumValueType(enumValues)
+    if (!valueType) {
+      return null
+    }
+
+    const defaultValue = enumValues.includes(value.default as never)
+      ? value.default as string | number | boolean
+      : null
+
+    return {
+      kind: 'enum',
+      key,
+      label,
+      description,
+      required,
+      valueType,
+      defaultValue,
+      options: enumValues.map(option => ({
+        label: String(option),
+        value: option
+      }))
+    }
+  }
+
+  if (value.type === 'string') {
+    const format = value.format === 'email'
+      || value.format === 'uri'
+      || value.format === 'date'
+      || value.format === 'date-time'
+      ? value.format
+      : null
+
+    return {
+      kind: 'string',
+      key,
+      label,
+      description,
+      required,
+      minLength: parseNumber(value.minLength),
+      maxLength: parseNumber(value.maxLength),
+      format,
+      defaultValue: typeof value.default === 'string' ? value.default : null
+    }
+  }
+
+  if (value.type === 'number' || value.type === 'integer') {
+    return {
+      kind: 'number',
+      key,
+      label,
+      description,
+      required,
+      numericType: value.type,
+      minimum: parseNumber(value.minimum),
+      maximum: parseNumber(value.maximum),
+      defaultValue: typeof value.default === 'number' ? value.default : null
+    }
+  }
+
+  if (value.type === 'boolean') {
+    return {
+      kind: 'boolean',
+      key,
+      label,
+      description,
+      required,
+      defaultValue: value.default === true
+    }
+  }
+
+  return null
+}
+
+export const parsePendingUserRequest = (request: CodexRpcServerRequest): PendingUserRequest | null => {
+  const params = isObjectRecord(request.params) ? request.params : null
+
+  switch (request.method) {
+    case 'item/tool/requestUserInput': {
+      const questions = Array.isArray(params?.questions)
+        ? params.questions
+          .map(parseRequestUserInputQuestion)
+          .filter((question): question is PendingRequestUserInputQuestion => question !== null)
+        : []
+      if (questions.length === 0) {
+        return null
+      }
+
+      return {
+        kind: 'requestUserInput',
+        requestId: request.id,
+        threadId: asTrimmedString(params?.threadId),
+        turnId: asTrimmedString(params?.turnId),
+        itemId: asTrimmedString(params?.itemId),
+        questions
+      }
+    }
+    case 'mcpServer/elicitation/request': {
+      const mode = asTrimmedString(params?.mode)
+      if (mode === 'url') {
+        const url = asTrimmedString(params?.url)
+        if (!url) {
+          return null
+        }
+
+        return {
+          kind: 'mcpElicitationUrl',
+          requestId: request.id,
+          message: asTrimmedString(params?.message),
+          url,
+          elicitationId: asTrimmedString(params?.elicitationId)
+        }
+      }
+
+      if (mode !== 'form') {
+        return null
+      }
+
+      const requestedSchema = isObjectRecord(params?.requestedSchema) ? params.requestedSchema : null
+      if (!requestedSchema || requestedSchema.type !== 'object') {
+        return null
+      }
+
+      const properties = isObjectRecord(requestedSchema.properties) ? requestedSchema.properties : null
+      if (!properties) {
+        return null
+      }
+
+      const requiredKeys = new Set(asStringArray(requestedSchema.required))
+      const fields = Object.entries(properties)
+        .map(([key, value]) => parseElicitationField(key, value, requiredKeys))
+        .filter((field): field is PendingElicitationField => field !== null)
+      if (fields.length === 0) {
+        return null
+      }
+
+      return {
+        kind: 'mcpElicitationForm',
+        requestId: request.id,
+        message: asTrimmedString(params?.message),
+        fields
+      }
+    }
+    default:
+      return null
+  }
+}
+
+const sanitizeAnswerList = (answers: string[]) =>
+  answers
+    .map(answer => answer.trim())
+    .filter(answer => answer.length > 0)
+
+export const buildRequestUserInputResponse = (
+  answers: Record<string, string[]>
+) => ({
+  answers: Object.fromEntries(
+    Object.entries(answers).map(([questionId, questionAnswers]) => [questionId, sanitizeAnswerList(questionAnswers)])
+  )
+})
+
+export const buildMcpElicitationResponse = (
+  action: 'accept' | 'decline' | 'cancel',
+  content?: Record<string, string | number | boolean>
+) => {
+  if (action !== 'accept') {
+    return { action }
+  }
+
+  return content ? { action, content } : { action }
+}

--- a/packages/client/shared/pending-user-request.ts
+++ b/packages/client/shared/pending-user-request.ts
@@ -87,6 +87,7 @@ export type PendingElicitationField =
 export type PendingMcpElicitationForm = {
   kind: 'mcpElicitationForm'
   requestId: number
+  threadId: string | null
   message: string | null
   fields: PendingElicitationField[]
 }
@@ -94,6 +95,7 @@ export type PendingMcpElicitationForm = {
 export type PendingMcpElicitationUrl = {
   kind: 'mcpElicitationUrl'
   requestId: number
+  threadId: string | null
   message: string | null
   url: string
   elicitationId: string | null
@@ -295,6 +297,7 @@ export const parsePendingUserRequest = (request: CodexRpcServerRequest): Pending
         return {
           kind: 'mcpElicitationUrl',
           requestId: request.id,
+          threadId: asTrimmedString(params?.threadId),
           message: asTrimmedString(params?.message),
           url,
           elicitationId: asTrimmedString(params?.elicitationId)
@@ -326,6 +329,7 @@ export const parsePendingUserRequest = (request: CodexRpcServerRequest): Pending
       return {
         kind: 'mcpElicitationForm',
         requestId: request.id,
+        threadId: asTrimmedString(params?.threadId),
         message: asTrimmedString(params?.message),
         fields
       }

--- a/packages/client/shared/pending-user-request.ts
+++ b/packages/client/shared/pending-user-request.ts
@@ -362,3 +362,13 @@ export const buildMcpElicitationResponse = (
 
   return content ? { action, content } : { action }
 }
+
+export const buildPendingUserRequestDismissResponse = (request: PendingUserRequest) => {
+  switch (request.kind) {
+    case 'requestUserInput':
+      return buildRequestUserInputResponse({})
+    case 'mcpElicitationForm':
+    case 'mcpElicitationUrl':
+      return buildMcpElicitationResponse('cancel')
+  }
+}

--- a/packages/client/test/pending-user-request-drawer.test.ts
+++ b/packages/client/test/pending-user-request-drawer.test.ts
@@ -338,6 +338,30 @@ describe('pending user request drawer', () => {
     })
   })
 
+  it('omits unchecked optional boolean fields from elicitation form payloads', async () => {
+    const wrapper = mountDrawer({
+      kind: 'mcpElicitationForm',
+      requestId: 31,
+      threadId: null,
+      message: 'Provide the release metadata.',
+      fields: [{
+        kind: 'boolean',
+        key: 'approved',
+        label: 'Approved',
+        description: null,
+        required: false,
+        defaultValue: false
+      }]
+    })
+
+    await wrapper.get('button[type="submit"]').trigger('submit')
+
+    expect(wrapper.emitted('respond')?.[0]?.[0]).toEqual({
+      action: 'accept',
+      content: {}
+    })
+  })
+
   it('resets elicitation form state when a new request replaces the current one', async () => {
     const wrapper = mountDrawer({
       kind: 'mcpElicitationForm',

--- a/packages/client/test/pending-user-request-drawer.test.ts
+++ b/packages/client/test/pending-user-request-drawer.test.ts
@@ -27,12 +27,139 @@ const DrawerStub = defineComponent({
   }
 })
 
+const ButtonStub = defineComponent({
+  name: 'ButtonStub',
+  props: {
+    type: {
+      type: String,
+      default: 'button'
+    },
+    disabled: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['click'],
+  setup(props, { emit, slots }) {
+    return () => h('button', {
+      type: props.type,
+      disabled: props.disabled,
+      onClick: (event: MouseEvent) => emit('click', event)
+    }, slots.default?.())
+  }
+})
+
+const InputStub = defineComponent({
+  name: 'InputStub',
+  props: {
+    modelValue: {
+      type: [String, Number],
+      default: ''
+    },
+    type: {
+      type: String,
+      default: 'text'
+    },
+    id: {
+      type: String,
+      default: undefined
+    },
+    placeholder: {
+      type: String,
+      default: undefined
+    },
+    size: {
+      type: String,
+      default: undefined
+    }
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () => h('input', {
+      id: props.id,
+      type: props.type,
+      placeholder: props.placeholder,
+      value: props.modelValue,
+      onInput: (event: Event) => emit('update:modelValue', (event.target as HTMLInputElement).value)
+    })
+  }
+})
+
+const FormFieldStub = defineComponent({
+  name: 'FormFieldStub',
+  props: {
+    label: {
+      type: String,
+      default: undefined
+    },
+    description: {
+      type: String,
+      default: undefined
+    },
+    help: {
+      type: String,
+      default: undefined
+    },
+    error: {
+      type: [String, Boolean],
+      default: undefined
+    }
+  },
+  setup(props, { slots }) {
+    return () => h('div', { class: 'form-field-stub' }, [
+      props.label ? h('label', props.label) : null,
+      props.description ? h('p', props.description) : null,
+      slots.default?.(),
+      typeof props.error === 'string' ? h('p', props.error) : null,
+      props.help ? h('p', props.help) : null
+    ])
+  }
+})
+
+const NavigationMenuStub = defineComponent({
+  name: 'NavigationMenuStub',
+  props: {
+    items: {
+      type: Array,
+      default: () => []
+    }
+  },
+  setup(props, { slots }) {
+    return () => h('div', { class: 'navigation-menu-stub' }, (props.items as Array<Record<string, unknown>>).map((item, index) =>
+      h('button', {
+        key: `${String(item.label)}-${index}`,
+        type: 'button',
+        'data-active': String(item.active === true),
+        onClick: (event: Event) => {
+          const onSelect = item.onSelect
+          if (typeof onSelect === 'function') {
+            onSelect(event)
+          }
+        }
+      }, [
+        slots['item-label']?.({ item }),
+        slots['item-trailing']?.({ item })
+      ])
+    ))
+  }
+})
+
 const mountDrawer = (request: PendingUserRequest | null) =>
   mount(PendingUserRequestDrawer, {
     props: { request },
     global: {
       stubs: {
-        UDrawer: DrawerStub
+        UDrawer: DrawerStub,
+        UButton: ButtonStub,
+        UInput: InputStub,
+        UFormField: FormFieldStub,
+        UNavigationMenu: NavigationMenuStub,
+        UIcon: defineComponent({
+          name: 'IconStub',
+          setup() {
+            return () => h('span', { class: 'icon-stub' })
+          }
+        })
       }
     }
   })

--- a/packages/client/test/pending-user-request-drawer.test.ts
+++ b/packages/client/test/pending-user-request-drawer.test.ts
@@ -310,6 +310,51 @@ describe('pending user request drawer', () => {
     })
   })
 
+  it('resets elicitation form state when a new request replaces the current one', async () => {
+    const wrapper = mountDrawer({
+      kind: 'mcpElicitationForm',
+      requestId: 21,
+      threadId: null,
+      message: 'Provide the release metadata.',
+      fields: [{
+        kind: 'string',
+        key: 'email',
+        label: 'Email',
+        description: null,
+        required: true,
+        minLength: null,
+        maxLength: 80,
+        format: 'email',
+        defaultValue: null
+      }]
+    })
+
+    await wrapper.get('input[type="email"]').setValue('octocat@example.com')
+
+    await wrapper.setProps({
+      request: {
+        kind: 'mcpElicitationForm',
+        requestId: 22,
+        threadId: null,
+        message: 'Need a fresh value.',
+        fields: [{
+          kind: 'string',
+          key: 'email',
+          label: 'Email',
+          description: null,
+          required: true,
+          minLength: null,
+          maxLength: 80,
+          format: 'email',
+          defaultValue: null
+        }]
+      }
+    })
+    await nextTick()
+
+    expect(wrapper.get('input[type="email"]').element).toHaveProperty('value', '')
+  })
+
   it('supports url-mode accept, decline, and cancel actions', async () => {
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
     const wrapper = mountDrawer({

--- a/packages/client/test/pending-user-request-drawer.test.ts
+++ b/packages/client/test/pending-user-request-drawer.test.ts
@@ -165,7 +165,7 @@ const mountDrawer = (request: PendingUserRequest | null) =>
   })
 
 describe('pending user request drawer', () => {
-  it('renders request-user-input flows and emits structured answers', async () => {
+  it('renders request-user-input as a sequential flow and emits structured answers at the end', async () => {
     const wrapper = mountDrawer({
       kind: 'requestUserInput',
       requestId: 1,
@@ -186,20 +186,78 @@ describe('pending user request drawer', () => {
     })
 
     expect(wrapper.find('.drawer-stub').attributes('data-open')).toBe('true')
-    expect(wrapper.text()).toContain('Codex needs your input')
+    expect(wrapper.text()).toContain('Which direction should Codex take?')
+    expect(wrapper.text()).not.toContain('Implementation')
+    expect(wrapper.text()).not.toContain('Pending request')
+    expect(wrapper.text()).not.toContain('Custom answer')
 
     await wrapper.get('button[type="button"]').trigger('click')
-    await wrapper.get('input[type="text"]').setValue('Keep ChatWorkspace slim')
-    await wrapper.get('button[type="submit"]').trigger('submit')
+
+    expect(wrapper.text()).toContain('Ready to send')
+    expect(wrapper.text()).toContain('Use drawer')
+
+    await wrapper.get('form').trigger('submit')
 
     expect(wrapper.emitted('respond')?.[0]?.[0]).toEqual({
       answers: {
-        plan: ['Use drawer', 'Keep ChatWorkspace slim']
+        plan: ['Use drawer']
       }
     })
   })
 
-  it('renders secret input fields as password controls', () => {
+  it('advances across multiple questions and supports custom answers before submission', async () => {
+    const wrapper = mountDrawer({
+      kind: 'requestUserInput',
+      requestId: 11,
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      itemId: 'item-1',
+      questions: [{
+        header: 'Layout',
+        id: 'layout',
+        question: 'Choose the drawer layout.',
+        options: [{
+          label: 'Compact',
+          description: 'Keep the layout dense.'
+        }],
+        isOther: false,
+        isSecret: false
+      }, {
+        header: 'Notes',
+        id: 'notes',
+        question: 'Add any final guidance.',
+        options: [],
+        isOther: false,
+        isSecret: false
+      }]
+    })
+
+    expect(wrapper.text()).toContain('Choose the drawer layout.')
+    expect(wrapper.text()).not.toContain('Add any final guidance.')
+
+    await wrapper.get('button[type="button"]').trigger('click')
+
+    expect(wrapper.text()).toContain('Add any final guidance.')
+    expect(wrapper.text()).not.toContain('Choose the drawer layout.')
+
+    await wrapper.get('input[type="text"]').setValue('Keep the controls left aligned.')
+    await wrapper.get('form').trigger('submit')
+
+    expect(wrapper.text()).toContain('Ready to send')
+    expect(wrapper.text()).toContain('Compact')
+    expect(wrapper.text()).toContain('Keep the controls left aligned.')
+
+    await wrapper.get('form').trigger('submit')
+
+    expect(wrapper.emitted('respond')?.[0]?.[0]).toEqual({
+      answers: {
+        layout: ['Compact'],
+        notes: ['Keep the controls left aligned.']
+      }
+    })
+  })
+
+  it('renders secret input fields as password controls', async () => {
     const wrapper = mountDrawer({
       kind: 'requestUserInput',
       requestId: 2,
@@ -216,6 +274,7 @@ describe('pending user request drawer', () => {
       }]
     })
 
+    expect(wrapper.text()).not.toContain('Answer')
     expect(wrapper.find('input[type="password"]').exists()).toBe(true)
   })
 

--- a/packages/client/test/pending-user-request-drawer.test.ts
+++ b/packages/client/test/pending-user-request-drawer.test.ts
@@ -165,7 +165,7 @@ const mountDrawer = (request: PendingUserRequest | null) =>
   })
 
 describe('pending user request drawer', () => {
-  it('renders request-user-input as a sequential flow and emits structured answers at the end', async () => {
+  it('renders request-user-input as a sequential flow and emits structured answers on the last answer', async () => {
     const wrapper = mountDrawer({
       kind: 'requestUserInput',
       requestId: 1,
@@ -193,11 +193,6 @@ describe('pending user request drawer', () => {
 
     await wrapper.get('button[type="button"]').trigger('click')
 
-    expect(wrapper.text()).toContain('Ready to send')
-    expect(wrapper.text()).toContain('Use drawer')
-
-    await wrapper.get('form').trigger('submit')
-
     expect(wrapper.emitted('respond')?.[0]?.[0]).toEqual({
       answers: {
         plan: ['Use drawer']
@@ -205,7 +200,7 @@ describe('pending user request drawer', () => {
     })
   })
 
-  it('advances across multiple questions and supports custom answers before submission', async () => {
+  it('advances across multiple questions and submits from the final custom answer step', async () => {
     const wrapper = mountDrawer({
       kind: 'requestUserInput',
       requestId: 11,
@@ -241,12 +236,6 @@ describe('pending user request drawer', () => {
     expect(wrapper.text()).not.toContain('Choose the drawer layout.')
 
     await wrapper.get('input[type="text"]').setValue('Keep the controls left aligned.')
-    await wrapper.get('form').trigger('submit')
-
-    expect(wrapper.text()).toContain('Ready to send')
-    expect(wrapper.text()).toContain('Compact')
-    expect(wrapper.text()).toContain('Keep the controls left aligned.')
-
     await wrapper.get('form').trigger('submit')
 
     expect(wrapper.emitted('respond')?.[0]?.[0]).toEqual({

--- a/packages/client/test/pending-user-request-drawer.test.ts
+++ b/packages/client/test/pending-user-request-drawer.test.ts
@@ -271,6 +271,7 @@ describe('pending user request drawer', () => {
     const wrapper = mountDrawer({
       kind: 'mcpElicitationForm',
       requestId: 3,
+      threadId: null,
       message: 'Provide the release metadata.',
       fields: [{
         kind: 'string',
@@ -314,6 +315,7 @@ describe('pending user request drawer', () => {
     const wrapper = mountDrawer({
       kind: 'mcpElicitationUrl',
       requestId: 4,
+      threadId: null,
       message: 'Authorize the connector.',
       url: 'https://example.com/oauth',
       elicitationId: 'elic-2'

--- a/packages/client/test/pending-user-request-drawer.test.ts
+++ b/packages/client/test/pending-user-request-drawer.test.ts
@@ -409,4 +409,24 @@ describe('pending user request drawer', () => {
     }])
     expect(openSpy).toHaveBeenCalledWith('https://example.com/oauth', '_blank', 'noopener,noreferrer')
   })
+
+  it('cancels url-mode requests with unsafe URL schemes', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    const wrapper = mountDrawer({
+      kind: 'mcpElicitationUrl',
+      requestId: 5,
+      threadId: null,
+      message: 'Authorize the connector.',
+      url: 'javascript:alert(1)',
+      elicitationId: 'elic-3'
+    })
+
+    const buttons = wrapper.findAll('button')
+    await buttons[2]!.trigger('click')
+
+    expect(wrapper.emitted('respond')?.[0]?.[0]).toEqual({
+      action: 'cancel'
+    })
+    expect(openSpy).not.toHaveBeenCalled()
+  })
 })

--- a/packages/client/test/pending-user-request-drawer.test.ts
+++ b/packages/client/test/pending-user-request-drawer.test.ts
@@ -200,6 +200,34 @@ describe('pending user request drawer', () => {
     })
   })
 
+  it('dismisses request-user-input when the drawer is manually closed', async () => {
+    const wrapper = mountDrawer({
+      kind: 'requestUserInput',
+      requestId: 101,
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      itemId: 'item-1',
+      questions: [{
+        header: null,
+        id: 'plan',
+        question: 'Which direction should Codex take?',
+        options: [{
+          label: 'Use drawer',
+          description: null
+        }],
+        isOther: false,
+        isSecret: false
+      }]
+    })
+
+    wrapper.getComponent(DrawerStub).vm.$emit('update:open', false)
+    await nextTick()
+
+    expect(wrapper.emitted('respond')?.[0]?.[0]).toEqual({
+      answers: {}
+    })
+  })
+
   it('advances across multiple questions and submits from the final custom answer step', async () => {
     const wrapper = mountDrawer({
       kind: 'requestUserInput',

--- a/packages/client/test/pending-user-request-drawer.test.ts
+++ b/packages/client/test/pending-user-request-drawer.test.ts
@@ -1,0 +1,162 @@
+/* eslint-disable vue/one-component-per-file */
+// @vitest-environment jsdom
+
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, nextTick } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+import PendingUserRequestDrawer from '../app/components/PendingUserRequestDrawer.vue'
+import type { PendingUserRequest } from '../shared/pending-user-request'
+
+const DrawerStub = defineComponent({
+  name: 'DrawerStub',
+  props: {
+    open: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['update:open'],
+  setup(props, { slots }) {
+    return () => h('div', {
+      class: 'drawer-stub',
+      'data-open': String(props.open)
+    }, [
+      h('div', { class: 'drawer-header' }, slots.header?.()),
+      h('div', { class: 'drawer-body' }, slots.body?.())
+    ])
+  }
+})
+
+const mountDrawer = (request: PendingUserRequest | null) =>
+  mount(PendingUserRequestDrawer, {
+    props: { request },
+    global: {
+      stubs: {
+        UDrawer: DrawerStub
+      }
+    }
+  })
+
+describe('pending user request drawer', () => {
+  it('renders request-user-input flows and emits structured answers', async () => {
+    const wrapper = mountDrawer({
+      kind: 'requestUserInput',
+      requestId: 1,
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      itemId: 'item-1',
+      questions: [{
+        header: 'Implementation',
+        id: 'plan',
+        question: 'Which direction should Codex take?',
+        options: [{
+          label: 'Use drawer',
+          description: 'Move it out of the chat composer'
+        }],
+        isOther: true,
+        isSecret: false
+      }]
+    })
+
+    expect(wrapper.find('.drawer-stub').attributes('data-open')).toBe('true')
+    expect(wrapper.text()).toContain('Codex needs your input')
+
+    await wrapper.get('button[type="button"]').trigger('click')
+    await wrapper.get('input[type="text"]').setValue('Keep ChatWorkspace slim')
+    await wrapper.get('button[type="submit"]').trigger('submit')
+
+    expect(wrapper.emitted('respond')?.[0]?.[0]).toEqual({
+      answers: {
+        plan: ['Use drawer', 'Keep ChatWorkspace slim']
+      }
+    })
+  })
+
+  it('renders secret input fields as password controls', () => {
+    const wrapper = mountDrawer({
+      kind: 'requestUserInput',
+      requestId: 2,
+      threadId: null,
+      turnId: null,
+      itemId: null,
+      questions: [{
+        header: null,
+        id: 'token',
+        question: 'Enter the token',
+        options: [],
+        isOther: false,
+        isSecret: true
+      }]
+    })
+
+    expect(wrapper.find('input[type="password"]').exists()).toBe(true)
+  })
+
+  it('renders elicitation form requests and emits typed accept payloads', async () => {
+    const wrapper = mountDrawer({
+      kind: 'mcpElicitationForm',
+      requestId: 3,
+      message: 'Provide the release metadata.',
+      fields: [{
+        kind: 'string',
+        key: 'email',
+        label: 'Email',
+        description: null,
+        required: true,
+        minLength: null,
+        maxLength: 80,
+        format: 'email',
+        defaultValue: null
+      }, {
+        kind: 'number',
+        key: 'attempts',
+        label: 'Attempts',
+        description: null,
+        required: true,
+        numericType: 'integer',
+        minimum: 1,
+        maximum: 5,
+        defaultValue: null
+      }]
+    })
+
+    const inputs = wrapper.findAll('input')
+    await inputs[0]!.setValue('octocat@example.com')
+    await inputs[1]!.setValue('3')
+    await wrapper.get('button[type="submit"]').trigger('submit')
+
+    expect(wrapper.emitted('respond')?.[0]?.[0]).toEqual({
+      action: 'accept',
+      content: {
+        email: 'octocat@example.com',
+        attempts: 3
+      }
+    })
+  })
+
+  it('supports url-mode accept, decline, and cancel actions', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    const wrapper = mountDrawer({
+      kind: 'mcpElicitationUrl',
+      requestId: 4,
+      message: 'Authorize the connector.',
+      url: 'https://example.com/oauth',
+      elicitationId: 'elic-2'
+    })
+
+    const buttons = wrapper.findAll('button')
+    await buttons[0]!.trigger('click')
+    await buttons[1]!.trigger('click')
+    await buttons[2]!.trigger('click')
+    await nextTick()
+
+    expect(wrapper.emitted('respond')?.map(event => event[0])).toEqual([{
+      action: 'decline'
+    }, {
+      action: 'cancel'
+    }, {
+      action: 'accept'
+    }])
+    expect(openSpy).toHaveBeenCalledWith('https://example.com/oauth', '_blank', 'noopener,noreferrer')
+  })
+})

--- a/packages/client/test/pending-user-request-shared.test.ts
+++ b/packages/client/test/pending-user-request-shared.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest'
+import { usePendingUserRequest } from '../app/composables/usePendingUserRequest'
+import { toServerRequestResponse } from '../shared/codex-rpc'
+import {
+  buildMcpElicitationResponse,
+  buildRequestUserInputResponse,
+  parsePendingUserRequest
+} from '../shared/pending-user-request'
+
+describe('pending user request shared helpers', () => {
+  it('parses request-user-input questions and builds answers payloads', () => {
+    const parsed = parsePendingUserRequest({
+      id: 7,
+      method: 'item/tool/requestUserInput',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        itemId: 'item-1',
+        questions: [{
+          header: 'Scope',
+          id: 'scope',
+          question: 'What should Codex focus on?',
+          options: [{
+            label: 'UI',
+            description: 'Tweak the interface'
+          }],
+          isOther: true,
+          isSecret: false
+        }]
+      }
+    })
+
+    expect(parsed).toEqual({
+      kind: 'requestUserInput',
+      requestId: 7,
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      itemId: 'item-1',
+      questions: [{
+        header: 'Scope',
+        id: 'scope',
+        question: 'What should Codex focus on?',
+        options: [{
+          label: 'UI',
+          description: 'Tweak the interface'
+        }],
+        isOther: true,
+        isSecret: false
+      }]
+    })
+
+    expect(buildRequestUserInputResponse({
+      scope: [' UI ', '', 'drawer copy']
+    })).toEqual({
+      answers: {
+        scope: ['UI', 'drawer copy']
+      }
+    })
+  })
+
+  it('parses MCP elicitation form and url requests', () => {
+    expect(parsePendingUserRequest({
+      id: 9,
+      method: 'mcpServer/elicitation/request',
+      params: {
+        mode: 'form',
+        message: 'Need confirmation',
+        requestedSchema: {
+          type: 'object',
+          properties: {
+            email: {
+              type: 'string',
+              title: 'Email',
+              format: 'email'
+            },
+            approved: {
+              type: 'boolean',
+              title: 'Approved'
+            }
+          },
+          required: ['email']
+        }
+      }
+    })).toEqual({
+      kind: 'mcpElicitationForm',
+      requestId: 9,
+      message: 'Need confirmation',
+      fields: [{
+        kind: 'string',
+        key: 'email',
+        label: 'Email',
+        description: null,
+        required: true,
+        minLength: null,
+        maxLength: null,
+        format: 'email',
+        defaultValue: null
+      }, {
+        kind: 'boolean',
+        key: 'approved',
+        label: 'Approved',
+        description: null,
+        required: false,
+        defaultValue: false
+      }]
+    })
+
+    expect(parsePendingUserRequest({
+      id: 10,
+      method: 'mcpServer/elicitation/request',
+      params: {
+        mode: 'url',
+        message: 'Open the auth flow',
+        url: 'https://example.com/auth',
+        elicitationId: 'elic-1'
+      }
+    })).toEqual({
+      kind: 'mcpElicitationUrl',
+      requestId: 10,
+      message: 'Open the auth flow',
+      url: 'https://example.com/auth',
+      elicitationId: 'elic-1'
+    })
+
+    expect(buildMcpElicitationResponse('accept', {
+      email: 'octocat@example.com',
+      approved: true
+    })).toEqual({
+      action: 'accept',
+      content: {
+        email: 'octocat@example.com',
+        approved: true
+      }
+    })
+  })
+
+  it('delegates interactive server requests to the UI handler before falling back', async () => {
+    await expect(toServerRequestResponse({
+      id: 12,
+      method: 'item/tool/requestUserInput',
+      params: {
+        questions: [{
+          id: 'choice',
+          question: 'Pick one'
+        }]
+      }
+    }, {
+      handler: async () => ({
+        answers: {
+          choice: ['Drawer flow']
+        }
+      })
+    })).resolves.toEqual({
+      answers: {
+        choice: ['Drawer flow']
+      }
+    })
+
+    await expect(toServerRequestResponse({
+      id: 13,
+      method: 'mcpServer/elicitation/request',
+      params: {
+        mode: 'url',
+        url: 'https://example.com/auth'
+      }
+    }, {
+      handler: async () => null
+    })).resolves.toEqual({
+      action: 'decline',
+      content: null,
+      _meta: null
+    })
+  })
+
+  it('holds an incoming request until the UI resolves it', async () => {
+    const manager = usePendingUserRequest(`project-${Date.now()}`)
+    const responsePromise = manager.handleServerRequest({
+      id: 11,
+      method: 'item/tool/requestUserInput',
+      params: {
+        questions: [{
+          id: 'choice',
+          question: 'Pick one',
+          options: [{ label: 'Ship', description: 'Proceed' }]
+        }]
+      }
+    })
+
+    expect(manager.pendingRequest.value?.kind).toBe('requestUserInput')
+
+    manager.resolveCurrentRequest({
+      answers: {
+        choice: ['Ship']
+      }
+    })
+
+    await expect(responsePromise).resolves.toEqual({
+      answers: {
+        choice: ['Ship']
+      }
+    })
+    expect(manager.pendingRequest.value).toBeNull()
+  })
+})

--- a/packages/client/test/pending-user-request-shared.test.ts
+++ b/packages/client/test/pending-user-request-shared.test.ts
@@ -241,4 +241,49 @@ describe('pending user request shared helpers', () => {
       }
     })
   })
+
+  it('cancels pending requests on teardown with protocol-specific responses', async () => {
+    const projectId = `project-${Date.now()}`
+    const activeThreadId = ref('thread-a')
+    const manager = usePendingUserRequest(projectId, activeThreadId)
+
+    const userInputPromise = manager.handleServerRequest({
+      id: 15,
+      method: 'item/tool/requestUserInput',
+      params: {
+        threadId: 'thread-a',
+        questions: [{
+          id: 'choice',
+          question: 'Pick one'
+        }]
+      }
+    })
+    const mcpPromise = manager.handleServerRequest({
+      id: 16,
+      method: 'mcpServer/elicitation/request',
+      params: {
+        threadId: 'thread-b',
+        mode: 'form',
+        requestedSchema: {
+          type: 'object',
+          properties: {
+            email: {
+              type: 'string',
+              title: 'Email'
+            }
+          }
+        }
+      }
+    })
+
+    manager.cancelAllPendingRequests()
+
+    await expect(userInputPromise).resolves.toEqual({
+      answers: {}
+    })
+    await expect(mcpPromise).resolves.toEqual({
+      action: 'cancel'
+    })
+    expect(manager.pendingRequest.value).toBeNull()
+  })
 })

--- a/packages/client/test/pending-user-request-shared.test.ts
+++ b/packages/client/test/pending-user-request-shared.test.ts
@@ -1,3 +1,4 @@
+import { ref } from 'vue'
 import { describe, expect, it } from 'vitest'
 import { usePendingUserRequest } from '../app/composables/usePendingUserRequest'
 import { toServerRequestResponse } from '../shared/codex-rpc'
@@ -84,6 +85,7 @@ describe('pending user request shared helpers', () => {
     })).toEqual({
       kind: 'mcpElicitationForm',
       requestId: 9,
+      threadId: null,
       message: 'Need confirmation',
       fields: [{
         kind: 'string',
@@ -117,6 +119,7 @@ describe('pending user request shared helpers', () => {
     })).toEqual({
       kind: 'mcpElicitationUrl',
       requestId: 10,
+      threadId: null,
       message: 'Open the auth flow',
       url: 'https://example.com/auth',
       elicitationId: 'elic-1'
@@ -173,7 +176,7 @@ describe('pending user request shared helpers', () => {
   })
 
   it('holds an incoming request until the UI resolves it', async () => {
-    const manager = usePendingUserRequest(`project-${Date.now()}`)
+    const manager = usePendingUserRequest(`project-${Date.now()}`, ref('thread-1'))
     const responsePromise = manager.handleServerRequest({
       id: 11,
       method: 'item/tool/requestUserInput',
@@ -200,5 +203,42 @@ describe('pending user request shared helpers', () => {
       }
     })
     expect(manager.pendingRequest.value).toBeNull()
+  })
+
+  it('only exposes requests for the active thread session', async () => {
+    const activeThreadId = ref('thread-a')
+    const manager = usePendingUserRequest(`project-${Date.now()}`, activeThreadId)
+    const responsePromise = manager.handleServerRequest({
+      id: 14,
+      method: 'item/tool/requestUserInput',
+      params: {
+        threadId: 'thread-a',
+        questions: [{
+          id: 'choice',
+          question: 'Pick one',
+          options: [{ label: 'Ship' }]
+        }]
+      }
+    })
+
+    expect(manager.pendingRequest.value?.threadId).toBe('thread-a')
+
+    activeThreadId.value = 'thread-b'
+    expect(manager.pendingRequest.value).toBeNull()
+
+    activeThreadId.value = 'thread-a'
+    expect(manager.pendingRequest.value?.threadId).toBe('thread-a')
+
+    manager.resolveCurrentRequest({
+      answers: {
+        choice: ['Ship']
+      }
+    })
+
+    await expect(responsePromise).resolves.toEqual({
+      answers: {
+        choice: ['Ship']
+      }
+    })
   })
 })


### PR DESCRIPTION
## Summary
- add client-side handling for pending user input and MCP elicitation requests
- move the request interaction UI out of ChatWorkspace into focused drawer/form components
- support compact sequential question flow, active-thread scoping, and teardown-safe request cleanup

## Follow-up commits
- fix: dismiss pending requests when the drawer closes
- fix: block unsafe elicitation URLs
- fix: omit unset optional boolean elicitation values

## Validation
- pnpm --filter @codori/client test
- pnpm --filter @codori/client typecheck
- pnpm build

Closes #13