### PR TITLE
feat: add usage slash command and status modal

### DIFF
--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -2689,7 +2689,7 @@ watch(input, async () => {
             ref="slashDropdownRef"
             role="listbox"
             aria-label="Slash commands"
-            class="absolute bottom-full left-0 z-20 mb-2 w-[90vw] max-w-[calc(100vw-2rem)] overflow-hidden rounded-2xl border border-default bg-default/95 shadow-2xl backdrop-blur md:w-[min(50vw,52rem)] md:max-w-[min(50vw,52rem)]"
+            class="absolute bottom-full left-0 z-20 mb-2 w-[90vw] max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-default bg-default/95 shadow-2xl backdrop-blur md:w-[min(50vw,52rem)] md:max-w-[min(50vw,52rem)]"
             @pointerdown="handleSlashDropdownPointerDown"
           >
             <!-- Do not swap this back to a focus-managing listbox/palette. Slash
@@ -2703,7 +2703,7 @@ watch(input, async () => {
                 role="option"
                 :aria-selected="index === slashHighlightIndex"
                 data-slash-command-option=""
-                class="group relative flex cursor-pointer items-start gap-1.5 rounded-xl px-3 py-2.5 text-sm text-highlighted outline-none transition-colors before:absolute before:inset-px before:z-[-1] before:rounded-md"
+                class="group relative flex cursor-pointer items-start gap-1.5 px-3 py-2.5 text-sm text-highlighted outline-none transition-colors before:absolute before:inset-px before:z-[-1] before:rounded-md"
                 :class="index === slashHighlightIndex
                   ? 'before:bg-elevated'
                   : 'hover:before:bg-elevated/60'"

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -6,8 +6,7 @@ import {
   onBeforeUnmount,
   onMounted,
   ref,
-  watch,
-  type ComponentPublicInstance
+  watch
 } from 'vue'
 import MessageContent from './MessageContent.vue'
 import ReviewStartDrawer from './ReviewStartDrawer.vue'
@@ -26,6 +25,7 @@ import {
   shouldRetrySteerWithTurnStart,
   shouldIgnoreNotificationAfterInterrupt
 } from '../utils/chat-turn-engagement'
+import { isFocusWithinContainer } from '../utils/slash-prompt-focus'
 import { useChatAttachments, type DraftAttachment } from '../composables/useChatAttachments'
 import { usePendingUserRequest } from '../composables/usePendingUserRequest'
 import { useChatSession, type LiveStream, type SubagentPanelState } from '../composables/useChatSession'
@@ -147,7 +147,7 @@ const input = ref('')
 const chatPromptRef = ref<{
   textareaRef?: unknown
 } | null>(null)
-const slashDropdownRef = ref<ComponentPublicInstance | HTMLElement | null>(null)
+const slashDropdownRef = ref<HTMLElement | null>(null)
 const scrollViewport = ref<HTMLElement | null>(null)
 const pinnedToBottom = ref(true)
 const session = useChatSession(props.projectId)
@@ -277,24 +277,6 @@ const slashDropdownOpen = computed(() =>
 const highlightedSlashCommand = computed(() =>
   filteredSlashCommands.value[slashHighlightIndex.value] ?? filteredSlashCommands.value[0] ?? null
 )
-
-const slashPaletteGroups = computed(() => [{
-  id: 'slash-commands',
-  ignoreFilter: true,
-  items: filteredSlashCommands.value.map((command, index) => ({
-    label: `/${command.name}`,
-    description: command.description,
-    icon: command.name === 'review'
-      ? 'i-lucide-search-check'
-      : (command.name === 'usage' || command.name === 'status')
-          ? 'i-lucide-gauge'
-          : 'i-lucide-terminal',
-    active: index === slashHighlightIndex.value,
-    onSelect: () => {
-      void activateSlashCommand(command, command.supportsInlineArgs ? 'complete' : 'execute')
-    }
-  }))
-}])
 
 const reviewBaseBranches = computed(() =>
   reviewBranches.value.filter(branch => branch !== reviewCurrentBranch.value)
@@ -737,23 +719,15 @@ const focusPromptAt = async (position?: number) => {
   isPromptFocused.value = true
 }
 
-const resolveSlashDropdownElement = () => {
-  const target = slashDropdownRef.value
-  if (target instanceof HTMLElement) {
-    return target
-  }
-
-  const rootElement = target?.$el
-  return rootElement instanceof HTMLElement ? rootElement : null
-}
-
-const shouldRetainPromptFocus = (nextFocused: EventTarget | null) =>
-  nextFocused instanceof Node
-  && Boolean(resolveSlashDropdownElement()?.contains(nextFocused))
+const shouldRetainPromptFocus = (nextFocused: EventTarget | null | undefined) =>
+  isFocusWithinContainer(nextFocused, slashDropdownRef.value)
 
 const handlePromptBlur = (event: FocusEvent) => {
+  // Slash suggestions must stay focusless. If focus ever moves into the popup,
+  // the composer stops matching slash commands and the menu collapses while the
+  // textarea still contains `/`. Keep this blur guard aligned with the inert
+  // popup template below.
   if (shouldRetainPromptFocus(event.relatedTarget)) {
-    isPromptFocused.value = true
     void focusPromptAt(promptSelectionStart.value)
     return
   }
@@ -761,16 +735,12 @@ const handlePromptBlur = (event: FocusEvent) => {
   isPromptFocused.value = false
 }
 
-const handleSlashDropdownFocusIn = () => {
-  if (!slashDropdownOpen.value) {
-    return
-  }
-
-  void focusPromptAt(promptSelectionStart.value)
-}
-
-const preventSlashPaletteEntryFocus = (event: CustomEvent) => {
+const handleSlashDropdownPointerDown = (event: PointerEvent) => {
+  // Fundamental rule for slash commands: the popup is only a visual chooser.
+  // Selection happens through the textarea's keyboard handlers, and mouse/touch
+  // clicks must not transfer DOM focus into popup items.
   event.preventDefault()
+  void focusPromptAt(promptSelectionStart.value)
 }
 
 const setComposerError = (messageText: string) => {
@@ -878,6 +848,18 @@ const moveSlashHighlight = (delta: number) => {
   }
 
   slashHighlightIndex.value = nextIndex
+}
+
+const resolveSlashCommandIcon = (command: SlashCommandDefinition) => {
+  if (command.name === 'review') {
+    return 'i-lucide-search-check'
+  }
+
+  if (command.name === 'usage' || command.name === 'status') {
+    return 'i-lucide-gauge'
+  }
+
+  return 'i-lucide-terminal'
 }
 
 const completeSlashCommand = async (command: SlashCommandDefinition) => {
@@ -2766,27 +2748,46 @@ watch(input, async () => {
             Drop images to attach them
           </div>
 
-          <UCommandPalette
+          <div
             v-if="slashDropdownOpen"
             ref="slashDropdownRef"
-            class="absolute bottom-full left-0 z-20 mb-2 w-[90vw] max-w-[calc(100vw-2rem)] md:w-[min(50vw,52rem)] md:max-w-[min(50vw,52rem)]"
-            :groups="slashPaletteGroups"
-            :input="false"
-            :autofocus="false"
-            :search-term="activeSlashMatch?.query ?? ''"
-            :ui="{
-              root: 'min-h-0 overflow-hidden rounded-2xl border border-default bg-default/95 shadow-2xl backdrop-blur',
-              content: 'max-h-72 overflow-y-auto p-2',
-              group: 'space-y-1',
-              item: 'rounded-xl px-3 py-2.5',
-              itemLeadingIcon: 'size-4',
-              itemLabel: 'text-sm font-medium',
-              itemDescription: 'text-xs leading-5'
-            }"
-            @entry-focus="preventSlashPaletteEntryFocus"
-            @focusin.capture="handleSlashDropdownFocusIn"
-            @mousedown.prevent
-          />
+            role="listbox"
+            aria-label="Slash commands"
+            class="absolute bottom-full left-0 z-20 mb-2 w-[90vw] max-w-[calc(100vw-2rem)] overflow-hidden rounded-2xl border border-default bg-default/95 shadow-2xl backdrop-blur md:w-[min(50vw,52rem)] md:max-w-[min(50vw,52rem)]"
+            @pointerdown="handleSlashDropdownPointerDown"
+          >
+            <!-- Do not swap this back to a focus-managing listbox/palette. Slash
+                 suggestions are anchored to the textarea selection state; the
+                 popup must remain an inert overlay or the first `/` can move
+                 focus out of the composer and permanently collapse matching. -->
+            <div class="max-h-72 space-y-1 overflow-y-auto p-2">
+              <div
+                v-for="(command, index) in filteredSlashCommands"
+                :key="command.name"
+                role="option"
+                :aria-selected="index === slashHighlightIndex"
+                data-slash-command-option=""
+                class="group relative flex cursor-pointer items-start gap-1.5 rounded-xl px-3 py-2.5 text-sm text-highlighted outline-none transition-colors before:absolute before:inset-px before:z-[-1] before:rounded-md"
+                :class="index === slashHighlightIndex
+                  ? 'before:bg-elevated'
+                  : 'hover:before:bg-elevated/60'"
+                @click="void activateSlashCommand(command, command.supportsInlineArgs ? 'complete' : 'execute')"
+              >
+                <UIcon
+                  :name="resolveSlashCommandIcon(command)"
+                  class="mt-0.5 size-4 shrink-0 text-dimmed group-aria-selected:text-highlighted"
+                />
+                <div class="min-w-0">
+                  <div class="text-sm font-medium">
+                    /{{ command.name }}
+                  </div>
+                  <div class="text-xs leading-5 text-toned">
+                    {{ command.description }}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
 
           <UChatPrompt
             ref="chatPromptRef"

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -12,6 +12,7 @@ import {
 import MessageContent from './MessageContent.vue'
 import ReviewStartDrawer from './ReviewStartDrawer.vue'
 import PendingUserRequestDrawer from './PendingUserRequestDrawer.vue'
+import UsageStatusModal from './UsageStatusModal.vue'
 import {
   reconcileOptimisticUserMessage,
   removeChatMessage,
@@ -70,6 +71,10 @@ import {
   type ThreadStartResponse,
   type TurnStartResponse
 } from '~~/shared/codex-rpc'
+import {
+  normalizeAccountRateLimits,
+  type RateLimitBucket
+} from '~~/shared/account-rate-limits'
 import {
   buildTurnOverrides,
   coercePromptSelection,
@@ -188,10 +193,16 @@ const slashHighlightIndex = ref(0)
 const reviewDrawerOpen = ref(false)
 const reviewDrawerMode = ref<'target' | 'branch'>('target')
 const reviewDrawerCommandText = ref('/review')
+const usageStatusModalOpen = ref(false)
+const usageStatusLoading = ref(false)
+const usageStatusError = ref<string | null>(null)
+const usageStatusBuckets = ref<RateLimitBucket[]>([])
 const reviewBranches = ref<string[]>([])
 const reviewCurrentBranch = ref<string | null>(null)
 const reviewBranchesLoading = ref(false)
 const reviewBranchesError = ref<string | null>(null)
+let releaseUsageStatusSubscription: (() => void) | null = null
+let usageStatusLoadToken = 0
 const isBusy = computed(() =>
   status.value === 'submitted'
   || status.value === 'streaming'
@@ -273,7 +284,11 @@ const slashPaletteGroups = computed(() => [{
   items: filteredSlashCommands.value.map((command, index) => ({
     label: `/${command.name}`,
     description: command.description,
-    icon: command.name === 'review' ? 'i-lucide-search-check' : 'i-lucide-terminal',
+    icon: command.name === 'review'
+      ? 'i-lucide-search-check'
+      : (command.name === 'usage' || command.name === 'status')
+          ? 'i-lucide-gauge'
+          : 'i-lucide-terminal',
     active: index === slashHighlightIndex.value,
     onSelect: () => {
       void activateSlashCommand(command, command.supportsInlineArgs ? 'complete' : 'execute')
@@ -776,6 +791,66 @@ const closeReviewDrawer = () => {
   resetReviewDrawerState()
 }
 
+const resetUsageStatusState = () => {
+  usageStatusLoading.value = false
+  usageStatusError.value = null
+  usageStatusBuckets.value = []
+}
+
+const closeUsageStatusModal = () => {
+  usageStatusLoadToken += 1
+  usageStatusModalOpen.value = false
+  releaseUsageStatusSubscription?.()
+  releaseUsageStatusSubscription = null
+  resetUsageStatusState()
+}
+
+const applyUsageStatusSnapshot = (value: unknown) => {
+  usageStatusBuckets.value = normalizeAccountRateLimits(value)
+  usageStatusError.value = null
+}
+
+const openUsageStatusModal = async () => {
+  dismissedSlashMatchKey.value = null
+  usageStatusLoadToken += 1
+  const loadToken = usageStatusLoadToken
+  usageStatusModalOpen.value = true
+  usageStatusLoading.value = true
+  usageStatusError.value = null
+  usageStatusBuckets.value = []
+
+  const client = getClient(props.projectId)
+  releaseUsageStatusSubscription?.()
+  releaseUsageStatusSubscription = client.subscribe((notification) => {
+    if (notification.method !== 'account/rateLimits/updated' || !usageStatusModalOpen.value) {
+      return
+    }
+
+    applyUsageStatusSnapshot(notification.params)
+    usageStatusLoading.value = false
+  })
+
+  try {
+    await ensureProjectRuntime()
+    const response = await client.request('account/rateLimits/read')
+    if (!usageStatusModalOpen.value || loadToken !== usageStatusLoadToken) {
+      return
+    }
+
+    applyUsageStatusSnapshot(response)
+  } catch (caughtError) {
+    if (!usageStatusModalOpen.value || loadToken !== usageStatusLoadToken) {
+      return
+    }
+
+    usageStatusError.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
+  } finally {
+    if (loadToken === usageStatusLoadToken) {
+      usageStatusLoading.value = false
+    }
+  }
+}
+
 const openReviewDrawer = (commandText = '/review') => {
   dismissedSlashMatchKey.value = null
   reviewDrawerCommandText.value = commandText
@@ -928,16 +1003,34 @@ const handleSlashCommandSubmission = async (
     return true
   }
 
-  if (!slashCommand.isBare) {
-    setComposerError('`/review` currently only supports the bare command. Choose the diff target in the review drawer.')
-    return true
-  }
+  switch (command.name) {
+    case 'review': {
+      if (!slashCommand.isBare) {
+        setComposerError('`/review` currently only supports the bare command. Choose the diff target in the review drawer.')
+        return true
+      }
 
-  error.value = null
-  status.value = 'ready'
-  openReviewDrawer(`/${command.name}`)
-  await focusPromptAt(rawText.trim().length)
-  return true
+      error.value = null
+      status.value = 'ready'
+      openReviewDrawer(`/${command.name}`)
+      await focusPromptAt(rawText.trim().length)
+      return true
+    }
+    case 'usage':
+    case 'status': {
+      if (!slashCommand.isBare) {
+        setComposerError(`\`/${command.name}\` currently only supports the bare command.`)
+        return true
+      }
+
+      error.value = null
+      status.value = 'ready'
+      await openUsageStatusModal()
+      return true
+    }
+    default:
+      return false
+  }
 }
 
 const activateSlashCommand = async (
@@ -959,6 +1052,15 @@ const handleReviewDrawerOpenChange = (open: boolean) => {
   }
 
   closeReviewDrawer()
+}
+
+const handleUsageStatusOpenChange = (open: boolean) => {
+  if (open) {
+    void openUsageStatusModal()
+    return
+  }
+
+  closeUsageStatusModal()
 }
 
 const handleReviewDrawerBack = () => {
@@ -2461,6 +2563,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   cancelAllPendingRequests()
+  closeUsageStatusModal()
   releaseServerRequestHandler?.()
   releaseServerRequestHandler = null
 })
@@ -2931,5 +3034,13 @@ watch(input, async () => {
     @choose-base-branch-mode="openBaseBranchPicker"
     @choose-base-branch="(branch) => startReview({ type: 'baseBranch', branch })"
     @back="handleReviewDrawerBack"
+  />
+
+  <UsageStatusModal
+    :open="usageStatusModalOpen"
+    :loading="usageStatusLoading"
+    :error="usageStatusError"
+    :buckets="usageStatusBuckets"
+    @update:open="handleUsageStatusOpenChange"
   />
 </template>

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -72,10 +72,6 @@ import {
   type TurnStartResponse
 } from '~~/shared/codex-rpc'
 import {
-  normalizeAccountRateLimits,
-  type RateLimitBucket
-} from '~~/shared/account-rate-limits'
-import {
   buildTurnOverrides,
   coercePromptSelection,
   ensureModelOption,
@@ -194,15 +190,10 @@ const reviewDrawerOpen = ref(false)
 const reviewDrawerMode = ref<'target' | 'branch'>('target')
 const reviewDrawerCommandText = ref('/review')
 const usageStatusModalOpen = ref(false)
-const usageStatusLoading = ref(false)
-const usageStatusError = ref<string | null>(null)
-const usageStatusBuckets = ref<RateLimitBucket[]>([])
 const reviewBranches = ref<string[]>([])
 const reviewCurrentBranch = ref<string | null>(null)
 const reviewBranchesLoading = ref(false)
 const reviewBranchesError = ref<string | null>(null)
-let releaseUsageStatusSubscription: (() => void) | null = null
-let usageStatusLoadToken = 0
 const isBusy = computed(() =>
   status.value === 'submitted'
   || status.value === 'streaming'
@@ -761,72 +752,21 @@ const closeReviewDrawer = () => {
   resetReviewDrawerState()
 }
 
-const resetUsageStatusState = () => {
-  usageStatusLoading.value = false
-  usageStatusError.value = null
-  usageStatusBuckets.value = []
-}
-
-const closeUsageStatusModal = () => {
-  usageStatusLoadToken += 1
-  usageStatusModalOpen.value = false
-  releaseUsageStatusSubscription?.()
-  releaseUsageStatusSubscription = null
-  resetUsageStatusState()
-}
-
-const applyUsageStatusSnapshot = (value: unknown) => {
-  usageStatusBuckets.value = normalizeAccountRateLimits(value)
-  usageStatusError.value = null
-}
-
-const openUsageStatusModal = async () => {
-  dismissedSlashMatchKey.value = null
-  usageStatusLoadToken += 1
-  const loadToken = usageStatusLoadToken
-  usageStatusModalOpen.value = true
-  usageStatusLoading.value = true
-  usageStatusError.value = null
-  usageStatusBuckets.value = []
-
-  const client = getClient(props.projectId)
-  releaseUsageStatusSubscription?.()
-  releaseUsageStatusSubscription = client.subscribe((notification) => {
-    if (notification.method !== 'account/rateLimits/updated' || !usageStatusModalOpen.value) {
-      return
-    }
-
-    applyUsageStatusSnapshot(notification.params)
-    usageStatusLoading.value = false
-  })
-
-  try {
-    await ensureProjectRuntime()
-    const response = await client.request('account/rateLimits/read')
-    if (!usageStatusModalOpen.value || loadToken !== usageStatusLoadToken) {
-      return
-    }
-
-    applyUsageStatusSnapshot(response)
-  } catch (caughtError) {
-    if (!usageStatusModalOpen.value || loadToken !== usageStatusLoadToken) {
-      return
-    }
-
-    usageStatusError.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
-  } finally {
-    if (loadToken === usageStatusLoadToken) {
-      usageStatusLoading.value = false
-    }
-  }
-}
-
 const openReviewDrawer = (commandText = '/review') => {
   dismissedSlashMatchKey.value = null
   reviewDrawerCommandText.value = commandText
   reviewDrawerMode.value = 'target'
   reviewBranchesError.value = null
   reviewDrawerOpen.value = true
+}
+
+const clearSlashCommandDraft = () => {
+  // Successful slash commands consume the draft immediately. Leaving `/usage`
+  // or `/review` in the prompt after opening the modal/drawer makes the next
+  // edit start from stale command text and feels like the action did not finish.
+  input.value = ''
+  clearAttachments({ revoke: false })
+  dismissedSlashMatchKey.value = null
 }
 
 const moveSlashHighlight = (delta: number) => {
@@ -994,8 +934,9 @@ const handleSlashCommandSubmission = async (
 
       error.value = null
       status.value = 'ready'
-      openReviewDrawer(`/${command.name}`)
-      await focusPromptAt(rawText.trim().length)
+      clearSlashCommandDraft()
+      openReviewDrawer(rawText.trim())
+      await focusPromptAt(0)
       return true
     }
     case 'usage':
@@ -1007,7 +948,8 @@ const handleSlashCommandSubmission = async (
 
       error.value = null
       status.value = 'ready'
-      await openUsageStatusModal()
+      clearSlashCommandDraft()
+      usageStatusModalOpen.value = true
       return true
     }
     default:
@@ -1037,12 +979,7 @@ const handleReviewDrawerOpenChange = (open: boolean) => {
 }
 
 const handleUsageStatusOpenChange = (open: boolean) => {
-  if (open) {
-    void openUsageStatusModal()
-    return
-  }
-
-  closeUsageStatusModal()
+  usageStatusModalOpen.value = open
 }
 
 const handleReviewDrawerBack = () => {
@@ -2545,7 +2482,6 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   cancelAllPendingRequests()
-  closeUsageStatusModal()
   releaseServerRequestHandler?.()
   releaseServerRequestHandler = null
 })
@@ -3038,10 +2974,8 @@ watch(input, async () => {
   />
 
   <UsageStatusModal
+    :project-id="props.projectId"
     :open="usageStatusModalOpen"
-    :loading="usageStatusLoading"
-    :error="usageStatusError"
-    :buckets="usageStatusBuckets"
     @update:open="handleUsageStatusOpenChange"
   />
 </template>

--- a/packages/client/app/components/UsageStatusModal.vue
+++ b/packages/client/app/components/UsageStatusModal.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { useProjects } from '../composables/useProjects'
+import { useRpc } from '../composables/useRpc'
 import {
+  normalizeAccountRateLimits,
   formatRateLimitWindowDuration,
   type RateLimitBucket
 } from '../../shared/account-rate-limits'
@@ -8,66 +11,77 @@ import {
 type UsageWindowRow = {
   id: string
   title: string
-  usedPercent: number | null
-  percentLabel: string
-  durationLabel: string | null
+  remainingPercent: number | null
+  progressLabel: string
   resetsAt: string | null
-  resetLabel: string
+  nextResetLabel: string
   durationMins: number | null
 }
 
 const props = withDefaults(defineProps<{
+  projectId: string
   open?: boolean
-  loading?: boolean
-  error?: string | null
-  buckets?: RateLimitBucket[]
 }>(), {
-  open: false,
-  loading: false,
-  error: null,
-  buckets: () => []
+  open: false
 })
 
 const emit = defineEmits<{
   'update:open': [open: boolean]
 }>()
 
-const resetFormatter = new Intl.DateTimeFormat(undefined, {
+const { getClient } = useRpc()
+const {
+  loaded,
+  refreshProjects,
+  getProject,
+  startProject
+} = useProjects()
+const loading = ref(false)
+const error = ref<string | null>(null)
+const buckets = ref<RateLimitBucket[]>([])
+const selectedProject = computed(() => getProject(props.projectId))
+let usageStatusLoadToken = 0
+let releaseUsageStatusSubscription: (() => void) | null = null
+
+const nextResetFormatter = new Intl.DateTimeFormat(undefined, {
   month: 'short',
   day: 'numeric',
   hour: 'numeric',
   minute: '2-digit'
 })
 
-const formatPercentLabel = (value: number | null) =>
-  value == null ? 'Usage unavailable' : `${Math.round(value)}% used`
+const toRemainingPercent = (usedPercent: number | null) =>
+  usedPercent == null ? null : Math.max(0, 100 - usedPercent)
 
-const formatResetLabel = (value: string | null) =>
-  value ? `Resets ${resetFormatter.format(new Date(value))}` : 'Reset unavailable'
+const formatProgressLabel = (usedPercent: number | null) => {
+  const remainingPercent = toRemainingPercent(usedPercent)
+  return remainingPercent == null ? 'Remaining quota unavailable' : `${Math.round(remainingPercent)}% remaining`
+}
+
+const formatNextResetLabel = (value: string | null) =>
+  value ? `Next reset ${nextResetFormatter.format(new Date(value))}` : 'Next reset unavailable'
 
 const cards = computed(() =>
-  props.buckets.map((bucket) => {
+  buckets.value.map((bucket) => {
     const windows = [{
       id: `${bucket.limitId}-primary`,
       title: formatRateLimitWindowDuration(bucket.primary?.windowDurationMins ?? null) ?? 'Primary window',
-      usedPercent: bucket.primary?.usedPercent ?? null,
-      percentLabel: formatPercentLabel(bucket.primary?.usedPercent ?? null),
-      durationLabel: formatRateLimitWindowDuration(bucket.primary?.windowDurationMins ?? null),
+      remainingPercent: toRemainingPercent(bucket.primary?.usedPercent ?? null),
+      progressLabel: formatProgressLabel(bucket.primary?.usedPercent ?? null),
       resetsAt: bucket.primary?.resetsAt ?? null,
-      resetLabel: formatResetLabel(bucket.primary?.resetsAt ?? null),
+      nextResetLabel: formatNextResetLabel(bucket.primary?.resetsAt ?? null),
       durationMins: bucket.primary?.windowDurationMins ?? null
     }, {
       id: `${bucket.limitId}-secondary`,
       title: formatRateLimitWindowDuration(bucket.secondary?.windowDurationMins ?? null) ?? 'Secondary window',
-      usedPercent: bucket.secondary?.usedPercent ?? null,
-      percentLabel: formatPercentLabel(bucket.secondary?.usedPercent ?? null),
-      durationLabel: formatRateLimitWindowDuration(bucket.secondary?.windowDurationMins ?? null),
+      remainingPercent: toRemainingPercent(bucket.secondary?.usedPercent ?? null),
+      progressLabel: formatProgressLabel(bucket.secondary?.usedPercent ?? null),
       resetsAt: bucket.secondary?.resetsAt ?? null,
-      resetLabel: formatResetLabel(bucket.secondary?.resetsAt ?? null),
+      nextResetLabel: formatNextResetLabel(bucket.secondary?.resetsAt ?? null),
       durationMins: bucket.secondary?.windowDurationMins ?? null
     }]
       .filter((window) =>
-        window.usedPercent != null
+        window.remainingPercent != null
         || window.resetsAt != null
         || window.durationMins != null
       )
@@ -81,6 +95,92 @@ const cards = computed(() =>
     }
   })
 )
+
+const resetUsageStatusState = () => {
+  loading.value = false
+  error.value = null
+  buckets.value = []
+}
+
+const closeUsageStatus = () => {
+  usageStatusLoadToken += 1
+  releaseUsageStatusSubscription?.()
+  releaseUsageStatusSubscription = null
+  resetUsageStatusState()
+}
+
+const applyUsageStatusSnapshot = (value: unknown) => {
+  buckets.value = normalizeAccountRateLimits(value)
+  error.value = null
+}
+
+const ensureProjectRuntime = async () => {
+  if (!loaded.value) {
+    await refreshProjects()
+  }
+
+  if (selectedProject.value?.status === 'running') {
+    return
+  }
+
+  await startProject(props.projectId)
+}
+
+const openUsageStatus = async () => {
+  usageStatusLoadToken += 1
+  const loadToken = usageStatusLoadToken
+  loading.value = true
+  error.value = null
+  buckets.value = []
+
+  const client = getClient(props.projectId)
+  releaseUsageStatusSubscription?.()
+  releaseUsageStatusSubscription = client.subscribe((notification) => {
+    if (notification.method !== 'account/rateLimits/updated' || !props.open) {
+      return
+    }
+
+    applyUsageStatusSnapshot(notification.params)
+    loading.value = false
+  })
+
+  try {
+    await ensureProjectRuntime()
+    const response = await client.request('account/rateLimits/read')
+    if (!props.open || loadToken !== usageStatusLoadToken) {
+      return
+    }
+
+    applyUsageStatusSnapshot(response)
+  } catch (caughtError) {
+    if (!props.open || loadToken !== usageStatusLoadToken) {
+      return
+    }
+
+    error.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
+  } finally {
+    if (loadToken === usageStatusLoadToken) {
+      loading.value = false
+    }
+  }
+}
+
+watch(() => [props.open, props.projectId] as const, ([open, projectId], previous) => {
+  const [wasOpen, previousProjectId] = previous ?? [false, projectId]
+
+  if (!open) {
+    closeUsageStatus()
+    return
+  }
+
+  if (!wasOpen || projectId !== previousProjectId) {
+    void openUsageStatus()
+  }
+}, { immediate: true })
+
+onBeforeUnmount(() => {
+  closeUsageStatus()
+})
 </script>
 
 <template>
@@ -88,26 +188,13 @@ const cards = computed(() =>
     :open="open"
     title="Usage status"
     description="Live Codex quota windows for the current account."
-    :close="{
-      color: 'neutral',
-      variant: 'ghost',
-      class: 'rounded-full'
-    }"
-    :ui="{
-      overlay: 'bg-black/45 backdrop-blur-sm',
-      content: 'w-[92vw] max-w-xl rounded-3xl border border-default bg-default shadow-2xl',
-      header: 'px-4 pb-1 pt-4 sm:px-5',
-      body: 'px-4 pb-4 pt-2 sm:px-5',
-      title: 'text-sm font-semibold text-highlighted sm:text-base',
-      description: 'text-sm leading-5 text-muted'
-    }"
     @update:open="emit('update:open', $event)"
   >
     <template #body>
       <div class="space-y-3">
         <div
           v-if="loading"
-          class="rounded-2xl border border-default bg-elevated/40 px-4 py-6 text-sm text-muted"
+          class="rounded-lg border border-default bg-elevated/40 px-4 py-6 text-sm text-muted"
         >
           Loading current quota windows...
         </div>
@@ -122,7 +209,7 @@ const cards = computed(() =>
 
         <div
           v-else-if="!cards.length"
-          class="rounded-2xl border border-dashed border-default px-4 py-6 text-center text-sm text-muted"
+          class="rounded-lg border border-dashed border-default px-4 py-6 text-center text-sm text-muted"
         >
           No live quota windows were reported.
         </div>
@@ -134,7 +221,7 @@ const cards = computed(() =>
           <section
             v-for="card in cards"
             :key="card.id"
-            class="rounded-2xl border border-default bg-elevated/35 p-3 sm:p-4"
+            class="rounded-lg border border-default bg-elevated/35 p-3 sm:p-4"
           >
             <div class="mb-3 flex items-start justify-between gap-3">
               <div class="min-w-0">
@@ -157,38 +244,31 @@ const cards = computed(() =>
               <div
                 v-for="window in card.windows"
                 :key="window.id"
-                class="rounded-xl border border-default/80 bg-default/75 p-3"
+                class="rounded-lg border border-default/80 bg-default/75 p-3"
               >
                 <div class="flex items-start justify-between gap-3">
                   <div class="text-xs font-semibold uppercase tracking-[0.18em] text-muted">
                     {{ window.title }}
                   </div>
                   <div class="text-sm font-semibold text-highlighted">
-                    {{ window.percentLabel }}
+                    {{ window.progressLabel }}
                   </div>
                 </div>
 
                 <div class="mt-2 h-2 overflow-hidden rounded-full bg-muted">
                   <div
                     class="h-full rounded-full bg-primary transition-[width]"
-                    :style="{ width: `${window.usedPercent ?? 0}%` }"
+                    :style="{ width: `${window.remainingPercent ?? 0}%` }"
                   />
                 </div>
 
-                <div class="mt-2 flex flex-wrap items-center justify-between gap-2 text-xs text-muted">
-                  <time
-                    v-if="window.resetsAt"
-                    :datetime="window.resetsAt"
-                  >
-                    {{ window.resetLabel }}
-                  </time>
-                  <span v-else>
-                    {{ window.resetLabel }}
-                  </span>
-                  <span v-if="window.durationLabel">
-                    {{ window.durationLabel }}
-                  </span>
-                </div>
+                <time
+                  v-if="window.resetsAt"
+                  class="mt-2 block text-xs text-muted"
+                  :datetime="window.resetsAt"
+                >
+                  {{ window.nextResetLabel }}
+                </time>
               </div>
             </div>
           </section>

--- a/packages/client/app/components/UsageStatusModal.vue
+++ b/packages/client/app/components/UsageStatusModal.vue
@@ -1,0 +1,199 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import {
+  formatRateLimitWindowDuration,
+  type RateLimitBucket
+} from '../../shared/account-rate-limits'
+
+type UsageWindowRow = {
+  id: string
+  title: string
+  usedPercent: number | null
+  percentLabel: string
+  durationLabel: string | null
+  resetsAt: string | null
+  resetLabel: string
+  durationMins: number | null
+}
+
+const props = withDefaults(defineProps<{
+  open?: boolean
+  loading?: boolean
+  error?: string | null
+  buckets?: RateLimitBucket[]
+}>(), {
+  open: false,
+  loading: false,
+  error: null,
+  buckets: () => []
+})
+
+const emit = defineEmits<{
+  'update:open': [open: boolean]
+}>()
+
+const resetFormatter = new Intl.DateTimeFormat(undefined, {
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: '2-digit'
+})
+
+const formatPercentLabel = (value: number | null) =>
+  value == null ? 'Usage unavailable' : `${Math.round(value)}% used`
+
+const formatResetLabel = (value: string | null) =>
+  value ? `Resets ${resetFormatter.format(new Date(value))}` : 'Reset unavailable'
+
+const cards = computed(() =>
+  props.buckets.map((bucket) => {
+    const windows = [{
+      id: `${bucket.limitId}-primary`,
+      title: formatRateLimitWindowDuration(bucket.primary?.windowDurationMins ?? null) ?? 'Primary window',
+      usedPercent: bucket.primary?.usedPercent ?? null,
+      percentLabel: formatPercentLabel(bucket.primary?.usedPercent ?? null),
+      durationLabel: formatRateLimitWindowDuration(bucket.primary?.windowDurationMins ?? null),
+      resetsAt: bucket.primary?.resetsAt ?? null,
+      resetLabel: formatResetLabel(bucket.primary?.resetsAt ?? null),
+      durationMins: bucket.primary?.windowDurationMins ?? null
+    }, {
+      id: `${bucket.limitId}-secondary`,
+      title: formatRateLimitWindowDuration(bucket.secondary?.windowDurationMins ?? null) ?? 'Secondary window',
+      usedPercent: bucket.secondary?.usedPercent ?? null,
+      percentLabel: formatPercentLabel(bucket.secondary?.usedPercent ?? null),
+      durationLabel: formatRateLimitWindowDuration(bucket.secondary?.windowDurationMins ?? null),
+      resetsAt: bucket.secondary?.resetsAt ?? null,
+      resetLabel: formatResetLabel(bucket.secondary?.resetsAt ?? null),
+      durationMins: bucket.secondary?.windowDurationMins ?? null
+    }]
+      .filter((window) =>
+        window.usedPercent != null
+        || window.resetsAt != null
+        || window.durationMins != null
+      )
+      .sort((left, right) => (left.durationMins ?? Number.POSITIVE_INFINITY) - (right.durationMins ?? Number.POSITIVE_INFINITY))
+
+    return {
+      id: bucket.limitId,
+      label: bucket.limitName ?? bucket.limitId,
+      detail: bucket.limitName && bucket.limitName !== bucket.limitId ? bucket.limitId : null,
+      windows
+    }
+  })
+)
+</script>
+
+<template>
+  <UModal
+    :open="open"
+    title="Usage status"
+    description="Live Codex quota windows for the current account."
+    :close="{
+      color: 'neutral',
+      variant: 'ghost',
+      class: 'rounded-full'
+    }"
+    :ui="{
+      overlay: 'bg-black/45 backdrop-blur-sm',
+      content: 'w-[92vw] max-w-xl rounded-3xl border border-default bg-default shadow-2xl',
+      header: 'px-4 pb-1 pt-4 sm:px-5',
+      body: 'px-4 pb-4 pt-2 sm:px-5',
+      title: 'text-sm font-semibold text-highlighted sm:text-base',
+      description: 'text-sm leading-5 text-muted'
+    }"
+    @update:open="emit('update:open', $event)"
+  >
+    <template #body>
+      <div class="space-y-3">
+        <div
+          v-if="loading"
+          class="rounded-2xl border border-default bg-elevated/40 px-4 py-6 text-sm text-muted"
+        >
+          Loading current quota windows...
+        </div>
+
+        <UAlert
+          v-else-if="error"
+          color="error"
+          variant="soft"
+          icon="i-lucide-circle-alert"
+          :title="error"
+        />
+
+        <div
+          v-else-if="!cards.length"
+          class="rounded-2xl border border-dashed border-default px-4 py-6 text-center text-sm text-muted"
+        >
+          No live quota windows were reported.
+        </div>
+
+        <div
+          v-else
+          class="space-y-3"
+        >
+          <section
+            v-for="card in cards"
+            :key="card.id"
+            class="rounded-2xl border border-default bg-elevated/35 p-3 sm:p-4"
+          >
+            <div class="mb-3 flex items-start justify-between gap-3">
+              <div class="min-w-0">
+                <h3 class="truncate text-sm font-semibold text-highlighted">
+                  {{ card.label }}
+                </h3>
+                <p
+                  v-if="card.detail"
+                  class="text-xs text-muted"
+                >
+                  {{ card.detail }}
+                </p>
+              </div>
+              <div class="rounded-full border border-default px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.18em] text-muted">
+                bucket
+              </div>
+            </div>
+
+            <div class="space-y-2">
+              <div
+                v-for="window in card.windows"
+                :key="window.id"
+                class="rounded-xl border border-default/80 bg-default/75 p-3"
+              >
+                <div class="flex items-start justify-between gap-3">
+                  <div class="text-xs font-semibold uppercase tracking-[0.18em] text-muted">
+                    {{ window.title }}
+                  </div>
+                  <div class="text-sm font-semibold text-highlighted">
+                    {{ window.percentLabel }}
+                  </div>
+                </div>
+
+                <div class="mt-2 h-2 overflow-hidden rounded-full bg-muted">
+                  <div
+                    class="h-full rounded-full bg-primary transition-[width]"
+                    :style="{ width: `${window.usedPercent ?? 0}%` }"
+                  />
+                </div>
+
+                <div class="mt-2 flex flex-wrap items-center justify-between gap-2 text-xs text-muted">
+                  <time
+                    v-if="window.resetsAt"
+                    :datetime="window.resetsAt"
+                  >
+                    {{ window.resetLabel }}
+                  </time>
+                  <span v-else>
+                    {{ window.resetLabel }}
+                  </span>
+                  <span v-if="window.durationLabel">
+                    {{ window.durationLabel }}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </template>
+  </UModal>
+</template>

--- a/packages/client/app/components/UsageStatusModal.vue
+++ b/packages/client/app/components/UsageStatusModal.vue
@@ -8,16 +8,6 @@ import {
   type RateLimitBucket
 } from '../../shared/account-rate-limits'
 
-type UsageWindowRow = {
-  id: string
-  title: string
-  remainingPercent: number | null
-  progressLabel: string
-  resetsAt: string | null
-  nextResetLabel: string
-  durationMins: number | null
-}
-
 const props = withDefaults(defineProps<{
   projectId: string
   open?: boolean

--- a/packages/client/app/components/UsageStatusModal.vue
+++ b/packages/client/app/components/UsageStatusModal.vue
@@ -187,7 +187,6 @@ onBeforeUnmount(() => {
   <UModal
     :open="open"
     title="Usage status"
-    description="Live Codex quota windows for the current account."
     @update:open="emit('update:open', $event)"
   >
     <template #body>
@@ -223,7 +222,7 @@ onBeforeUnmount(() => {
             :key="card.id"
             class="rounded-lg border border-default bg-elevated/35 p-3 sm:p-4"
           >
-            <div class="mb-3 flex items-start justify-between gap-3">
+            <div class="mb-3 min-w-0">
               <div class="min-w-0">
                 <h3 class="truncate text-sm font-semibold text-highlighted">
                   {{ card.label }}
@@ -234,9 +233,6 @@ onBeforeUnmount(() => {
                 >
                   {{ card.detail }}
                 </p>
-              </div>
-              <div class="rounded-full border border-default px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.18em] text-muted">
-                bucket
               </div>
             </div>
 

--- a/packages/client/app/utils/slash-prompt-focus.ts
+++ b/packages/client/app/utils/slash-prompt-focus.ts
@@ -1,0 +1,8 @@
+// Slash-command popups are rendered as inert overlays. This helper is only for
+// the composer blur guard to recognize "still inside the slash popup" targets.
+export const isFocusWithinContainer = (
+  target: EventTarget | null | undefined,
+  container: ParentNode | null | undefined
+) =>
+  target instanceof Node
+  && Boolean(container?.contains(target))

--- a/packages/client/shared/account-rate-limits.ts
+++ b/packages/client/shared/account-rate-limits.ts
@@ -72,6 +72,25 @@ const normalizeRateLimitWindow = (value: unknown): RateLimitWindow | null => {
   }
 }
 
+const mergeRateLimitWindow = (
+  existing: RateLimitWindow | null,
+  incoming: RateLimitWindow | null
+): RateLimitWindow | null => {
+  if (!existing) {
+    return incoming
+  }
+
+  if (!incoming) {
+    return existing
+  }
+
+  return {
+    usedPercent: incoming.usedPercent ?? existing.usedPercent,
+    resetsAt: incoming.resetsAt ?? existing.resetsAt,
+    windowDurationMins: incoming.windowDurationMins ?? existing.windowDurationMins
+  }
+}
+
 const normalizeRateLimitBucket = (value: unknown): RateLimitBucket | null => {
   const record = isObjectRecord(value) ? value : null
   if (!record) {
@@ -135,8 +154,8 @@ export const normalizeAccountRateLimits = (value: unknown): RateLimitBucket[] =>
     bucketsById.set(bucket.limitId, {
       ...existing,
       limitName: existing.limitName ?? bucket.limitName,
-      primary: existing.primary ?? bucket.primary,
-      secondary: existing.secondary ?? bucket.secondary
+      primary: mergeRateLimitWindow(existing.primary, bucket.primary),
+      secondary: mergeRateLimitWindow(existing.secondary, bucket.secondary)
     })
   }
 

--- a/packages/client/shared/account-rate-limits.ts
+++ b/packages/client/shared/account-rate-limits.ts
@@ -1,0 +1,171 @@
+export type RateLimitWindow = {
+  usedPercent: number | null
+  resetsAt: string | null
+  windowDurationMins: number | null
+}
+
+export type RateLimitBucket = {
+  limitId: string
+  limitName: string | null
+  primary: RateLimitWindow | null
+  secondary: RateLimitWindow | null
+}
+
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const toFiniteNumber = (value: unknown) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === 'bigint') {
+    return Number(value)
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) {
+      return parsed
+    }
+  }
+
+  return null
+}
+
+const toPercent = (value: unknown) => {
+  const parsed = toFiniteNumber(value)
+  if (parsed == null) {
+    return null
+  }
+
+  const normalized = parsed > 0 && parsed <= 1 ? parsed * 100 : parsed
+  return Math.max(0, Math.min(100, normalized))
+}
+
+const toTimestamp = (value: unknown) => {
+  if (typeof value !== 'string' || !value.trim()) {
+    return null
+  }
+
+  return Number.isNaN(Date.parse(value)) ? null : value
+}
+
+const normalizeRateLimitWindow = (value: unknown): RateLimitWindow | null => {
+  const record = isObjectRecord(value) ? value : null
+  if (!record) {
+    return null
+  }
+
+  const usedPercent = toPercent(record.usedPercent)
+  const resetsAt = toTimestamp(record.resetsAt)
+  const windowDurationMins = toFiniteNumber(record.windowDurationMins)
+
+  if (usedPercent == null && resetsAt == null && windowDurationMins == null) {
+    return null
+  }
+
+  return {
+    usedPercent,
+    resetsAt,
+    windowDurationMins
+  }
+}
+
+const normalizeRateLimitBucket = (value: unknown): RateLimitBucket | null => {
+  const record = isObjectRecord(value) ? value : null
+  if (!record) {
+    return null
+  }
+
+  const limitId = typeof record.limitId === 'string' && record.limitId.trim()
+    ? record.limitId.trim()
+    : null
+  const limitName = typeof record.limitName === 'string' && record.limitName.trim()
+    ? record.limitName.trim()
+    : null
+
+  if (!limitId && !limitName) {
+    return null
+  }
+
+  const primary = normalizeRateLimitWindow(record.primary)
+  const secondary = normalizeRateLimitWindow(record.secondary)
+  if (!primary && !secondary) {
+    return null
+  }
+
+  return {
+    limitId: limitId ?? limitName ?? 'unknown',
+    limitName,
+    primary,
+    secondary
+  }
+}
+
+const collectRateLimitCandidates = (value: unknown) => {
+  const root = isObjectRecord(value) ? value : null
+  const rateLimits = Array.isArray(root?.rateLimits) ? root.rateLimits : []
+  const rateLimitsByLimitId = isObjectRecord(root?.rateLimitsByLimitId)
+    ? Object.values(root.rateLimitsByLimitId)
+    : []
+
+  if (rateLimits.length > 0 || rateLimitsByLimitId.length > 0) {
+    return [...rateLimits, ...rateLimitsByLimitId]
+  }
+
+  return Array.isArray(value) ? value : []
+}
+
+export const normalizeAccountRateLimits = (value: unknown): RateLimitBucket[] => {
+  const bucketsById = new Map<string, RateLimitBucket>()
+
+  for (const candidate of collectRateLimitCandidates(value)) {
+    const bucket = normalizeRateLimitBucket(candidate)
+    if (!bucket) {
+      continue
+    }
+
+    const existing = bucketsById.get(bucket.limitId)
+    if (!existing) {
+      bucketsById.set(bucket.limitId, bucket)
+      continue
+    }
+
+    bucketsById.set(bucket.limitId, {
+      ...existing,
+      limitName: existing.limitName ?? bucket.limitName,
+      primary: existing.primary ?? bucket.primary,
+      secondary: existing.secondary ?? bucket.secondary
+    })
+  }
+
+  return [...bucketsById.values()].sort((left, right) => {
+    const leftLabel = (left.limitName ?? left.limitId).toLowerCase()
+    const rightLabel = (right.limitName ?? right.limitId).toLowerCase()
+    return leftLabel.localeCompare(rightLabel)
+  })
+}
+
+export const formatRateLimitWindowDuration = (value: number | null) => {
+  if (value == null || value <= 0) {
+    return null
+  }
+
+  if (value % (60 * 24 * 7) === 0) {
+    const weeks = value / (60 * 24 * 7)
+    return `${weeks}w window`
+  }
+
+  if (value % (60 * 24) === 0) {
+    const days = value / (60 * 24)
+    return `${days}d window`
+  }
+
+  if (value % 60 === 0) {
+    const hours = value / 60
+    return `${hours}h window`
+  }
+
+  return `${value}m window`
+}

--- a/packages/client/shared/slash-commands.ts
+++ b/packages/client/shared/slash-commands.ts
@@ -1,4 +1,4 @@
-export type SlashCommandName = 'review'
+export type SlashCommandName = 'review' | 'usage' | 'status'
 
 export type SlashCommandDefinition = {
   name: SlashCommandName
@@ -24,6 +24,18 @@ export type SubmittedSlashCommand = {
 export const SLASH_COMMANDS: SlashCommandDefinition[] = [{
   name: 'review',
   description: 'Review current changes or compare against a base branch.',
+  supportsInlineArgs: false,
+  completeOnSpace: true,
+  executeOnEnter: true
+}, {
+  name: 'usage',
+  description: 'Inspect current Codex quota windows and reset timing.',
+  supportsInlineArgs: false,
+  completeOnSpace: true,
+  executeOnEnter: true
+}, {
+  name: 'status',
+  description: 'Alias for `/usage` to inspect current Codex quota windows.',
   supportsInlineArgs: false,
   completeOnSpace: true,
   executeOnEnter: true

--- a/packages/client/test/slash-commands.test.ts
+++ b/packages/client/test/slash-commands.test.ts
@@ -30,9 +30,12 @@ describe('slash command helpers', () => {
   })
 
   it('filters available commands by prefix and formats completion text', () => {
-    expect(filterSlashCommands(SLASH_COMMANDS, '')).toHaveLength(1)
+    expect(filterSlashCommands(SLASH_COMMANDS, '')).toHaveLength(3)
     expect(filterSlashCommands(SLASH_COMMANDS, 're').map(command => command.name)).toEqual(['review'])
+    expect(filterSlashCommands(SLASH_COMMANDS, 'us').map(command => command.name)).toEqual(['usage'])
+    expect(filterSlashCommands(SLASH_COMMANDS, 'st').map(command => command.name)).toEqual(['status'])
     expect(toSlashCommandCompletion(SLASH_COMMANDS[0]!)).toBe('/review ')
+    expect(toSlashCommandCompletion(SLASH_COMMANDS[1]!)).toBe('/usage ')
   })
 
   it('parses submitted slash commands and inline args', () => {
@@ -46,6 +49,18 @@ describe('slash command helpers', () => {
       name: 'review',
       args: 'compare this',
       isBare: false
+    })
+
+    expect(parseSubmittedSlashCommand('/usage')).toEqual({
+      name: 'usage',
+      args: '',
+      isBare: true
+    })
+
+    expect(parseSubmittedSlashCommand('/status')).toEqual({
+      name: 'status',
+      args: '',
+      isBare: true
     })
 
     expect(parseSubmittedSlashCommand('review')).toBeNull()

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -168,6 +168,11 @@ describe('client package', () => {
       rateLimitsByLimitId: {
         'gpt-5': {
           limitId: 'gpt-5',
+          primary: {
+            usedPercent: 65,
+            resetsAt: '2026-04-15T13:00:00.000Z',
+            windowDurationMins: 300
+          },
           secondary: {
             usedPercent: '0.5',
             resetsAt: '2026-04-20T00:00:00.000Z',
@@ -190,8 +195,8 @@ describe('client package', () => {
       limitId: 'gpt-5',
       limitName: 'GPT-5',
       primary: {
-        usedPercent: 72,
-        resetsAt: '2026-04-15T12:00:00.000Z',
+        usedPercent: 65,
+        resetsAt: '2026-04-15T13:00:00.000Z',
         windowDurationMins: 300
       },
       secondary: {

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -26,6 +26,11 @@ import {
   validateAttachmentSelection
 } from '../shared/chat-attachments'
 import {
+  formatRateLimitWindowDuration,
+  normalizeAccountRateLimits,
+  type RateLimitBucket
+} from '../shared/account-rate-limits'
+import {
   buildTurnOverrides,
   coercePromptSelection,
   ensureModelOption,
@@ -147,6 +152,71 @@ describe('client package', () => {
         state: 'done'
       }]
     }])
+  })
+
+  it('normalizes account rate limit snapshots from both list and map payloads', () => {
+    const buckets = normalizeAccountRateLimits({
+      rateLimits: [{
+        limitId: 'gpt-5',
+        limitName: 'GPT-5',
+        primary: {
+          usedPercent: 72,
+          resetsAt: '2026-04-15T12:00:00.000Z',
+          windowDurationMins: 300
+        }
+      }],
+      rateLimitsByLimitId: {
+        'gpt-5': {
+          limitId: 'gpt-5',
+          secondary: {
+            usedPercent: '0.5',
+            resetsAt: '2026-04-20T00:00:00.000Z',
+            windowDurationMins: 10080
+          }
+        },
+        'gpt-5-mini': {
+          limitId: 'gpt-5-mini',
+          limitName: 'GPT-5 Mini',
+          primary: {
+            usedPercent: 18,
+            resetsAt: 'invalid-date',
+            windowDurationMins: 1440
+          }
+        }
+      }
+    })
+
+    expect(buckets).toEqual<RateLimitBucket[]>([{
+      limitId: 'gpt-5',
+      limitName: 'GPT-5',
+      primary: {
+        usedPercent: 72,
+        resetsAt: '2026-04-15T12:00:00.000Z',
+        windowDurationMins: 300
+      },
+      secondary: {
+        usedPercent: 50,
+        resetsAt: '2026-04-20T00:00:00.000Z',
+        windowDurationMins: 10080
+      }
+    }, {
+      limitId: 'gpt-5-mini',
+      limitName: 'GPT-5 Mini',
+      primary: {
+        usedPercent: 18,
+        resetsAt: null,
+        windowDurationMins: 1440
+      },
+      secondary: null
+    }])
+  })
+
+  it('formats rate limit window durations compactly', () => {
+    expect(formatRateLimitWindowDuration(300)).toBe('5h window')
+    expect(formatRateLimitWindowDuration(1440)).toBe('1d window')
+    expect(formatRateLimitWindowDuration(10080)).toBe('1w window')
+    expect(formatRateLimitWindowDuration(15)).toBe('15m window')
+    expect(formatRateLimitWindowDuration(null)).toBeNull()
   })
 
   it('builds turn input for text with image attachments', () => {

--- a/packages/client/test/usage-status-modal.test.ts
+++ b/packages/client/test/usage-status-modal.test.ts
@@ -1,10 +1,35 @@
 /* eslint-disable vue/one-component-per-file */
 // @vitest-environment jsdom
 
-import { mount } from '@vue/test-utils'
-import { defineComponent, h } from 'vue'
-import { describe, expect, it } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent, h, ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import UsageStatusModal from '../app/components/UsageStatusModal.vue'
+
+const mockRequest = vi.fn()
+const mockSubscribe = vi.fn()
+const mockRefreshProjects = vi.fn()
+const mockStartProject = vi.fn()
+const mockGetProject = vi.fn()
+const mockLoaded = ref(true)
+
+vi.mock('../app/composables/useRpc', () => ({
+  useRpc: () => ({
+    getClient: () => ({
+      request: mockRequest,
+      subscribe: mockSubscribe
+    })
+  })
+}))
+
+vi.mock('../app/composables/useProjects', () => ({
+  useProjects: () => ({
+    loaded: mockLoaded,
+    refreshProjects: mockRefreshProjects,
+    getProject: mockGetProject,
+    startProject: mockStartProject
+  })
+}))
 
 const ModalStub = defineComponent({
   name: 'ModalStub',
@@ -38,7 +63,10 @@ const AlertStub = defineComponent({
 
 const mountModal = (props: Record<string, unknown>) =>
   mount(UsageStatusModal, {
-    props,
+    props: {
+      projectId: 'codori',
+      ...props
+    },
     global: {
       stubs: {
         UModal: ModalStub,
@@ -48,58 +76,103 @@ const mountModal = (props: Record<string, unknown>) =>
   })
 
 describe('usage status modal', () => {
-  it('renders loading and empty states compactly', () => {
-    const loadingWrapper = mountModal({
-      open: true,
-      loading: true
-    })
+  beforeEach(() => {
+    mockLoaded.value = true
+    mockRequest.mockReset()
+    mockSubscribe.mockReset()
+    mockRefreshProjects.mockReset()
+    mockStartProject.mockReset()
+    mockGetProject.mockReset()
 
-    expect(loadingWrapper.text()).toContain('Loading current quota windows...')
-
-    const emptyWrapper = mountModal({
-      open: true,
-      loading: false,
-      buckets: []
-    })
-
-    expect(emptyWrapper.text()).toContain('No live quota windows were reported.')
+    mockSubscribe.mockReturnValue(vi.fn())
+    mockGetProject.mockReturnValue({ status: 'running' })
   })
 
-  it('renders stacked quota windows with reset timestamps', () => {
+  it('renders loading and empty states compactly', async () => {
+    let resolveRequest: (value: unknown) => void = () => {}
+    mockRequest.mockReturnValue(new Promise((resolve) => {
+      resolveRequest = resolve as (value: unknown) => void
+    }))
+
     const wrapper = mountModal({
-      open: true,
-      buckets: [{
-        limitId: 'gpt-5',
-        limitName: 'GPT-5',
-        primary: {
-          usedPercent: 72,
-          resetsAt: '2026-04-15T12:00:00.000Z',
-          windowDurationMins: 300
-        },
-        secondary: {
-          usedPercent: 45,
-          resetsAt: '2026-04-20T00:00:00.000Z',
-          windowDurationMins: 10080
-        }
-      }]
+      open: true
     })
+
+    expect(wrapper.text()).toContain('Loading current quota windows...')
+
+    resolveRequest([])
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No live quota windows were reported.')
+  })
+
+  it('renders stacked quota windows with reset timestamps', async () => {
+    mockRequest.mockResolvedValue([{
+      limitId: 'gpt-5',
+      limitName: 'GPT-5',
+      primary: {
+        usedPercent: 72,
+        resetsAt: '2026-04-15T12:00:00.000Z',
+        windowDurationMins: 300
+      },
+      secondary: {
+        usedPercent: 45,
+        resetsAt: '2026-04-20T00:00:00.000Z',
+        windowDurationMins: 10080
+      }
+    }])
+
+    const wrapper = mountModal({
+      open: true
+    })
+
+    await flushPromises()
 
     expect(wrapper.text()).toContain('GPT-5')
     expect(wrapper.text()).toContain('5h window')
     expect(wrapper.text()).toContain('1w window')
-    expect(wrapper.text()).toContain('72% used')
-    expect(wrapper.text()).toContain('45% used')
+    expect(wrapper.text()).toContain('28% remaining')
+    expect(wrapper.text()).toContain('55% remaining')
+    expect(wrapper.text()).toContain('Next reset')
     expect(wrapper.findAll('time').map(node => node.attributes('datetime'))).toEqual([
       '2026-04-15T12:00:00.000Z',
       '2026-04-20T00:00:00.000Z'
     ])
   })
 
-  it('renders server errors when quota loading fails', () => {
+  it('hides next reset rows when the API does not provide reset timestamps', async () => {
+    mockRequest.mockResolvedValue([{
+      limitId: 'codex',
+      limitName: 'codex',
+      primary: {
+        usedPercent: 9,
+        resetsAt: null,
+        windowDurationMins: 300
+      },
+      secondary: {
+        usedPercent: 23,
+        resetsAt: null,
+        windowDurationMins: 10080
+      }
+    }])
+
     const wrapper = mountModal({
-      open: true,
-      error: 'Failed to load rate limits.'
+      open: true
     })
+
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('Next reset')
+  })
+
+  it('renders server errors when quota loading fails', async () => {
+    mockRequest.mockRejectedValue(new Error('Failed to load rate limits.'))
+
+    const wrapper = mountModal({
+      open: true
+    })
+
+    await flushPromises()
 
     expect(wrapper.text()).toContain('Failed to load rate limits.')
   })

--- a/packages/client/test/usage-status-modal.test.ts
+++ b/packages/client/test/usage-status-modal.test.ts
@@ -1,0 +1,106 @@
+/* eslint-disable vue/one-component-per-file */
+// @vitest-environment jsdom
+
+import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { describe, expect, it } from 'vitest'
+import UsageStatusModal from '../app/components/UsageStatusModal.vue'
+
+const ModalStub = defineComponent({
+  name: 'ModalStub',
+  props: {
+    open: {
+      type: Boolean,
+      default: false
+    }
+  },
+  setup(props, { slots }) {
+    return () => props.open
+      ? h('div', { class: 'modal-stub' }, [
+          h('div', { class: 'modal-body' }, slots.body?.())
+        ])
+      : null
+  }
+})
+
+const AlertStub = defineComponent({
+  name: 'AlertStub',
+  props: {
+    title: {
+      type: String,
+      default: ''
+    }
+  },
+  setup(props) {
+    return () => h('div', { class: 'alert-stub' }, props.title)
+  }
+})
+
+const mountModal = (props: Record<string, unknown>) =>
+  mount(UsageStatusModal, {
+    props,
+    global: {
+      stubs: {
+        UModal: ModalStub,
+        UAlert: AlertStub
+      }
+    }
+  })
+
+describe('usage status modal', () => {
+  it('renders loading and empty states compactly', () => {
+    const loadingWrapper = mountModal({
+      open: true,
+      loading: true
+    })
+
+    expect(loadingWrapper.text()).toContain('Loading current quota windows...')
+
+    const emptyWrapper = mountModal({
+      open: true,
+      loading: false,
+      buckets: []
+    })
+
+    expect(emptyWrapper.text()).toContain('No live quota windows were reported.')
+  })
+
+  it('renders stacked quota windows with reset timestamps', () => {
+    const wrapper = mountModal({
+      open: true,
+      buckets: [{
+        limitId: 'gpt-5',
+        limitName: 'GPT-5',
+        primary: {
+          usedPercent: 72,
+          resetsAt: '2026-04-15T12:00:00.000Z',
+          windowDurationMins: 300
+        },
+        secondary: {
+          usedPercent: 45,
+          resetsAt: '2026-04-20T00:00:00.000Z',
+          windowDurationMins: 10080
+        }
+      }]
+    })
+
+    expect(wrapper.text()).toContain('GPT-5')
+    expect(wrapper.text()).toContain('5h window')
+    expect(wrapper.text()).toContain('1w window')
+    expect(wrapper.text()).toContain('72% used')
+    expect(wrapper.text()).toContain('45% used')
+    expect(wrapper.findAll('time').map(node => node.attributes('datetime'))).toEqual([
+      '2026-04-15T12:00:00.000Z',
+      '2026-04-20T00:00:00.000Z'
+    ])
+  })
+
+  it('renders server errors when quota loading fails', () => {
+    const wrapper = mountModal({
+      open: true,
+      error: 'Failed to load rate limits.'
+    })
+
+    expect(wrapper.text()).toContain('Failed to load rate limits.')
+  })
+})


### PR DESCRIPTION
## Summary
- add `/usage` and `/status` slash commands with a usage status modal
- move usage-status loading/subscription logic into the modal and show remaining quota with optional next reset
- keep slash command focus anchored in the chat prompt and clear consumed slash drafts after execution
- address review feedback by removing unused modal types and merging duplicate rate-limit windows with newer values

## Why
- expose quota status directly from chat without starting a normal message flow
- avoid slash-command focus regressions and stale `/usage` or `/review` text left in the composer
- keep the modal closer to Nuxt UI defaults so later styling stays consistent
- prefer fresher rate-limit data when the same bucket appears in multiple payload sections

## Testing
- pnpm --filter @codori/client test
- pnpm --filter @codori/client typecheck
- pnpm build
- verified slash command behavior and usage modal flow on localhost:4310

Closes #32