### PR TITLE
Add /review flow and slash command palette

### DIFF
--- a/packages/client/app/components/BottomDrawerShell.vue
+++ b/packages/client/app/components/BottomDrawerShell.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+const props = withDefaults(defineProps<{
+  open?: boolean
+  title?: string
+  description?: string
+  hideHeader?: boolean
+  bodyClass?: string
+}>(), {
+  open: false,
+  title: '',
+  description: '',
+  hideHeader: false,
+  bodyClass: ''
+})
+
+const emit = defineEmits<{
+  'update:open': [open: boolean]
+}>()
+</script>
+
+<template>
+  <UDrawer
+    :open="open"
+    direction="bottom"
+    :handle="true"
+    :ui="{
+      content: 'inset-x-auto right-auto bottom-0 left-1/2 w-[90vw] max-w-[52rem] -translate-x-1/2 rounded-t-2xl rounded-b-none border-x border-t border-default bg-default shadow-2xl md:w-[min(50vw,52rem)]',
+      container: 'gap-0 p-0',
+      handle: 'mt-2 !h-1 !w-10 rounded-full',
+      header: hideHeader ? 'hidden' : 'px-4 pb-1 pt-3 md:px-5',
+      body: bodyClass || 'px-4 pb-4 pt-2 md:px-5',
+      footer: 'hidden'
+    }"
+    @update:open="emit('update:open', $event)"
+  >
+    <template #header>
+      <div
+        v-if="!hideHeader && (title || description || $slots.header)"
+        class="space-y-1.5"
+      >
+        <slot name="header">
+          <h2
+            v-if="title"
+            class="text-sm font-semibold text-highlighted md:text-base"
+          >
+            {{ title }}
+          </h2>
+          <p
+            v-if="description"
+            class="text-sm leading-5 text-muted"
+          >
+            {{ description }}
+          </p>
+        </slot>
+      </div>
+    </template>
+
+    <template #body>
+      <slot />
+    </template>
+  </UDrawer>
+</template>

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { useRouter } from '#imports'
+import { useRouter, useRuntimeConfig } from '#imports'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import MessageContent from './MessageContent.vue'
+import ReviewStartDrawer from './ReviewStartDrawer.vue'
 import PendingUserRequestDrawer from './PendingUserRequestDrawer.vue'
 import {
   reconcileOptimisticUserMessage,
@@ -48,6 +49,9 @@ import {
   type CodexRpcNotification,
   type CodexThread,
   type CodexThreadItem,
+  type ReviewStartParams,
+  type ReviewStartResponse,
+  type ReviewTarget,
   type ThreadReadResponse,
   type ThreadResumeResponse,
   type ThreadStartResponse,
@@ -69,7 +73,19 @@ import {
   visibleModelOptions,
   type ReasoningEffort
 } from '~~/shared/chat-prompt-controls'
-import { toProjectThreadRoute } from '~~/shared/codori'
+import {
+  resolveProjectGitBranchesUrl,
+  toProjectThreadRoute,
+  type ProjectGitBranchesResponse
+} from '~~/shared/codori'
+import {
+  filterSlashCommands,
+  findActiveSlashCommand,
+  parseSubmittedSlashCommand,
+  SLASH_COMMANDS,
+  toSlashCommandCompletion,
+  type SlashCommandDefinition
+} from '~~/shared/slash-commands'
 
 const props = defineProps<{
   projectId: string
@@ -77,6 +93,7 @@ const props = defineProps<{
 }>()
 
 const router = useRouter()
+const runtimeConfig = useRuntimeConfig()
 const { getClient } = useRpc()
 const {
   loaded,
@@ -109,6 +126,9 @@ const {
   uploadAttachments
 } = useChatAttachments(props.projectId)
 const input = ref('')
+const chatPromptRef = ref<{
+  textareaRef?: unknown
+} | null>(null)
 const scrollViewport = ref<HTMLElement | null>(null)
 const pinnedToBottom = ref(true)
 const session = useChatSession(props.projectId)
@@ -145,10 +165,23 @@ const submitError = computed(() => composerError.value ? new Error(composerError
 const interruptRequested = ref(false)
 const awaitingAssistantOutput = ref(false)
 const sendMessageLocked = ref(false)
+const reviewStartPending = ref(false)
+const promptSelectionStart = ref(0)
+const promptSelectionEnd = ref(0)
+const isPromptFocused = ref(false)
+const slashHighlightIndex = ref(0)
+const reviewDrawerOpen = ref(false)
+const reviewDrawerMode = ref<'target' | 'branch'>('target')
+const reviewDrawerCommandText = ref('/review')
+const reviewBranches = ref<string[]>([])
+const reviewCurrentBranch = ref<string | null>(null)
+const reviewBranchesLoading = ref(false)
+const reviewBranchesError = ref<string | null>(null)
 const isBusy = computed(() =>
   status.value === 'submitted'
   || status.value === 'streaming'
   || isUploading.value
+  || reviewStartPending.value
 )
 const hasDraftContent = computed(() =>
   input.value.trim().length > 0
@@ -158,6 +191,7 @@ const isComposerDisabled = computed(() =>
   isUploading.value
   || interruptRequested.value
   || hasPendingRequest.value
+  || reviewStartPending.value
 )
 const composerPlaceholder = computed(() =>
   hasPendingRequest.value
@@ -180,6 +214,50 @@ const showWelcomeState = computed(() =>
   && !activeThreadId.value
   && messages.value.length === 0
   && !isBusy.value
+)
+
+const slashCommands = computed(() =>
+  SLASH_COMMANDS.filter(() => !hasPendingRequest.value)
+)
+
+const activeSlashMatch = computed(() =>
+  isPromptFocused.value
+    ? findActiveSlashCommand(input.value, promptSelectionStart.value, promptSelectionEnd.value)
+    : null
+)
+
+const filteredSlashCommands = computed(() =>
+  activeSlashMatch.value
+    ? filterSlashCommands(slashCommands.value, activeSlashMatch.value.query)
+    : []
+)
+
+const slashDropdownOpen = computed(() =>
+  !reviewDrawerOpen.value
+  && Boolean(activeSlashMatch.value)
+  && filteredSlashCommands.value.length > 0
+)
+
+const highlightedSlashCommand = computed(() =>
+  filteredSlashCommands.value[slashHighlightIndex.value] ?? filteredSlashCommands.value[0] ?? null
+)
+
+const slashPaletteGroups = computed(() => [{
+  id: 'slash-commands',
+  ignoreFilter: true,
+  items: filteredSlashCommands.value.map((command, index) => ({
+    label: `/${command.name}`,
+    description: command.description,
+    icon: command.name === 'review' ? 'i-lucide-search-check' : 'i-lucide-terminal',
+    active: index === slashHighlightIndex.value,
+    onSelect: () => {
+      void activateSlashCommand(command, command.supportsInlineArgs ? 'complete' : 'execute')
+    }
+  }))
+}])
+
+const reviewBaseBranches = computed(() =>
+  reviewBranches.value.filter(branch => branch !== reviewCurrentBranch.value)
 )
 
 const starterPrompts = computed(() => {
@@ -561,6 +639,238 @@ const formatAttachmentSize = (size: number) => {
   }
 
   return `${size} B`
+}
+
+const isTextareaElement = (value: unknown): value is HTMLTextAreaElement =>
+  typeof HTMLTextAreaElement !== 'undefined'
+  && value instanceof HTMLTextAreaElement
+
+const getPromptTextarea = () => {
+  const exposed = chatPromptRef.value?.textareaRef
+  if (isTextareaElement(exposed)) {
+    return exposed
+  }
+
+  if (
+    typeof exposed === 'object'
+    && exposed !== null
+    && 'value' in exposed
+    && isTextareaElement(exposed.value)
+  ) {
+    return exposed.value
+  }
+
+  return null
+}
+
+const syncPromptSelectionFromDom = () => {
+  const textarea = getPromptTextarea()
+  promptSelectionStart.value = textarea?.selectionStart ?? input.value.length
+  promptSelectionEnd.value = textarea?.selectionEnd ?? input.value.length
+}
+
+const focusPromptAt = async (position?: number) => {
+  await nextTick()
+  const textarea = getPromptTextarea()
+  if (!textarea) {
+    return
+  }
+
+  const nextPosition = position ?? textarea.value.length
+  textarea.focus()
+  textarea.setSelectionRange(nextPosition, nextPosition)
+  promptSelectionStart.value = nextPosition
+  promptSelectionEnd.value = nextPosition
+  isPromptFocused.value = true
+}
+
+const setComposerError = (messageText: string) => {
+  markAwaitingAssistantOutput(false)
+  error.value = messageText
+  status.value = 'error'
+}
+
+const resetReviewDrawerState = () => {
+  reviewDrawerMode.value = 'target'
+  reviewDrawerCommandText.value = '/review'
+  reviewBranchesLoading.value = false
+  reviewBranchesError.value = null
+}
+
+const closeReviewDrawer = () => {
+  reviewDrawerOpen.value = false
+  resetReviewDrawerState()
+}
+
+const openReviewDrawer = (commandText = '/review') => {
+  reviewDrawerCommandText.value = commandText
+  reviewDrawerMode.value = 'target'
+  reviewBranchesError.value = null
+  reviewDrawerOpen.value = true
+}
+
+const moveSlashHighlight = (delta: number) => {
+  if (!filteredSlashCommands.value.length) {
+    slashHighlightIndex.value = 0
+    return
+  }
+
+  const maxIndex = filteredSlashCommands.value.length - 1
+  const nextIndex = slashHighlightIndex.value + delta
+  if (nextIndex < 0) {
+    slashHighlightIndex.value = maxIndex
+    return
+  }
+
+  if (nextIndex > maxIndex) {
+    slashHighlightIndex.value = 0
+    return
+  }
+
+  slashHighlightIndex.value = nextIndex
+}
+
+const completeSlashCommand = async (command: SlashCommandDefinition) => {
+  const match = activeSlashMatch.value
+  if (!match) {
+    return
+  }
+
+  const completion = toSlashCommandCompletion(command)
+  input.value = `${input.value.slice(0, match.start)}${completion}${input.value.slice(match.end)}`
+  await focusPromptAt(match.start + completion.length)
+}
+
+const fetchProjectGitBranches = async () => {
+  reviewBranchesLoading.value = true
+  reviewBranchesError.value = null
+
+  try {
+    const response = await fetch(resolveProjectGitBranchesUrl({
+      projectId: props.projectId,
+      configuredBase: String(runtimeConfig.public.serverBase ?? '')
+    }))
+
+    const body = await response.json() as ProjectGitBranchesResponse | { error?: { message?: string } }
+    if (!response.ok) {
+      throw new Error(body && typeof body === 'object' && 'error' in body
+        ? body.error?.message ?? 'Failed to load local branches.'
+        : 'Failed to load local branches.')
+    }
+
+    const result = body as ProjectGitBranchesResponse
+    reviewCurrentBranch.value = result.currentBranch
+    reviewBranches.value = result.branches
+  } finally {
+    reviewBranchesLoading.value = false
+  }
+}
+
+const openBaseBranchPicker = async () => {
+  reviewDrawerMode.value = 'branch'
+
+  try {
+    await fetchProjectGitBranches()
+    if (!reviewBaseBranches.value.length) {
+      reviewBranchesError.value = 'No local base branches are available to compare against.'
+    }
+  } catch (caughtError) {
+    reviewBranchesError.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
+  }
+}
+
+const startReview = async (target: ReviewTarget) => {
+  if (hasPendingRequest.value || isBusy.value) {
+    setComposerError('Review can only start when the current thread is idle.')
+    return
+  }
+
+  reviewStartPending.value = true
+  const draftText = reviewDrawerCommandText.value
+  const submittedAttachments = attachments.value.slice()
+  input.value = ''
+  clearAttachments({ revoke: false })
+
+  try {
+    const client = getClient(props.projectId)
+    const liveStream = await ensurePendingLiveStream()
+    error.value = null
+    status.value = 'submitted'
+    tokenUsage.value = null
+    markAwaitingAssistantOutput(true)
+
+    const response = await client.request<ReviewStartResponse>('review/start', {
+      threadId: liveStream.threadId,
+      delivery: 'inline',
+      target
+    } satisfies ReviewStartParams)
+
+    setLiveStreamTurnId(liveStream, response.turn.id)
+    replayBufferedNotifications(liveStream)
+    closeReviewDrawer()
+  } catch (caughtError) {
+    restoreDraftIfPristine(draftText, submittedAttachments)
+    setComposerError(caughtError instanceof Error ? caughtError.message : String(caughtError))
+  } finally {
+    reviewStartPending.value = false
+  }
+}
+
+const handleSlashCommandSubmission = async (
+  rawText: string,
+  submittedAttachments: DraftAttachment[]
+) => {
+  const slashCommand = parseSubmittedSlashCommand(rawText)
+  if (!slashCommand) {
+    return false
+  }
+
+  const command = slashCommands.value.find(candidate => candidate.name === slashCommand.name)
+  if (!command) {
+    return false
+  }
+
+  if (submittedAttachments.length > 0) {
+    setComposerError('Slash commands do not support image attachments yet.')
+    return true
+  }
+
+  if (!slashCommand.isBare) {
+    setComposerError('`/review` currently only supports the bare command. Choose the diff target in the review drawer.')
+    return true
+  }
+
+  error.value = null
+  status.value = 'ready'
+  openReviewDrawer(`/${command.name}`)
+  await focusPromptAt(rawText.trim().length)
+  return true
+}
+
+const activateSlashCommand = async (
+  command: SlashCommandDefinition,
+  mode: 'complete' | 'execute'
+) => {
+  if (mode === 'complete') {
+    await completeSlashCommand(command)
+    return
+  }
+
+  await handleSlashCommandSubmission(`/${command.name}`, attachments.value.slice())
+}
+
+const handleReviewDrawerOpenChange = (open: boolean) => {
+  if (open) {
+    reviewDrawerOpen.value = true
+    return
+  }
+
+  closeReviewDrawer()
+}
+
+const handleReviewDrawerBack = () => {
+  reviewDrawerMode.value = 'target'
+  reviewBranchesError.value = null
 }
 
 const removeOptimisticMessage = (messageId: string) => {
@@ -1794,10 +2104,16 @@ const sendMessage = async () => {
   }
 
   sendMessageLocked.value = true
-  const text = input.value.trim()
+  const rawText = input.value
+  const text = rawText.trim()
   const submittedAttachments = attachments.value.slice()
 
   if (!text && submittedAttachments.length === 0) {
+    sendMessageLocked.value = false
+    return
+  }
+
+  if (await handleSlashCommandSubmission(rawText, submittedAttachments)) {
     sendMessageLocked.value = false
     return
   }
@@ -1961,9 +2277,56 @@ const respondToPendingRequest = (response: unknown) => {
   resolveCurrentRequest(response)
 }
 
+const onPromptKeydown = (event: KeyboardEvent) => {
+  if (!slashDropdownOpen.value) {
+    return
+  }
+
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    moveSlashHighlight(1)
+    return
+  }
+
+  if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    moveSlashHighlight(-1)
+    return
+  }
+
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    isPromptFocused.value = false
+    return
+  }
+
+  if (event.key === ' ') {
+    const command = highlightedSlashCommand.value
+    if (!command) {
+      return
+    }
+
+    event.preventDefault()
+    void activateSlashCommand(command, 'complete')
+  }
+}
+
 const onPromptEnter = (event: KeyboardEvent) => {
   if (!shouldSubmit(event)) {
     return
+  }
+
+  if (slashDropdownOpen.value) {
+    const command = highlightedSlashCommand.value
+    if (command) {
+      event.preventDefault()
+      const isExactMatch = activeSlashMatch.value?.query === command.name
+      const action = isExactMatch && command.executeOnEnter && !command.supportsInlineArgs
+        ? 'execute'
+        : 'complete'
+      void activateSlashCommand(command, action)
+      return
+    }
   }
 
   event.preventDefault()
@@ -2037,6 +2400,17 @@ watch(status, (nextStatus, previousStatus) => {
   void scheduleScrollToBottom(nextStatus === 'streaming' ? 'auto' : 'smooth')
 }, { flush: 'post' })
 
+watch(filteredSlashCommands, (commands) => {
+  if (!commands.length) {
+    slashHighlightIndex.value = 0
+    return
+  }
+
+  if (slashHighlightIndex.value >= commands.length) {
+    slashHighlightIndex.value = 0
+  }
+}, { flush: 'sync' })
+
 watch([selectedModel, availableModels], () => {
   const nextSelection = coercePromptSelection(effectiveModelList.value, selectedModel.value, selectedEffort.value)
   if (selectedModel.value !== nextSelection.model) {
@@ -2048,6 +2422,11 @@ watch([selectedModel, availableModels], () => {
     selectedEffort.value = nextSelection.effort
   }
 }, { flush: 'sync' })
+
+watch(input, async () => {
+  await nextTick()
+  syncPromptSelectionFromDom()
+}, { flush: 'post' })
 </script>
 
 <template>
@@ -2168,14 +2547,39 @@ watch([selectedModel, availableModels], () => {
             Drop images to attach them
           </div>
 
+          <UCommandPalette
+            v-if="slashDropdownOpen"
+            :groups="slashPaletteGroups"
+            :input="false"
+            :search-term="activeSlashMatch?.query ?? ''"
+            class="absolute inset-x-0 bottom-full z-20 mb-2 overflow-hidden rounded-2xl border border-default bg-default/95 shadow-2xl backdrop-blur"
+            :ui="{
+              root: 'min-h-0',
+              content: 'max-h-72 overflow-y-auto p-2',
+              group: 'space-y-1',
+              item: 'rounded-xl px-3 py-2.5',
+              itemLeadingIcon: 'size-4',
+              itemLabel: 'text-sm font-medium',
+              itemDescription: 'text-xs leading-5'
+            }"
+          />
+
           <UChatPrompt
+            ref="chatPromptRef"
             v-model="input"
             :placeholder="composerPlaceholder"
             :error="submitError"
             :disabled="isComposerDisabled"
             autoresize
             @submit.prevent="sendMessage"
+            @keydown="onPromptKeydown"
             @keydown.enter="onPromptEnter"
+            @input="syncPromptSelectionFromDom"
+            @click="syncPromptSelectionFromDom"
+            @keyup="syncPromptSelectionFromDom"
+            @focus="isPromptFocused = true; syncPromptSelectionFromDom()"
+            @blur="isPromptFocused = false"
+            @select="syncPromptSelectionFromDom"
             @compositionstart="onCompositionStart"
             @compositionend="onCompositionEnd"
             @paste="onPaste"
@@ -2391,5 +2795,19 @@ watch([selectedModel, availableModels], () => {
   <PendingUserRequestDrawer
     :request="pendingRequest"
     @respond="respondToPendingRequest"
+  />
+
+  <ReviewStartDrawer
+    :open="reviewDrawerOpen"
+    :mode="reviewDrawerMode"
+    :branches="reviewBaseBranches"
+    :current-branch="reviewCurrentBranch"
+    :loading="reviewBranchesLoading"
+    :error="reviewBranchesError"
+    @update:open="handleReviewDrawerOpenChange"
+    @choose-current-changes="startReview({ type: 'uncommittedChanges' })"
+    @choose-base-branch-mode="openBaseBranchPicker"
+    @choose-base-branch="(branch) => startReview({ type: 'baseBranch', branch })"
+    @back="handleReviewDrawerBack"
   />
 </template>

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -1,6 +1,14 @@
 <script setup lang="ts">
 import { useRouter, useRuntimeConfig } from '#imports'
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch,
+  type ComponentPublicInstance
+} from 'vue'
 import MessageContent from './MessageContent.vue'
 import ReviewStartDrawer from './ReviewStartDrawer.vue'
 import PendingUserRequestDrawer from './PendingUserRequestDrawer.vue'
@@ -134,7 +142,7 @@ const input = ref('')
 const chatPromptRef = ref<{
   textareaRef?: unknown
 } | null>(null)
-const slashDropdownRef = ref<HTMLElement | null>(null)
+const slashDropdownRef = ref<ComponentPublicInstance | HTMLElement | null>(null)
 const scrollViewport = ref<HTMLElement | null>(null)
 const pinnedToBottom = ref(true)
 const session = useChatSession(props.projectId)
@@ -714,9 +722,19 @@ const focusPromptAt = async (position?: number) => {
   isPromptFocused.value = true
 }
 
+const resolveSlashDropdownElement = () => {
+  const target = slashDropdownRef.value
+  if (target instanceof HTMLElement) {
+    return target
+  }
+
+  const rootElement = target?.$el
+  return rootElement instanceof HTMLElement ? rootElement : null
+}
+
 const shouldRetainPromptFocus = (nextFocused: EventTarget | null) =>
   nextFocused instanceof Node
-  && Boolean(slashDropdownRef.value?.contains(nextFocused))
+  && Boolean(resolveSlashDropdownElement()?.contains(nextFocused))
 
 const handlePromptBlur = (event: FocusEvent) => {
   if (shouldRetainPromptFocus(event.relatedTarget)) {

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -10,6 +10,7 @@ import {
   removePendingUserMessageId,
   resolvePromptSubmitStatus,
   resolveTurnSubmissionMethod,
+  shouldAdvanceLiveStreamTurn,
   shouldApplyNotificationToCurrentTurn,
   shouldSubmitViaTurnSteer,
   shouldAwaitThreadHydration,
@@ -22,7 +23,11 @@ import { useChatSession, type LiveStream, type SubagentPanelState } from '../com
 import { useProjects } from '../composables/useProjects'
 import { useRpc } from '../composables/useRpc'
 import { useChatSubmitGuard } from '../composables/useChatSubmitGuard'
-import { resolveThreadSummaryTitle, useThreadSummaries } from '../composables/useThreadSummaries'
+import {
+  normalizeThreadTitleCandidate,
+  resolveThreadSummaryTitle,
+  useThreadSummaries
+} from '../composables/useThreadSummaries'
 import { resolveChatMessagesStatus, shouldAwaitAssistantOutput } from '../utils/chat-messages-status'
 import {
   ITEM_PART,
@@ -129,6 +134,7 @@ const input = ref('')
 const chatPromptRef = ref<{
   textareaRef?: unknown
 } | null>(null)
+const slashDropdownRef = ref<HTMLElement | null>(null)
 const scrollViewport = ref<HTMLElement | null>(null)
 const pinnedToBottom = ref(true)
 const session = useChatSession(props.projectId)
@@ -169,6 +175,7 @@ const reviewStartPending = ref(false)
 const promptSelectionStart = ref(0)
 const promptSelectionEnd = ref(0)
 const isPromptFocused = ref(false)
+const dismissedSlashMatchKey = ref<string | null>(null)
 const slashHighlightIndex = ref(0)
 const reviewDrawerOpen = ref(false)
 const reviewDrawerMode = ref<'target' | 'branch'>('target')
@@ -226,6 +233,15 @@ const activeSlashMatch = computed(() =>
     : null
 )
 
+const activeSlashMatchKey = computed(() => {
+  const match = activeSlashMatch.value
+  if (!match) {
+    return null
+  }
+
+  return `${match.start}:${match.end}:${match.raw}`
+})
+
 const filteredSlashCommands = computed(() =>
   activeSlashMatch.value
     ? filterSlashCommands(slashCommands.value, activeSlashMatch.value.query)
@@ -235,6 +251,7 @@ const filteredSlashCommands = computed(() =>
 const slashDropdownOpen = computed(() =>
   !reviewDrawerOpen.value
   && Boolean(activeSlashMatch.value)
+  && activeSlashMatchKey.value !== dismissedSlashMatchKey.value
   && filteredSlashCommands.value.length > 0
 )
 
@@ -447,6 +464,7 @@ const createLiveStreamState = (
 ): LiveStream => ({
   threadId,
   turnId: null,
+  lockedTurnId: null,
   bufferedNotifications,
   observedSubagentThreadIds: new Set<string>(),
   pendingUserMessageIds: [],
@@ -473,6 +491,7 @@ const setLiveStreamTurnId = (liveStream: LiveStream, turnId: string | null) => {
   liveStream.turnId = turnId
 
   if (!turnId) {
+    liveStream.lockedTurnId = null
     return
   }
 
@@ -481,6 +500,11 @@ const setLiveStreamTurnId = (liveStream: LiveStream, turnId: string | null) => {
   for (const waiter of waiters) {
     waiter.resolve(turnId)
   }
+}
+
+const lockLiveStreamTurnId = (liveStream: LiveStream, turnId: string | null) => {
+  liveStream.lockedTurnId = turnId
+  setLiveStreamTurnId(liveStream, turnId)
 }
 
 const waitForLiveStreamTurnId = async (liveStream: LiveStream) => {
@@ -502,9 +526,10 @@ const queuePendingUserMessage = (liveStream: LiveStream, messageId: string) => {
 }
 
 const replayBufferedNotifications = (liveStream: LiveStream) => {
+  const trackedTurnId = liveStream.lockedTurnId ?? liveStream.turnId
   for (const notification of liveStream.bufferedNotifications.splice(0, liveStream.bufferedNotifications.length)) {
     const turnId = notificationTurnId(notification)
-    if (turnId && turnId !== liveStream.turnId) {
+    if (turnId && trackedTurnId && turnId !== trackedTurnId) {
       continue
     }
 
@@ -564,6 +589,7 @@ const ensurePendingLiveStream = async () => {
       const turnId = notificationTurnId(notification)
       if (!shouldApplyNotificationToCurrentTurn({
         liveStreamTurnId: liveStream.turnId,
+        lockedTurnId: liveStream.lockedTurnId,
         notificationMethod: notification.method,
         notificationTurnId: turnId
       })) {
@@ -667,6 +693,10 @@ const syncPromptSelectionFromDom = () => {
   const textarea = getPromptTextarea()
   promptSelectionStart.value = textarea?.selectionStart ?? input.value.length
   promptSelectionEnd.value = textarea?.selectionEnd ?? input.value.length
+
+  if (!activeSlashMatchKey.value || activeSlashMatchKey.value !== dismissedSlashMatchKey.value) {
+    dismissedSlashMatchKey.value = null
+  }
 }
 
 const focusPromptAt = async (position?: number) => {
@@ -682,6 +712,32 @@ const focusPromptAt = async (position?: number) => {
   promptSelectionStart.value = nextPosition
   promptSelectionEnd.value = nextPosition
   isPromptFocused.value = true
+}
+
+const shouldRetainPromptFocus = (nextFocused: EventTarget | null) =>
+  nextFocused instanceof Node
+  && Boolean(slashDropdownRef.value?.contains(nextFocused))
+
+const handlePromptBlur = (event: FocusEvent) => {
+  if (shouldRetainPromptFocus(event.relatedTarget)) {
+    isPromptFocused.value = true
+    void focusPromptAt(promptSelectionStart.value)
+    return
+  }
+
+  isPromptFocused.value = false
+}
+
+const handleSlashDropdownFocusIn = () => {
+  if (!slashDropdownOpen.value) {
+    return
+  }
+
+  void focusPromptAt(promptSelectionStart.value)
+}
+
+const preventSlashPaletteEntryFocus = (event: CustomEvent) => {
+  event.preventDefault()
 }
 
 const setComposerError = (messageText: string) => {
@@ -703,6 +759,7 @@ const closeReviewDrawer = () => {
 }
 
 const openReviewDrawer = (commandText = '/review') => {
+  dismissedSlashMatchKey.value = null
   reviewDrawerCommandText.value = commandText
   reviewDrawerMode.value = 'target'
   reviewBranchesError.value = null
@@ -736,6 +793,7 @@ const completeSlashCommand = async (command: SlashCommandDefinition) => {
     return
   }
 
+  dismissedSlashMatchKey.value = null
   const completion = toSlashCommandCompletion(command)
   input.value = `${input.value.slice(0, match.start)}${completion}${input.value.slice(match.end)}`
   await focusPromptAt(match.start + completion.length)
@@ -780,6 +838,10 @@ const openBaseBranchPicker = async () => {
 }
 
 const startReview = async (target: ReviewTarget) => {
+  if (reviewStartPending.value) {
+    return
+  }
+
   if (hasPendingRequest.value || isBusy.value) {
     setComposerError('Review can only start when the current thread is idle.')
     return
@@ -805,7 +867,20 @@ const startReview = async (target: ReviewTarget) => {
       target
     } satisfies ReviewStartParams)
 
-    setLiveStreamTurnId(liveStream, response.turn.id)
+    for (const item of response.turn.items) {
+      if (item.type === 'userMessage') {
+        continue
+      }
+
+      for (const nextMessage of itemToMessages(item)) {
+        messages.value = upsertStreamingMessage(messages.value, {
+          ...nextMessage,
+          pending: false
+        })
+      }
+    }
+
+    lockLiveStreamTurnId(liveStream, response.turn.id)
     replayBufferedNotifications(liveStream)
     closeReviewDrawer()
   } catch (caughtError) {
@@ -1139,6 +1214,7 @@ const hydrateThread = async (threadId: string) => {
           const turnId = notificationTurnId(notification)
           if (!shouldApplyNotificationToCurrentTurn({
             liveStreamTurnId: nextLiveStream.turnId,
+            lockedTurnId: nextLiveStream.lockedTurnId,
             notificationMethod: notification.method,
             notificationTurnId: turnId
           })) {
@@ -1846,7 +1922,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
       if (!nextThreadId || !nextThreadName) {
         return
       }
-      const nextTitle = nextThreadName.trim()
+      const nextTitle = normalizeThreadTitleCandidate(nextThreadName)
       if (!nextTitle) {
         return
       }
@@ -1859,13 +1935,21 @@ const applyNotification = (notification: CodexRpcNotification) => {
       return
     }
     case 'turn/started': {
+      const nextTurnId = notificationTurnId(notification)
+      if (liveStream && !shouldAdvanceLiveStreamTurn({
+        lockedTurnId: liveStream.lockedTurnId,
+        nextTurnId
+      })) {
+        return
+      }
+
       if (liveStream) {
-        setLiveStreamTurnId(liveStream, notificationTurnId(notification))
+        setLiveStreamTurnId(liveStream, nextTurnId)
         setLiveStreamInterruptRequested(liveStream, false)
       }
       messages.value = upsertStreamingMessage(
         messages.value,
-        eventToMessage(`event-turn-started-${notificationTurnId(notification) ?? Date.now()}`, {
+        eventToMessage(`event-turn-started-${nextTurnId ?? Date.now()}`, {
           kind: 'turn.started'
         })
       )
@@ -2058,6 +2142,9 @@ const applyNotification = (notification: CodexRpcNotification) => {
       markAwaitingAssistantOutput(false)
       pushEventMessage('stream.error', messageText)
       clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
+      if (liveStream) {
+        liveStream.lockedTurnId = null
+      }
       clearLiveStream(new Error(messageText))
       error.value = messageText
       status.value = 'error'
@@ -2069,6 +2156,9 @@ const applyNotification = (notification: CodexRpcNotification) => {
       markAwaitingAssistantOutput(false)
       pushEventMessage('turn.failed', messageText)
       clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
+      if (liveStream) {
+        liveStream.lockedTurnId = null
+      }
       clearLiveStream(new Error(messageText))
       error.value = messageText
       status.value = 'error'
@@ -2080,6 +2170,9 @@ const applyNotification = (notification: CodexRpcNotification) => {
       markAwaitingAssistantOutput(false)
       pushEventMessage('stream.error', messageText)
       clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
+      if (liveStream) {
+        liveStream.lockedTurnId = null
+      }
       clearLiveStream(new Error(messageText))
       error.value = messageText
       status.value = 'error'
@@ -2088,6 +2181,9 @@ const applyNotification = (notification: CodexRpcNotification) => {
     case 'turn/completed': {
       markAwaitingAssistantOutput(false)
       clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
+      if (liveStream) {
+        liveStream.lockedTurnId = null
+      }
       error.value = null
       status.value = 'ready'
       clearLiveStream()
@@ -2296,13 +2392,15 @@ const onPromptKeydown = (event: KeyboardEvent) => {
 
   if (event.key === 'Escape') {
     event.preventDefault()
-    isPromptFocused.value = false
+    dismissedSlashMatchKey.value = activeSlashMatchKey.value
+    isPromptFocused.value = true
+    void focusPromptAt(promptSelectionStart.value)
     return
   }
 
-  if (event.key === ' ') {
+  if (event.key === 'Tab' || event.key === ' ') {
     const command = highlightedSlashCommand.value
-    if (!command) {
+    if (!command || (event.key === ' ' && !command.completeOnSpace)) {
       return
     }
 
@@ -2549,12 +2647,17 @@ watch(input, async () => {
 
           <UCommandPalette
             v-if="slashDropdownOpen"
+            ref="slashDropdownRef"
+            class="absolute bottom-full left-0 z-20 mb-2 w-[90vw] max-w-[calc(100vw-2rem)] md:w-[min(50vw,52rem)] md:max-w-[min(50vw,52rem)]"
             :groups="slashPaletteGroups"
             :input="false"
+            :autofocus="false"
             :search-term="activeSlashMatch?.query ?? ''"
-            class="absolute inset-x-0 bottom-full z-20 mb-2 overflow-hidden rounded-2xl border border-default bg-default/95 shadow-2xl backdrop-blur"
+            @entry-focus="preventSlashPaletteEntryFocus"
+            @focusin.capture="handleSlashDropdownFocusIn"
+            @mousedown.prevent
             :ui="{
-              root: 'min-h-0',
+              root: 'min-h-0 overflow-hidden rounded-2xl border border-default bg-default/95 shadow-2xl backdrop-blur',
               content: 'max-h-72 overflow-y-auto p-2',
               group: 'space-y-1',
               item: 'rounded-xl px-3 py-2.5',
@@ -2578,7 +2681,7 @@ watch(input, async () => {
             @click="syncPromptSelectionFromDom"
             @keyup="syncPromptSelectionFromDom"
             @focus="isPromptFocused = true; syncPromptSelectionFromDom()"
-            @blur="isPromptFocused = false"
+            @blur="handlePromptBlur"
             @select="syncPromptSelectionFromDom"
             @compositionstart="onCompositionStart"
             @compositionend="onCompositionEnd"
@@ -2803,6 +2906,7 @@ watch(input, async () => {
     :branches="reviewBaseBranches"
     :current-branch="reviewCurrentBranch"
     :loading="reviewBranchesLoading"
+    :submitting="reviewStartPending"
     :error="reviewBranchesError"
     @update:open="handleReviewDrawerOpenChange"
     @choose-current-changes="startReview({ type: 'uncommittedChanges' })"

--- a/packages/client/app/components/PendingUserRequestDrawer.vue
+++ b/packages/client/app/components/PendingUserRequestDrawer.vue
@@ -6,6 +6,7 @@ import {
   buildRequestUserInputResponse,
   type PendingUserRequest
 } from '../../shared/pending-user-request'
+import BottomDrawerShell from './BottomDrawerShell.vue'
 import McpElicitationForm from './pending-request/McpElicitationForm.vue'
 import McpElicitationUrlPrompt from './pending-request/McpElicitationUrlPrompt.vue'
 import RequestUserInputForm from './pending-request/RequestUserInputForm.vue'
@@ -52,58 +53,36 @@ const handleOpenChange = (nextOpen: boolean) => {
 </script>
 
 <template>
-  <UDrawer
+  <BottomDrawerShell
     :open="Boolean(request)"
-    direction="bottom"
-    :handle="true"
-    :ui="{
-      content: 'inset-x-auto right-auto bottom-0 left-1/2 w-[90vw] max-w-[52rem] -translate-x-1/2 rounded-t-2xl rounded-b-none border-x border-t border-default bg-default shadow-2xl md:w-[min(50vw,52rem)]',
-      container: 'gap-0 p-0',
-      handle: 'mt-2 !h-1 !w-10 rounded-full',
-      header: isRequestUserInput ? 'hidden' : 'px-4 pb-1 pt-3 md:px-5',
-      body: isRequestUserInput ? 'px-3 pb-3 pt-3 md:px-4 md:pb-4 md:pt-4' : 'px-4 pb-4 pt-2 md:px-5',
-      footer: 'hidden'
-    }"
+    :hide-header="isRequestUserInput"
+    :title="title"
+    :description="description"
+    :body-class="isRequestUserInput ? 'px-3 pb-3 pt-3 md:px-4 md:pb-4 md:pt-4' : 'px-4 pb-4 pt-2 md:px-5'"
     @update:open="handleOpenChange"
   >
-    <template #header>
-      <div
-        v-if="request && !isRequestUserInput"
-        class="space-y-1.5"
-      >
-        <h2 class="text-sm font-semibold text-highlighted md:text-base">
-          {{ title }}
-        </h2>
-        <p class="text-sm leading-5 text-muted">
-          {{ description }}
-        </p>
-      </div>
-    </template>
+    <RequestUserInputForm
+      v-if="request?.kind === 'requestUserInput'"
+      :key="request.requestId"
+      :request="request"
+      @submit="emit('respond', buildRequestUserInputResponse($event))"
+    />
 
-    <template #body>
-      <RequestUserInputForm
-        v-if="request?.kind === 'requestUserInput'"
-        :key="request.requestId"
-        :request="request"
-        @submit="emit('respond', buildRequestUserInputResponse($event))"
-      />
+    <McpElicitationForm
+      v-else-if="request?.kind === 'mcpElicitationForm'"
+      :key="request.requestId"
+      :request="request"
+      @accept="emit('respond', buildMcpElicitationResponse('accept', $event))"
+      @decline="emit('respond', buildMcpElicitationResponse('decline'))"
+      @cancel="emit('respond', buildMcpElicitationResponse('cancel'))"
+    />
 
-      <McpElicitationForm
-        v-else-if="request?.kind === 'mcpElicitationForm'"
-        :key="request.requestId"
-        :request="request"
-        @accept="emit('respond', buildMcpElicitationResponse('accept', $event))"
-        @decline="emit('respond', buildMcpElicitationResponse('decline'))"
-        @cancel="emit('respond', buildMcpElicitationResponse('cancel'))"
-      />
-
-      <McpElicitationUrlPrompt
-        v-else-if="request?.kind === 'mcpElicitationUrl'"
-        :request="request"
-        @accept="emit('respond', buildMcpElicitationResponse('accept'))"
-        @decline="emit('respond', buildMcpElicitationResponse('decline'))"
-        @cancel="emit('respond', buildMcpElicitationResponse('cancel'))"
-      />
-    </template>
-  </UDrawer>
+    <McpElicitationUrlPrompt
+      v-else-if="request?.kind === 'mcpElicitationUrl'"
+      :request="request"
+      @accept="emit('respond', buildMcpElicitationResponse('accept'))"
+      @decline="emit('respond', buildMcpElicitationResponse('decline'))"
+      @cancel="emit('respond', buildMcpElicitationResponse('cancel'))"
+    />
+  </BottomDrawerShell>
 </template>

--- a/packages/client/app/components/ReviewStartDrawer.vue
+++ b/packages/client/app/components/ReviewStartDrawer.vue
@@ -8,6 +8,7 @@ const props = withDefaults(defineProps<{
   branches?: string[]
   currentBranch?: string | null
   loading?: boolean
+  submitting?: boolean
   error?: string | null
 }>(), {
   open: false,
@@ -15,6 +16,7 @@ const props = withDefaults(defineProps<{
   branches: () => [],
   currentBranch: null,
   loading: false,
+  submitting: false,
   error: null
 })
 
@@ -55,6 +57,7 @@ const branchGroups = computed(() => [{
   items: filteredBranches.value.map(branch => ({
     label: branch,
     description: props.currentBranch ? `${props.currentBranch} -> ${branch}` : 'Compare against this branch.',
+    disabled: props.loading || props.submitting,
     onSelect: () => emit('chooseBaseBranch', branch)
   }))
 }])
@@ -86,6 +89,7 @@ const description = computed(() =>
     >
       <button
         type="button"
+        :disabled="submitting"
         class="flex w-full items-start justify-between gap-4 rounded-2xl border border-default bg-elevated/35 px-4 py-4 text-left transition hover:border-primary/30 hover:bg-elevated/55"
         @click="emit('chooseCurrentChanges')"
       >
@@ -105,6 +109,7 @@ const description = computed(() =>
 
       <button
         type="button"
+        :disabled="submitting"
         class="flex w-full items-start justify-between gap-4 rounded-2xl border border-default bg-elevated/35 px-4 py-4 text-left transition hover:border-primary/30 hover:bg-elevated/55"
         @click="emit('chooseBaseBranchMode')"
       >
@@ -158,7 +163,8 @@ const description = computed(() =>
       <UCommandPalette
         v-model:search-term="branchSearch"
         :groups="branchGroups"
-        :loading="loading"
+        :loading="loading || submitting"
+        :disabled="submitting"
         placeholder="Search local branches"
         class="rounded-2xl border border-default bg-default/70"
         :ui="{

--- a/packages/client/app/components/ReviewStartDrawer.vue
+++ b/packages/client/app/components/ReviewStartDrawer.vue
@@ -1,0 +1,180 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import BottomDrawerShell from './BottomDrawerShell.vue'
+
+const props = withDefaults(defineProps<{
+  open?: boolean
+  mode?: 'target' | 'branch'
+  branches?: string[]
+  currentBranch?: string | null
+  loading?: boolean
+  error?: string | null
+}>(), {
+  open: false,
+  mode: 'target',
+  branches: () => [],
+  currentBranch: null,
+  loading: false,
+  error: null
+})
+
+const emit = defineEmits<{
+  'update:open': [open: boolean]
+  chooseCurrentChanges: []
+  chooseBaseBranchMode: []
+  chooseBaseBranch: [branch: string]
+  back: []
+}>()
+
+const branchSearch = ref('')
+
+watch(() => props.open, (open) => {
+  if (!open) {
+    branchSearch.value = ''
+  }
+})
+
+watch(() => props.mode, (mode) => {
+  if (mode !== 'branch') {
+    branchSearch.value = ''
+  }
+})
+
+const filteredBranches = computed(() => {
+  const normalized = branchSearch.value.trim().toLowerCase()
+  const branches = props.branches ?? []
+  if (!normalized) {
+    return branches
+  }
+
+  return branches.filter(branch => branch.toLowerCase().includes(normalized))
+})
+
+const branchGroups = computed(() => [{
+  id: 'base-branches',
+  items: filteredBranches.value.map(branch => ({
+    label: branch,
+    description: props.currentBranch ? `${props.currentBranch} -> ${branch}` : 'Compare against this branch.',
+    onSelect: () => emit('chooseBaseBranch', branch)
+  }))
+}])
+
+const title = computed(() =>
+  props.mode === 'branch'
+    ? 'Select a base branch'
+    : 'Start a review'
+)
+
+const description = computed(() =>
+  props.mode === 'branch'
+    ? 'Choose the branch to diff against before starting the review.'
+    : 'Pick what Codori should review.'
+)
+</script>
+
+<template>
+  <BottomDrawerShell
+    :open="open"
+    :title="title"
+    :description="description"
+    :body-class="mode === 'branch' ? 'px-3 pb-3 pt-3 md:px-4 md:pb-4 md:pt-4' : 'px-4 pb-4 pt-2 md:px-5'"
+    @update:open="emit('update:open', $event)"
+  >
+    <div
+      v-if="mode === 'target'"
+      class="space-y-3"
+    >
+      <button
+        type="button"
+        class="flex w-full items-start justify-between gap-4 rounded-2xl border border-default bg-elevated/35 px-4 py-4 text-left transition hover:border-primary/30 hover:bg-elevated/55"
+        @click="emit('chooseCurrentChanges')"
+      >
+        <div class="space-y-1">
+          <div class="text-sm font-semibold text-highlighted">
+            Review current changes
+          </div>
+          <p class="text-sm leading-6 text-muted">
+            Review staged, unstaged, and untracked changes in the working tree.
+          </p>
+        </div>
+        <UIcon
+          name="i-lucide-git-compare-arrows"
+          class="mt-0.5 size-5 shrink-0 text-primary"
+        />
+      </button>
+
+      <button
+        type="button"
+        class="flex w-full items-start justify-between gap-4 rounded-2xl border border-default bg-elevated/35 px-4 py-4 text-left transition hover:border-primary/30 hover:bg-elevated/55"
+        @click="emit('chooseBaseBranchMode')"
+      >
+        <div class="space-y-1">
+          <div class="text-sm font-semibold text-highlighted">
+            Review against a base branch
+          </div>
+          <p class="text-sm leading-6 text-muted">
+            Pick a local branch and review the diff from that base to your current branch.
+          </p>
+        </div>
+        <UIcon
+          name="i-lucide-git-branch-plus"
+          class="mt-0.5 size-5 shrink-0 text-primary"
+        />
+      </button>
+    </div>
+
+    <div
+      v-else
+      class="space-y-3"
+    >
+      <div class="flex items-center justify-between gap-3">
+        <UButton
+          type="button"
+          color="neutral"
+          variant="ghost"
+          icon="i-lucide-arrow-left"
+          class="rounded-full"
+          @click="emit('back')"
+        >
+          Back
+        </UButton>
+
+        <div
+          v-if="currentBranch"
+          class="text-xs font-medium uppercase tracking-[0.2em] text-muted"
+        >
+          Current {{ currentBranch }}
+        </div>
+      </div>
+
+      <UAlert
+        v-if="error"
+        color="error"
+        variant="soft"
+        icon="i-lucide-circle-alert"
+        :title="error"
+      />
+
+      <UCommandPalette
+        v-model:search-term="branchSearch"
+        :groups="branchGroups"
+        :loading="loading"
+        placeholder="Search local branches"
+        class="rounded-2xl border border-default bg-default/70"
+        :ui="{
+          root: 'min-h-0',
+          content: 'max-h-[40vh] overflow-y-auto p-2',
+          item: 'rounded-xl',
+          input: 'border-0 bg-transparent'
+        }"
+      />
+
+      <p
+        v-if="!loading && !filteredBranches.length"
+        class="rounded-2xl border border-dashed border-default px-4 py-6 text-center text-sm text-muted"
+      >
+        No matching local branches.
+      </p>
+    </div>
+  </BottomDrawerShell>
+</template>

--- a/packages/client/app/components/message-part/Event.vue
+++ b/packages/client/app/components/message-part/Event.vue
@@ -19,11 +19,20 @@ const shouldRenderEvent = computed(() => {
     return false
   }
 
-  return event.kind === 'turn.failed' || event.kind === 'stream.error'
+  return (
+    event.kind === 'turn.failed'
+    || event.kind === 'stream.error'
+    || event.kind === 'review.started'
+    || event.kind === 'review.completed'
+  )
 })
 
 const title = computed(() => {
   switch (eventData.value?.kind) {
+    case 'review.started':
+      return 'Review started'
+    case 'review.completed':
+      return 'Review completed'
     case 'turn.failed':
       return 'Turn failed'
     case 'stream.error':
@@ -32,20 +41,45 @@ const title = computed(() => {
       return 'Event'
   }
 })
+const color = computed(() => {
+  switch (eventData.value?.kind) {
+    case 'review.completed':
+      return 'success'
+    case 'review.started':
+      return 'primary'
+    default:
+      return 'error'
+  }
+})
+
+const icon = computed(() => {
+  switch (eventData.value?.kind) {
+    case 'review.completed':
+      return 'i-lucide-badge-check'
+    case 'review.started':
+      return 'i-lucide-search-check'
+    default:
+      return 'i-lucide-circle-alert'
+  }
+})
 </script>
 
 <template>
   <UAlert
     v-if="shouldRenderEvent"
-    color="error"
+    :color="color"
     variant="soft"
-    icon="i-lucide-circle-alert"
+    :icon="icon"
     :title="title"
   >
     <template #description>
       <span class="text-sm">
         {{
-          eventData?.kind === 'turn.failed'
+          eventData?.kind === 'review.started'
+            ? eventData.summary ?? 'Codex is reviewing the selected diff.'
+            : eventData?.kind === 'review.completed'
+              ? 'The review turn finished.'
+              : eventData?.kind === 'turn.failed'
             ? eventData.error?.message ?? 'The turn failed.'
             : eventData?.kind === 'stream.error'
               ? eventData.message

--- a/packages/client/app/composables/useChatSession.ts
+++ b/packages/client/app/composables/useChatSession.ts
@@ -18,6 +18,7 @@ export type LiveStreamTurnIdWaiter = {
 export type LiveStream = {
   threadId: string
   turnId: string | null
+  lockedTurnId: string | null
   bufferedNotifications: CodexRpcNotification[]
   observedSubagentThreadIds: Set<string>
   pendingUserMessageIds: string[]

--- a/packages/client/app/composables/useThreadSummaries.ts
+++ b/packages/client/app/composables/useThreadSummaries.ts
@@ -23,8 +23,34 @@ type UseThreadSummariesResult = ThreadSummariesState & {
 
 const states = new Map<string, ThreadSummariesState>()
 
+export const normalizeThreadTitleCandidate = (value: string | null | undefined) => {
+  const raw = value?.trim() ?? ''
+  if (!raw) {
+    return ''
+  }
+
+  const stripped = raw
+    .replace(/<\/?[a-z_]+>/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (!stripped) {
+    return ''
+  }
+
+  if (
+    /<(?:user_action|context)>/i.test(raw)
+    || /user initiated a review task/i.test(stripped)
+    || /review output from reviewer mode/i.test(stripped)
+  ) {
+    return 'Code Review'
+  }
+
+  return stripped
+}
+
 export const resolveThreadSummaryTitle = (thread: Pick<CodexThread, 'id' | 'name' | 'preview'>) => {
-  const nextTitle = thread.name?.trim() || thread.preview.trim()
+  const nextTitle = normalizeThreadTitleCandidate(thread.name) || normalizeThreadTitleCandidate(thread.preview)
   return nextTitle || `Thread ${thread.id}`
 }
 
@@ -41,7 +67,7 @@ export const renameThreadSummary = (
     updatedAt?: number
   }
 ) => {
-  const nextTitle = input.title.trim()
+  const nextTitle = normalizeThreadTitleCandidate(input.title)
   if (!nextTitle) {
     return threads
   }

--- a/packages/client/app/utils/chat-turn-engagement.ts
+++ b/packages/client/app/utils/chat-turn-engagement.ts
@@ -48,13 +48,22 @@ export const shouldRetrySteerWithTurnStart = (message: string) =>
 
 export const shouldApplyNotificationToCurrentTurn = (input: {
   liveStreamTurnId: string | null
+  lockedTurnId?: string | null
   notificationMethod: string
   notificationTurnId: string | null
 }) =>
-  input.liveStreamTurnId === null
+  (input.lockedTurnId ?? input.liveStreamTurnId) === null
   || input.notificationTurnId === null
-  || input.notificationTurnId === input.liveStreamTurnId
+  || input.notificationTurnId === (input.lockedTurnId ?? input.liveStreamTurnId)
   || input.notificationMethod === 'turn/started'
+
+export const shouldAdvanceLiveStreamTurn = (input: {
+  lockedTurnId?: string | null
+  nextTurnId: string | null
+}) =>
+  !input.lockedTurnId
+  || !input.nextTurnId
+  || input.nextTurnId === input.lockedTurnId
 
 export const resolvePromptSubmitStatus = (input: {
   status: PromptSubmitStatus

--- a/packages/client/server/api/codori/projects/[projectId]/git/branches.get.ts
+++ b/packages/client/server/api/codori/projects/[projectId]/git/branches.get.ts
@@ -1,0 +1,15 @@
+import { defineEventHandler, getRouterParam } from 'h3'
+import { encodeProjectIdSegment, type ProjectGitBranchesResponse } from '~~/shared/codori'
+import { proxyServerRequest } from '../../../../../utils/server-proxy'
+
+export default defineEventHandler(async (event) => {
+  const projectId = getRouterParam(event, 'projectId')
+  if (!projectId) {
+    throw new Error('Missing project id.')
+  }
+
+  return await proxyServerRequest<ProjectGitBranchesResponse>(
+    event,
+    `/api/projects/${encodeProjectIdSegment(projectId)}/git/branches`
+  )
+})

--- a/packages/client/shared/codex-chat.ts
+++ b/packages/client/shared/codex-chat.ts
@@ -9,6 +9,13 @@ export type ThreadEventData =
       title?: string | null
     }
   | {
+      kind: 'review.started'
+      summary: string | null
+    }
+  | {
+      kind: 'review.completed'
+    }
+  | {
       kind: 'turn.failed'
       error: {
         message: string
@@ -300,6 +307,30 @@ export const itemToMessages = (item: CodexThreadItem): ChatMessage[] => {
           }
         }]
       }]
+    case 'enteredReviewMode':
+      return [{
+        id: item.id,
+        role: 'system',
+        parts: [{
+          type: EVENT_PART,
+          data: {
+            kind: 'review.started',
+            summary: item.review.trim() || null
+          }
+        }]
+      }]
+    case 'exitedReviewMode': {
+      return [{
+        id: item.id,
+        role: 'system',
+        parts: [{
+          type: EVENT_PART,
+          data: {
+            kind: 'review.completed'
+          }
+        }]
+      }]
+    }
     default:
       return []
   }

--- a/packages/client/shared/codex-chat.ts
+++ b/packages/client/shared/codex-chat.ts
@@ -1,4 +1,4 @@
-import type { CodexThread, CodexThreadItem, CodexUserInput } from './codex-rpc'
+import type { CodexThread, CodexThreadItem, CodexTurn, CodexUserInput } from './codex-rpc'
 
 export const EVENT_PART = 'data-thread-event' as const
 export const ITEM_PART = 'data-thread-item' as const
@@ -168,6 +168,29 @@ const userInputToParts = (input: CodexUserInput): ChatPart[] => {
   }]
 }
 
+const getUserMessageText = (item: Extract<CodexThreadItem, { type: 'userMessage' }>) =>
+  item.content
+    .filter((input): input is Extract<CodexUserInput, { type: 'text' }> => input.type === 'text')
+    .map(input => input.text.trim())
+    .filter(Boolean)
+    .join('\n')
+
+const shouldHideReviewBootstrapUserMessage = (
+  item: Extract<CodexThreadItem, { type: 'userMessage' }>,
+  turn: CodexTurn
+) => {
+  const reviewLifecycle = turn.items.find((candidate): candidate is Extract<CodexThreadItem, { type: 'enteredReviewMode' | 'exitedReviewMode' }> =>
+    (candidate.type === 'enteredReviewMode' || candidate.type === 'exitedReviewMode')
+    && candidate.id === item.id
+  )
+
+  if (!reviewLifecycle) {
+    return false
+  }
+
+  return getUserMessageText(item) === reviewLifecycle.review.trim()
+}
+
 export const itemToMessages = (item: CodexThreadItem): ChatMessage[] => {
   switch (item.type) {
     case 'userMessage':
@@ -309,7 +332,7 @@ export const itemToMessages = (item: CodexThreadItem): ChatMessage[] => {
       }]
     case 'enteredReviewMode':
       return [{
-        id: item.id,
+        id: `${item.id}-review-started`,
         role: 'system',
         parts: [{
           type: EVENT_PART,
@@ -321,13 +344,21 @@ export const itemToMessages = (item: CodexThreadItem): ChatMessage[] => {
       }]
     case 'exitedReviewMode': {
       return [{
-        id: item.id,
+        id: `${item.id}-review-completed`,
         role: 'system',
         parts: [{
           type: EVENT_PART,
           data: {
             kind: 'review.completed'
           }
+        }]
+      }, {
+        id: `${item.id}-review-output`,
+        role: 'assistant',
+        parts: [{
+          type: 'text',
+          text: item.review,
+          state: 'done'
         }]
       }]
     }
@@ -337,7 +368,15 @@ export const itemToMessages = (item: CodexThreadItem): ChatMessage[] => {
 }
 
 export const threadToMessages = (thread: CodexThread) =>
-  thread.turns.flatMap(turn => turn.items.flatMap(item => itemToMessages(item)))
+  thread.turns.flatMap((turn) =>
+    turn.items.flatMap((item) => {
+      if (item.type === 'userMessage' && shouldHideReviewBootstrapUserMessage(item, turn)) {
+        return []
+      }
+
+      return itemToMessages(item)
+    })
+  )
 
 export const eventToMessage = (id: string, data: ThreadEventData): ChatMessage => ({
   id,

--- a/packages/client/shared/codex-rpc.ts
+++ b/packages/client/shared/codex-rpc.ts
@@ -190,6 +190,31 @@ export type TurnStartResponse = {
   }
 }
 
+export type ReviewTarget =
+  | {
+      type: 'uncommittedChanges'
+    }
+  | {
+      type: 'baseBranch'
+      branch: string
+    }
+  | {
+      type: 'commit'
+      sha: string
+      title?: string | null
+    }
+  | {
+      type: 'custom'
+      instructions: string
+    }
+
+export type ReviewStartResponse = {
+  reviewThreadId: string
+  turn: {
+    id: string
+  }
+}
+
 export type ModelListResponse = {
   data?: unknown[]
 }

--- a/packages/client/shared/codex-rpc.ts
+++ b/packages/client/shared/codex-rpc.ts
@@ -135,6 +135,16 @@ export type CodexThreadItem =
       type: 'contextCompaction'
       id: string
     }
+  | {
+      type: 'enteredReviewMode'
+      id: string
+      review: string
+    }
+  | {
+      type: 'exitedReviewMode'
+      id: string
+      review: string
+    }
 
 export type CodexTurn = {
   id: string
@@ -208,11 +218,17 @@ export type ReviewTarget =
       instructions: string
     }
 
+export type ReviewDelivery = 'inline' | 'detached'
+
+export type ReviewStartParams = {
+  threadId: string
+  delivery?: ReviewDelivery
+  target: ReviewTarget
+}
+
 export type ReviewStartResponse = {
   reviewThreadId: string
-  turn: {
-    id: string
-  }
+  turn: CodexTurn
 }
 
 export type ModelListResponse = {

--- a/packages/client/shared/codori.ts
+++ b/packages/client/shared/codori.ts
@@ -1,3 +1,5 @@
+import { resolveApiUrl, shouldUseServerProxy } from './network'
+
 export type ProjectRuntimeStatus = 'running' | 'stopped' | 'error'
 
 export type ProjectRecord = {
@@ -38,6 +40,11 @@ export type ServiceUpdateResponse = {
   serviceUpdate: ServiceUpdateStatus
 }
 
+export type ProjectGitBranchesResponse = {
+  currentBranch: string | null
+  branches: string[]
+}
+
 export const normalizeProjectIdParam = (value: string | string[] | undefined) => {
   if (!value) {
     return null
@@ -56,6 +63,19 @@ export const toProjectThreadRoute = (projectId: string, threadId: string) =>
   `/projects/${projectId}/threads/${encodeURIComponent(threadId)}`
 
 export const encodeProjectIdSegment = (projectId: string) => encodeURIComponent(projectId)
+
+export const resolveProjectGitBranchesUrl = (input: {
+  projectId: string
+  configuredBase?: string | null
+}) => {
+  const requestPath = `/projects/${encodeProjectIdSegment(input.projectId)}/git/branches`
+
+  if (shouldUseServerProxy(input.configuredBase)) {
+    return `/api/codori${requestPath}`
+  }
+
+  return resolveApiUrl(requestPath, input.configuredBase)
+}
 
 export const projectStatusMeta = (status: ProjectRuntimeStatus) => {
   switch (status) {

--- a/packages/client/shared/slash-commands.ts
+++ b/packages/client/shared/slash-commands.ts
@@ -1,0 +1,85 @@
+export type SlashCommandName = 'review'
+
+export type SlashCommandDefinition = {
+  name: SlashCommandName
+  description: string
+  supportsInlineArgs: boolean
+  completeOnSpace: boolean
+  executeOnEnter: boolean
+}
+
+export type ActiveSlashCommandMatch = {
+  start: number
+  end: number
+  raw: string
+  query: string
+}
+
+export type SubmittedSlashCommand = {
+  name: string
+  args: string
+  isBare: boolean
+}
+
+export const SLASH_COMMANDS: SlashCommandDefinition[] = [{
+  name: 'review',
+  description: 'Review current changes or compare against a base branch.',
+  supportsInlineArgs: false,
+  completeOnSpace: true,
+  executeOnEnter: true
+}]
+
+export const findActiveSlashCommand = (
+  input: string,
+  selectionStart: number | null | undefined,
+  selectionEnd: number | null | undefined
+): ActiveSlashCommandMatch | null => {
+  if (selectionStart == null || selectionEnd == null || selectionStart !== selectionEnd) {
+    return null
+  }
+
+  const caret = selectionStart
+  const lineStart = input.lastIndexOf('\n', Math.max(0, caret - 1)) + 1
+  const linePrefix = input.slice(lineStart, caret)
+  const match = /(?:^|\s)(\/[a-z-]*)$/i.exec(linePrefix)
+  if (!match) {
+    return null
+  }
+
+  const raw = match[1] ?? ''
+  if (!raw.startsWith('/')) {
+    return null
+  }
+
+  return {
+    start: caret - raw.length,
+    end: caret,
+    raw,
+    query: raw.slice(1).toLowerCase()
+  }
+}
+
+export const filterSlashCommands = (
+  commands: SlashCommandDefinition[],
+  query: string
+) => {
+  const normalizedQuery = query.trim().toLowerCase()
+  return commands.filter(command => command.name.startsWith(normalizedQuery))
+}
+
+export const parseSubmittedSlashCommand = (input: string): SubmittedSlashCommand | null => {
+  const trimmed = input.trim()
+  const match = /^\/([a-z-]+)(?:\s+(.*))?$/i.exec(trimmed)
+  if (!match) {
+    return null
+  }
+
+  return {
+    name: match[1]?.toLowerCase() ?? '',
+    args: match[2]?.trim() ?? '',
+    isBare: !(match[2]?.trim())
+  }
+}
+
+export const toSlashCommandCompletion = (command: Pick<SlashCommandDefinition, 'name'>) =>
+  `/${command.name} `

--- a/packages/client/test/chat-transcript.test.ts
+++ b/packages/client/test/chat-transcript.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  itemToMessages,
   replaceStreamingMessage,
   upsertStreamingMessage,
   type ChatMessage
@@ -130,6 +131,39 @@ describe('chat transcript stability', () => {
       id: 'thread-1',
       title: 'Existing thread',
       updatedAt: 1
+    }])
+  })
+
+  it('maps review lifecycle items into a banner plus final assistant output', () => {
+    expect(itemToMessages({
+      type: 'enteredReviewMode',
+      id: 'review-1',
+      review: 'Reviewing current changes'
+    })).toEqual([{
+      id: 'review-1',
+      role: 'system',
+      parts: [{
+        type: 'data-thread-event',
+        data: {
+          kind: 'review.started',
+          summary: 'Reviewing current changes'
+        }
+      }]
+    }])
+
+    expect(itemToMessages({
+      type: 'exitedReviewMode',
+      id: 'review-1',
+      review: 'Final review output'
+    })).toEqual([{
+      id: 'review-1',
+      role: 'system',
+      parts: [{
+        type: 'data-thread-event',
+        data: {
+          kind: 'review.completed'
+        }
+      }]
     }])
   })
 })

--- a/packages/client/test/chat-transcript.test.ts
+++ b/packages/client/test/chat-transcript.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   itemToMessages,
+  threadToMessages,
   replaceStreamingMessage,
   upsertStreamingMessage,
   type ChatMessage
@@ -140,7 +141,7 @@ describe('chat transcript stability', () => {
       id: 'review-1',
       review: 'Reviewing current changes'
     })).toEqual([{
-      id: 'review-1',
+      id: 'review-1-review-started',
       role: 'system',
       parts: [{
         type: 'data-thread-event',
@@ -156,13 +157,76 @@ describe('chat transcript stability', () => {
       id: 'review-1',
       review: 'Final review output'
     })).toEqual([{
-      id: 'review-1',
+      id: 'review-1-review-completed',
       role: 'system',
       parts: [{
         type: 'data-thread-event',
         data: {
           kind: 'review.completed'
         }
+      }]
+    }, {
+      id: 'review-1-review-output',
+      role: 'assistant',
+      parts: [{
+        type: 'text',
+        text: 'Final review output',
+        state: 'done'
+      }]
+    }])
+  })
+
+  it('hides the synthetic review bootstrap user message when hydrating a thread', () => {
+    expect(threadToMessages({
+      id: 'thread-1',
+      preview: '',
+      cwd: '/tmp',
+      createdAt: 0,
+      updatedAt: 0,
+      name: null,
+      turns: [{
+        id: 'turn-1',
+        status: 'completed',
+        error: null,
+        items: [{
+          type: 'userMessage',
+          id: 'turn-1',
+          content: [{
+            type: 'text',
+            text: "changes against 'main'",
+            text_elements: []
+          }]
+        }, {
+          type: 'enteredReviewMode',
+          id: 'turn-1',
+          review: "changes against 'main'"
+        }, {
+          type: 'userMessage',
+          id: 'user-2',
+          content: [{
+            type: 'text',
+            text: 'Full review instructions',
+            text_elements: []
+          }]
+        }]
+      }]
+    })).toEqual<ChatMessage[]>([{
+      id: 'turn-1-review-started',
+      role: 'system',
+      parts: [{
+        type: 'data-thread-event',
+        data: {
+          kind: 'review.started',
+          summary: "changes against 'main'"
+        }
+      }]
+    }, {
+      id: 'user-2',
+      role: 'user',
+      parts: [{
+        type: 'text',
+        text: 'Full review instructions',
+        state: 'done'
       }]
     }])
   })

--- a/packages/client/test/review-start-drawer.test.ts
+++ b/packages/client/test/review-start-drawer.test.ts
@@ -1,0 +1,154 @@
+/* eslint-disable vue/one-component-per-file */
+// @vitest-environment jsdom
+
+import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { describe, expect, it } from 'vitest'
+import ReviewStartDrawer from '../app/components/ReviewStartDrawer.vue'
+
+const DrawerStub = defineComponent({
+  name: 'DrawerStub',
+  props: {
+    open: {
+      type: Boolean,
+      default: false
+    }
+  },
+  setup(props, { slots }) {
+    return () => props.open
+      ? h('div', { class: 'drawer-stub' }, [
+          h('div', { class: 'drawer-header' }, slots.header?.()),
+          h('div', { class: 'drawer-body' }, slots.body?.()),
+          slots.default?.()
+        ])
+      : null
+  }
+})
+
+const ButtonStub = defineComponent({
+  name: 'ButtonStub',
+  props: {
+    type: {
+      type: String,
+      default: 'button'
+    }
+  },
+  emits: ['click'],
+  setup(props, { emit, slots }) {
+    return () => h('button', {
+      type: props.type,
+      onClick: (event: MouseEvent) => emit('click', event)
+    }, slots.default?.())
+  }
+})
+
+const CommandPaletteStub = defineComponent({
+  name: 'CommandPaletteStub',
+  props: {
+    groups: {
+      type: Array,
+      default: () => []
+    },
+    searchTerm: {
+      type: String,
+      default: ''
+    }
+  },
+  emits: ['update:searchTerm'],
+  setup(props, { emit }) {
+    return () => h('div', { class: 'command-palette-stub' }, [
+      h('input', {
+        class: 'command-search',
+        value: props.searchTerm,
+        onInput: (event: Event) => emit('update:searchTerm', (event.target as HTMLInputElement).value)
+      }),
+      ...(props.groups as Array<{ items?: Array<Record<string, unknown>> }>).flatMap(group =>
+        (group.items ?? []).map((item) => h('button', {
+          type: 'button',
+          class: 'command-item',
+          onClick: () => {
+            const onSelect = item.onSelect
+            if (typeof onSelect === 'function') {
+              onSelect()
+            }
+          }
+        }, `${String(item.label ?? '')} ${String(item.description ?? '')}`))
+      )
+    ])
+  }
+})
+
+const mountDrawer = (props: Record<string, unknown>) =>
+  mount(ReviewStartDrawer, {
+    props,
+    global: {
+      stubs: {
+        BottomDrawerShell: false,
+        UDrawer: DrawerStub,
+        UButton: ButtonStub,
+        UCommandPalette: CommandPaletteStub,
+        UAlert: defineComponent({
+          name: 'AlertStub',
+          props: {
+            title: {
+              type: String,
+              default: ''
+            }
+          },
+          setup(props) {
+            return () => h('div', { class: 'alert-stub' }, props.title)
+          }
+        }),
+        UIcon: defineComponent({
+          name: 'IconStub',
+          setup() {
+            return () => h('span', { class: 'icon-stub' })
+          }
+        })
+      }
+    }
+  })
+
+describe('review start drawer', () => {
+  it('renders the target selection step and emits current-changes selection', async () => {
+    const wrapper = mountDrawer({
+      open: true,
+      mode: 'target'
+    })
+
+    expect(wrapper.text()).toContain('Review current changes')
+    expect(wrapper.text()).toContain('Review against a base branch')
+
+    const currentChangesButton = wrapper.findAll('button').find(button => button.text().includes('Review current changes'))
+    expect(currentChangesButton).toBeTruthy()
+
+    await currentChangesButton!.trigger('click')
+
+    expect(wrapper.emitted('chooseCurrentChanges')).toHaveLength(1)
+  })
+
+  it('renders searchable branches and emits the selected branch', async () => {
+    const wrapper = mountDrawer({
+      open: true,
+      mode: 'branch',
+      currentBranch: 'feature/ui',
+      branches: ['main', 'release']
+    })
+
+    expect(wrapper.text()).toContain('Current feature/ui')
+    expect(wrapper.text()).toContain('main')
+    expect(wrapper.text()).toContain('release')
+
+    await wrapper.get('.command-search').setValue('rel')
+
+    expect(wrapper.text()).not.toContain('main')
+    expect(wrapper.text()).toContain('release')
+
+    const releaseButton = wrapper.findAll('button').find(button => button.text().includes('release'))
+    expect(releaseButton).toBeTruthy()
+
+    await releaseButton!.trigger('click')
+
+    expect(wrapper.emitted('chooseBaseBranch')?.[0]?.[0]).toBe('release')
+  })
+})

--- a/packages/client/test/review-start-drawer.test.ts
+++ b/packages/client/test/review-start-drawer.test.ts
@@ -151,4 +151,19 @@ describe('review start drawer', () => {
 
     expect(wrapper.emitted('chooseBaseBranch')?.[0]?.[0]).toBe('release')
   })
+
+  it('does not emit selections while submitting', async () => {
+    const wrapper = mountDrawer({
+      open: true,
+      mode: 'target',
+      submitting: true
+    })
+
+    const currentChangesButton = wrapper.findAll('button').find(button => button.text().includes('Review current changes'))
+    expect(currentChangesButton).toBeTruthy()
+
+    await currentChangesButton!.trigger('click')
+
+    expect(wrapper.emitted('chooseCurrentChanges')).toBeUndefined()
+  })
 })

--- a/packages/client/test/slash-commands.test.ts
+++ b/packages/client/test/slash-commands.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  filterSlashCommands,
+  findActiveSlashCommand,
+  parseSubmittedSlashCommand,
+  SLASH_COMMANDS,
+  toSlashCommandCompletion
+} from '../shared/slash-commands'
+
+describe('slash command helpers', () => {
+  it('detects the active slash token from the caret position', () => {
+    expect(findActiveSlashCommand('/review', 7, 7)).toEqual({
+      start: 0,
+      end: 7,
+      raw: '/review',
+      query: 'review'
+    })
+
+    expect(findActiveSlashCommand('Check /re', 9, 9)).toEqual({
+      start: 6,
+      end: 9,
+      raw: '/re',
+      query: 're'
+    })
+  })
+
+  it('ignores caret positions outside the active slash token', () => {
+    expect(findActiveSlashCommand('/review more', 12, 12)).toBeNull()
+    expect(findActiveSlashCommand('/review', 3, 7)).toBeNull()
+  })
+
+  it('filters available commands by prefix and formats completion text', () => {
+    expect(filterSlashCommands(SLASH_COMMANDS, '')).toHaveLength(1)
+    expect(filterSlashCommands(SLASH_COMMANDS, 're').map(command => command.name)).toEqual(['review'])
+    expect(toSlashCommandCompletion(SLASH_COMMANDS[0]!)).toBe('/review ')
+  })
+
+  it('parses submitted slash commands and inline args', () => {
+    expect(parseSubmittedSlashCommand('/review')).toEqual({
+      name: 'review',
+      args: '',
+      isBare: true
+    })
+
+    expect(parseSubmittedSlashCommand('/review compare this')).toEqual({
+      name: 'review',
+      args: 'compare this',
+      isBare: false
+    })
+
+    expect(parseSubmittedSlashCommand('review')).toBeNull()
+  })
+})

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -47,6 +47,7 @@ import {
   encodeProjectIdSegment,
   normalizeProjectIdParam,
   projectStatusMeta,
+  resolveProjectGitBranchesUrl,
   toProjectRoute,
   toProjectThreadRoute
 } from '../shared/codori'
@@ -66,6 +67,18 @@ describe('client package', () => {
       color: 'success',
       label: 'Running'
     })
+  })
+
+  it('routes git branch requests through the correct base path', () => {
+    expect(resolveProjectGitBranchesUrl({
+      projectId: 'team/api',
+      configuredBase: 'https://codori.example.com'
+    })).toBe('/api/codori/projects/team%2Fapi/git/branches')
+
+    expect(resolveProjectGitBranchesUrl({
+      projectId: 'team/api',
+      configuredBase: ''
+    })).toBe('http://127.0.0.1:4310/api/projects/team%2Fapi/git/branches')
   })
 
   it('orders the active project first while preserving alphabetical order for the rest', () => {

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -5,6 +5,7 @@ import {
   removePendingUserMessageId,
   resolvePromptSubmitStatus,
   resolveTurnSubmissionMethod,
+  shouldAdvanceLiveStreamTurn,
   shouldApplyNotificationToCurrentTurn,
   shouldSubmitViaTurnSteer,
   shouldAwaitThreadHydration,
@@ -51,6 +52,7 @@ import {
   toProjectRoute,
   toProjectThreadRoute
 } from '../shared/codori'
+import { normalizeThreadTitleCandidate, resolveThreadSummaryTitle } from '../app/composables/useThreadSummaries'
 import { sortSidebarProjects } from '../app/utils/project-sidebar-order'
 import { resolveApiUrl, resolveWsBase, shouldUseServerProxy } from '../shared/network'
 
@@ -79,6 +81,15 @@ describe('client package', () => {
       projectId: 'team/api',
       configuredBase: ''
     })).toBe('http://127.0.0.1:4310/api/projects/team%2Fapi/git/branches')
+  })
+
+  it('normalizes structured review previews into a stable thread title', () => {
+    expect(normalizeThreadTitleCandidate("<user_action><context>User initiated a review task. Here's the full review output from reviewer mode...</context></user_action>")).toBe('Code Review')
+    expect(resolveThreadSummaryTitle({
+      id: 'thread-1',
+      name: null,
+      preview: "<user_action><context>User initiated a review task. Here's the full review output from reviewer mode...</context></user_action>"
+    })).toBe('Code Review')
   })
 
   it('orders the active project first while preserving alphabetical order for the rest', () => {
@@ -436,6 +447,25 @@ describe('client package', () => {
       liveStreamTurnId: 'turn-1',
       notificationMethod: 'item/agentMessage/delta',
       notificationTurnId: 'turn-1'
+    })).toBe(true)
+  })
+
+  it('keeps a locked review turn pinned when unrelated turns start', () => {
+    expect(shouldApplyNotificationToCurrentTurn({
+      liveStreamTurnId: 'turn-1',
+      lockedTurnId: 'turn-1',
+      notificationMethod: 'item/reasoning/textDelta',
+      notificationTurnId: 'turn-1'
+    })).toBe(true)
+
+    expect(shouldAdvanceLiveStreamTurn({
+      lockedTurnId: 'turn-1',
+      nextTurnId: 'turn-2'
+    })).toBe(false)
+
+    expect(shouldAdvanceLiveStreamTurn({
+      lockedTurnId: 'turn-1',
+      nextTurnId: 'turn-1'
     })).toBe(true)
   })
 

--- a/packages/server/src/git.ts
+++ b/packages/server/src/git.ts
@@ -18,12 +18,20 @@ const runGit = async (projectPath: string, args: string[]) => {
 }
 
 export const listGitBranches = async (projectPath: string): Promise<GitBranchesResult> => {
-  const branchesOutput = await runGit(projectPath, [
-    'for-each-ref',
-    '--sort=refname',
-    '--format=%(refname:short)',
-    'refs/heads'
-  ])
+  let branchesOutput = ''
+  try {
+    branchesOutput = await runGit(projectPath, [
+      'for-each-ref',
+      '--sort=refname',
+      '--format=%(refname:short)',
+      'refs/heads'
+    ])
+  } catch {
+    return {
+      currentBranch: null,
+      branches: []
+    }
+  }
 
   let currentBranch: string | null = null
   try {

--- a/packages/server/src/git.ts
+++ b/packages/server/src/git.ts
@@ -1,0 +1,50 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+export type GitBranchesResult = {
+  currentBranch: string | null
+  branches: string[]
+}
+
+const execFileAsync = promisify(execFile)
+
+const runGit = async (projectPath: string, args: string[]) => {
+  const { stdout } = await execFileAsync('git', args, {
+    cwd: projectPath,
+    encoding: 'utf8'
+  })
+
+  return stdout.trim()
+}
+
+export const listGitBranches = async (projectPath: string): Promise<GitBranchesResult> => {
+  const branchesOutput = await runGit(projectPath, [
+    'for-each-ref',
+    '--sort=refname',
+    '--format=%(refname:short)',
+    'refs/heads'
+  ])
+
+  let currentBranch: string | null = null
+  try {
+    currentBranch = (await runGit(projectPath, ['branch', '--show-current'])) || null
+  } catch {
+    currentBranch = null
+  }
+
+  const branchSet = new Set(
+    branchesOutput
+      .split('\n')
+      .map(branch => branch.trim())
+      .filter(Boolean)
+  )
+
+  if (currentBranch) {
+    branchSet.add(currentBranch)
+  }
+
+  return {
+    currentBranch,
+    branches: [...branchSet]
+  }
+}

--- a/packages/server/src/http-server.ts
+++ b/packages/server/src/http-server.ts
@@ -21,6 +21,7 @@ import {
   resolveProjectAttachmentsDir
 } from './attachment-store.js'
 import { CodoriError } from './errors.js'
+import { listGitBranches } from './git.js'
 import { createRuntimeManager } from './process-manager.js'
 import {
   createServiceUpdateController,
@@ -60,6 +61,11 @@ type ProjectsResponse = {
 
 type ServiceUpdateResponse = {
   serviceUpdate: ServiceUpdateStatus
+}
+
+type ProjectGitBranchesResponse = {
+  currentBranch: string | null
+  branches: string[]
 }
 
 export type HttpServerOptions = {
@@ -308,6 +314,16 @@ export const createHttpServer = async (
     async (request: FastifyRequest<{ Params: { projectId: string } }>): Promise<ProjectResponse> => ({
       project: await resolveValue(manager.getProjectStatus(getProjectIdFromRequest(request.params.projectId)))
     })
+  )
+
+  app.get<{ Params: { projectId: string } }>(
+    '/api/projects/:projectId/git/branches',
+    async (request: FastifyRequest<{ Params: { projectId: string } }>): Promise<ProjectGitBranchesResponse> => {
+      const projectId = getProjectIdFromRequest(request.params.projectId)
+      const project = await resolveValue(manager.getProjectStatus(projectId))
+      await touchProjectActivity(manager, projectId)
+      return await listGitBranches(project.projectPath)
+    }
   )
 
   app.post<{ Params: { projectId: string } }>(

--- a/packages/server/test/http-server.test.ts
+++ b/packages/server/test/http-server.test.ts
@@ -224,6 +224,30 @@ describe('createHttpServer', () => {
     })
   })
 
+  it('returns an empty branch list when the project is not a git repository', async () => {
+    const projectPath = mkdtempSync(join(os.tmpdir(), 'codori-non-git-'))
+    tempDirs.push(projectPath)
+
+    const app = await createHttpServer(createManager({
+      getProjectStatus: () => ({
+        ...createProjectRecord(),
+        projectPath
+      })
+    }))
+    startedApps.push(app)
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/projects/demo/git/branches'
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({
+      currentBranch: null,
+      branches: []
+    })
+  })
+
   it('serves the bundled client and falls back to index.html for app routes', async () => {
     const bundleDir = mkdtempSync(join(os.tmpdir(), 'codori-ui-'))
     writeFileSync(join(bundleDir, 'index.html'), '<html><body>codori ui</body></html>')

--- a/packages/server/test/http-server.test.ts
+++ b/packages/server/test/http-server.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
 import { createServer as createNetServer } from 'node:net'
@@ -14,6 +15,7 @@ const startedApps: Array<Awaited<ReturnType<typeof createHttpServer>>> = []
 const startedSocketServers: WebSocketServer[] = []
 const occupiedTcpServers: Array<ReturnType<typeof createNetServer>> = []
 const attachmentsRoots: string[] = []
+const tempDirs: string[] = []
 
 afterEach(async () => {
   for (const app of startedApps.splice(0, startedApps.length)) {
@@ -46,6 +48,10 @@ afterEach(async () => {
 
   for (const root of attachmentsRoots.splice(0, attachmentsRoots.length)) {
     await rm(root, { recursive: true, force: true })
+  }
+
+  for (const dir of tempDirs.splice(0, tempDirs.length)) {
+    await rm(dir, { recursive: true, force: true })
   }
 })
 
@@ -101,6 +107,19 @@ const rawDataToString = (value: WebSocket.RawData) => {
   }
 
   return value.toString('utf8')
+}
+
+const createGitRepo = () => {
+  const projectPath = mkdtempSync(join(os.tmpdir(), 'codori-git-'))
+  tempDirs.push(projectPath)
+  execFileSync('git', ['init', '-b', 'main'], { cwd: projectPath, stdio: 'ignore' })
+  execFileSync('git', ['config', 'user.name', 'Codori Test'], { cwd: projectPath, stdio: 'ignore' })
+  execFileSync('git', ['config', 'user.email', 'codori@example.com'], { cwd: projectPath, stdio: 'ignore' })
+  writeFileSync(join(projectPath, 'README.md'), '# test\n')
+  execFileSync('git', ['add', 'README.md'], { cwd: projectPath, stdio: 'ignore' })
+  execFileSync('git', ['commit', '-m', 'init'], { cwd: projectPath, stdio: 'ignore' })
+  execFileSync('git', ['branch', 'feature/review'], { cwd: projectPath, stdio: 'ignore' })
+  return projectPath
 }
 
 describe('createHttpServer', () => {
@@ -180,6 +199,28 @@ describe('createHttpServer', () => {
         installedVersion: '0.0.3',
         latestVersion: '0.0.4'
       }
+    })
+  })
+
+  it('lists local git branches for a project', async () => {
+    const projectPath = createGitRepo()
+    const app = await createHttpServer(createManager({
+      getProjectStatus: () => ({
+        ...createProjectRecord(),
+        projectPath
+      })
+    }))
+    startedApps.push(app)
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/projects/demo/git/branches'
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({
+      currentBranch: 'main',
+      branches: ['feature/review', 'main']
     })
   })
 


### PR DESCRIPTION
## Summary
- add a composer slash-command palette above the chat prompt with keyboard navigation, completion, and dismissal behavior
- implement the native `/review` flow with a review target drawer for current changes or a selected base branch
- add review-specific transcript handling so review banners, streamed output, and fallback thread titles render correctly in the web client

## Details
- intercept bare `/review` before normal chat submission and start review mode through `review/start`
- add base-branch loading and selection through the shared drawer shell and command palette UI
- prevent synthetic review bootstrap payloads from leaking into hydrated transcripts or fallback thread titles
- keep the active review turn pinned so review reasoning and output continue streaming even when unrelated turn notifications arrive
- harden the review drawer against repeated submissions and cover the new behavior with client tests
- guard slash palette focus retention against component refs that do not expose `contains()` directly
- return an empty branch list instead of a server error when the selected project path is not a git repository

## Validation
- `pnpm --filter @codori/client typecheck`
- `pnpm --filter @codori/client test`
- `pnpm --filter @codori/server exec vitest run test/http-server.test.ts -t "returns an empty branch list when the project is not a git repository"`
- `pnpm --filter @codori/server exec vitest run test/http-server.test.ts -t "lists local git branches for a project"`
- `pnpm build`

Closes #34
Related to #5
