### PR TITLE
Add local file viewer and file-handle autocomplete

### DIFF
--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -8,6 +8,7 @@ import {
   ref,
   watch
 } from 'vue'
+import LocalFileViewerModal from './LocalFileViewerModal.vue'
 import MessageContent from './MessageContent.vue'
 import ReviewStartDrawer from './ReviewStartDrawer.vue'
 import PendingUserRequestDrawer from './PendingUserRequestDrawer.vue'
@@ -2957,6 +2958,8 @@ watch(input, async () => {
     :request="pendingRequest"
     @respond="respondToPendingRequest"
   />
+
+  <LocalFileViewerModal />
 
   <ReviewStartDrawer
     :open="reviewDrawerOpen"

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -102,11 +102,13 @@ import {
   type SlashCommandDefinition
 } from '~~/shared/slash-commands'
 import {
+  buildFileAutocompletePathSegments,
   findActiveFileAutocompleteMatch,
   normalizeFileAutocompleteQuery,
   normalizeFuzzyFileSearchMatches,
   replaceActiveFileAutocompleteMatch,
   toFileAutocompleteHandle,
+  type FileAutocompletePathSegment,
   type NormalizedFuzzyFileSearchMatch
 } from '~~/shared/file-autocomplete'
 
@@ -154,6 +156,7 @@ const chatPromptRef = ref<{
 } | null>(null)
 const slashDropdownRef = ref<HTMLElement | null>(null)
 const fileAutocompleteDropdownRef = ref<HTMLElement | null>(null)
+const fileAutocompleteListRef = ref<HTMLElement | null>(null)
 const scrollViewport = ref<HTMLElement | null>(null)
 const pinnedToBottom = ref(true)
 const session = useChatSession(props.projectId)
@@ -934,6 +937,11 @@ const completeSlashCommand = async (command: SlashCommandDefinition) => {
 const resolveFileAutocompleteIcon = (match: Pick<NormalizedFuzzyFileSearchMatch, 'matchType'>) =>
   match.matchType === 'directory' ? 'i-lucide-folder-open' : 'i-lucide-file-code-2'
 
+const renderFileAutocompletePathSegments = (
+  match: Pick<NormalizedFuzzyFileSearchMatch, 'path' | 'indices'>
+): FileAutocompletePathSegment[] =>
+  buildFileAutocompletePathSegments(match)
+
 const selectFileAutocompleteResult = async (match: NormalizedFuzzyFileSearchMatch) => {
   const activeMatch = activeFileAutocompleteMatch.value
   if (!activeMatch) {
@@ -947,6 +955,17 @@ const selectFileAutocompleteResult = async (match: NormalizedFuzzyFileSearchMatc
   input.value = nextDraft.value
   fileAutocompleteResults.value = []
   await focusPromptAt(nextDraft.caret)
+}
+
+const syncFileAutocompleteScroll = async () => {
+  await nextTick()
+
+  const selected = fileAutocompleteListRef.value?.querySelector<HTMLElement>(
+    '[data-file-autocomplete-option][aria-selected="true"]'
+  )
+  selected?.scrollIntoView({
+    block: 'nearest'
+  })
 }
 
 const fetchProjectGitBranches = async () => {
@@ -2369,6 +2388,19 @@ const applyNotification = (notification: CodexRpcNotification) => {
 }
 
 const sendMessage = async () => {
+  // Nuxt UI's UChatPrompt emits `submit` directly from its internal
+  // `keydown.enter.exact` handler, so guarding only in our keydown callback is
+  // not sufficient to stop Enter from racing into a send while the file palette
+  // is open. Keep the submit path itself aware of the palette state.
+  if (fileAutocompleteOpen.value) {
+    const match = highlightedFileAutocompleteResult.value
+    if (match) {
+      await selectFileAutocompleteResult(match)
+    }
+
+    return
+  }
+
   if (sendMessageLocked.value || hasPendingRequest.value) {
     return
   }
@@ -2745,6 +2777,18 @@ watch(visibleFileAutocompleteResults, (results) => {
   }
 }, { flush: 'sync' })
 
+watch(
+  [fileAutocompleteOpen, fileAutocompleteHighlightIndex, visibleFileAutocompleteResults],
+  async ([open, highlightIndex, results]) => {
+    if (!open || !results.length || highlightIndex >= results.length) {
+      return
+    }
+
+    await syncFileAutocompleteScroll()
+  },
+  { flush: 'post' }
+)
+
 watch([selectedModel, availableModels], () => {
   const nextSelection = coercePromptSelection(effectiveModelList.value, selectedModel.value, selectedEffort.value)
   if (selectedModel.value !== nextSelection.model) {
@@ -2948,7 +2992,10 @@ watch(
             class="absolute bottom-full left-0 z-20 mb-2 w-[90vw] max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-default bg-default/95 shadow-2xl backdrop-blur md:w-[min(50vw,52rem)] md:max-w-[min(50vw,52rem)]"
             @pointerdown="handleFileAutocompletePointerDown"
           >
-            <div class="max-h-72 overflow-y-auto p-2">
+            <div
+              ref="fileAutocompleteListRef"
+              class="max-h-72 overflow-y-auto p-2"
+            >
               <div
                 v-if="fileAutocompleteEmptyState"
                 class="px-3 py-2 text-sm leading-6 text-muted"
@@ -2962,7 +3009,7 @@ watch(
                 role="option"
                 :aria-selected="index === fileAutocompleteHighlightIndex"
                 data-file-autocomplete-option=""
-                class="group relative flex cursor-pointer items-start gap-1.5 px-3 py-2.5 text-sm text-highlighted outline-none transition-colors before:absolute before:inset-px before:z-[-1] before:rounded-md"
+                class="group relative flex cursor-pointer items-center gap-1.5 px-3 py-2 text-sm text-highlighted outline-none transition-colors before:absolute before:inset-px before:z-[-1] before:rounded-md"
                 :class="index === fileAutocompleteHighlightIndex
                   ? 'before:bg-elevated'
                   : 'hover:before:bg-elevated/60'"
@@ -2970,15 +3017,17 @@ watch(
               >
                 <UIcon
                   :name="resolveFileAutocompleteIcon(match)"
-                  class="mt-0.5 size-4 shrink-0 text-dimmed group-aria-selected:text-highlighted"
+                  class="size-4 shrink-0 text-dimmed group-aria-selected:text-highlighted"
                 />
-                <div class="min-w-0">
-                  <div class="truncate text-sm font-medium">
-                    {{ match.fileName }}
-                  </div>
-                  <div class="truncate text-xs leading-5 text-toned">
-                    /{{ match.path }}
-                  </div>
+                <div class="min-w-0 truncate font-mono text-[13px] leading-6">
+                  <span
+                    v-for="(segment, segmentIndex) in renderFileAutocompletePathSegments(match)"
+                    :key="`${match.path}:${segmentIndex}:${segment.isMatch ? 'match' : 'plain'}`"
+                    class="truncate"
+                    :class="segment.isMatch ? 'font-semibold text-primary' : 'text-toned'"
+                  >
+                    {{ segment.text }}
+                  </span>
                 </div>
               </div>
             </div>

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -833,6 +833,24 @@ const handleFileAutocompletePointerDown = (event: PointerEvent) => {
   void focusPromptAt(promptSelectionStart.value)
 }
 
+const onPromptEnterCapture = (event: KeyboardEvent) => {
+  if (!fileAutocompleteOpen.value) {
+    return
+  }
+
+  // UChatPrompt wires its own `keydown.enter.exact` handler on the textarea and
+  // emits `submit` immediately. Intercept exact Enter in capture phase so file
+  // palette selection never falls through to the component's submit path.
+  event.preventDefault()
+  event.stopPropagation()
+  event.stopImmediatePropagation()
+
+  const match = highlightedFileAutocompleteResult.value
+  if (match) {
+    void selectFileAutocompleteResult(match)
+  }
+}
+
 const setComposerError = (messageText: string) => {
   markAwaitingAssistantOutput(false)
   error.value = messageText
@@ -3082,6 +3100,7 @@ watch(
             :disabled="isComposerDisabled"
             autoresize
             @submit.prevent="sendMessage"
+            @keydown.enter.exact.capture="onPromptEnterCapture"
             @keydown="onPromptKeydown"
             @keydown.enter="onPromptEnter"
             @input="syncPromptSelectionFromDom"

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -106,7 +106,7 @@ import {
   normalizeFileAutocompleteQuery,
   normalizeFuzzyFileSearchMatches,
   replaceActiveFileAutocompleteMatch,
-  toFileAutocompleteInsertion,
+  toFileAutocompleteHandle,
   type NormalizedFuzzyFileSearchMatch
 } from '~~/shared/file-autocomplete'
 
@@ -301,7 +301,9 @@ const fileAutocompleteOpen = computed(() =>
 )
 
 const visibleFileAutocompleteResults = computed(() =>
-  fileAutocompleteResults.value.slice(0, 8)
+  fileAutocompleteResults.value
+    .filter((match) => match.matchType === 'file')
+    .slice(0, 8)
 )
 
 const highlightedFileAutocompleteResult = computed(() =>
@@ -940,7 +942,7 @@ const selectFileAutocompleteResult = async (match: NormalizedFuzzyFileSearchMatc
 
   dismissedFileAutocompleteMatchKey.value = null
   fileAutocompleteError.value = null
-  const replacement = toFileAutocompleteInsertion(match)
+  const replacement = toFileAutocompleteHandle(match)
   const nextDraft = replaceActiveFileAutocompleteMatch(input.value, activeMatch, replacement)
   input.value = nextDraft.value
   fileAutocompleteResults.value = []
@@ -2628,12 +2630,13 @@ const onPromptEnter = (event: KeyboardEvent) => {
   }
 
   if (fileAutocompleteOpen.value) {
+    event.preventDefault()
     const match = highlightedFileAutocompleteResult.value
     if (match) {
-      event.preventDefault()
       void selectFileAutocompleteResult(match)
-      return
     }
+
+    return
   }
 
   if (slashDropdownOpen.value) {

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -101,6 +101,14 @@ import {
   toSlashCommandCompletion,
   type SlashCommandDefinition
 } from '~~/shared/slash-commands'
+import {
+  findActiveFileAutocompleteMatch,
+  normalizeFileAutocompleteQuery,
+  normalizeFuzzyFileSearchMatches,
+  replaceActiveFileAutocompleteMatch,
+  toFileAutocompleteInsertion,
+  type NormalizedFuzzyFileSearchMatch
+} from '~~/shared/file-autocomplete'
 
 const props = defineProps<{
   projectId: string
@@ -145,6 +153,7 @@ const chatPromptRef = ref<{
   textareaRef?: unknown
 } | null>(null)
 const slashDropdownRef = ref<HTMLElement | null>(null)
+const fileAutocompleteDropdownRef = ref<HTMLElement | null>(null)
 const scrollViewport = ref<HTMLElement | null>(null)
 const pinnedToBottom = ref(true)
 const session = useChatSession(props.projectId)
@@ -186,7 +195,12 @@ const promptSelectionStart = ref(0)
 const promptSelectionEnd = ref(0)
 const isPromptFocused = ref(false)
 const dismissedSlashMatchKey = ref<string | null>(null)
+const dismissedFileAutocompleteMatchKey = ref<string | null>(null)
 const slashHighlightIndex = ref(0)
+const fileAutocompleteHighlightIndex = ref(0)
+const fileAutocompleteLoading = ref(false)
+const fileAutocompleteError = ref<string | null>(null)
+const fileAutocompleteResults = ref<NormalizedFuzzyFileSearchMatch[]>([])
 const reviewDrawerOpen = ref(false)
 const reviewDrawerMode = ref<'target' | 'branch'>('target')
 const reviewDrawerCommandText = ref('/review')
@@ -259,8 +273,46 @@ const filteredSlashCommands = computed(() =>
     : []
 )
 
+const activeFileAutocompleteMatch = computed(() =>
+  isPromptFocused.value
+    ? findActiveFileAutocompleteMatch(input.value, promptSelectionStart.value, promptSelectionEnd.value)
+    : null
+)
+
+const activeFileAutocompleteMatchKey = computed(() => {
+  const match = activeFileAutocompleteMatch.value
+  if (!match) {
+    return null
+  }
+
+  return `${match.start}:${match.end}:${match.raw}`
+})
+
+const normalizedFileAutocompleteQuery = computed(() =>
+  activeFileAutocompleteMatch.value
+    ? normalizeFileAutocompleteQuery(activeFileAutocompleteMatch.value.query)
+    : ''
+)
+
+const fileAutocompleteOpen = computed(() =>
+  !reviewDrawerOpen.value
+  && Boolean(activeFileAutocompleteMatch.value)
+  && activeFileAutocompleteMatchKey.value !== dismissedFileAutocompleteMatchKey.value
+)
+
+const visibleFileAutocompleteResults = computed(() =>
+  fileAutocompleteResults.value.slice(0, 8)
+)
+
+const highlightedFileAutocompleteResult = computed(() =>
+  visibleFileAutocompleteResults.value[fileAutocompleteHighlightIndex.value]
+  ?? visibleFileAutocompleteResults.value[0]
+  ?? null
+)
+
 const slashDropdownOpen = computed(() =>
   !reviewDrawerOpen.value
+  && !fileAutocompleteOpen.value
   && Boolean(activeSlashMatch.value)
   && activeSlashMatchKey.value !== dismissedSlashMatchKey.value
   && filteredSlashCommands.value.length > 0
@@ -327,6 +379,34 @@ const contextUsedPercent = computed(() => contextWindowState.value.usedPercent ?
 const contextIndicatorLabel = computed(() => {
   const remainingPercent = contextWindowState.value.remainingPercent
   return remainingPercent == null ? 'ctx' : `${Math.round(remainingPercent)}%`
+})
+
+const fileAutocompleteEmptyState = computed(() => {
+  if (!fileAutocompleteOpen.value) {
+    return null
+  }
+
+  if (!selectedProject.value?.projectPath) {
+    return 'Project runtime is not ready yet.'
+  }
+
+  if (!normalizedFileAutocompleteQuery.value) {
+    return 'Type a path or filename to search project files.'
+  }
+
+  if (fileAutocompleteLoading.value) {
+    return 'Searching project files...'
+  }
+
+  if (fileAutocompleteError.value) {
+    return fileAutocompleteError.value
+  }
+
+  if (visibleFileAutocompleteResults.value.length === 0) {
+    return 'No matching project files.'
+  }
+
+  return null
 })
 
 const normalizePromptSelection = (
@@ -423,6 +503,7 @@ const optimisticAttachmentSnapshots = new Map<string, DraftAttachment[]>()
 let promptControlsPromise: Promise<void> | null = null
 let pendingThreadHydration: Promise<void> | null = null
 let releaseServerRequestHandler: (() => void) | null = null
+let fileAutocompleteRequestSequence = 0
 
 const isActiveTurnStatus = (value: string | null | undefined) => {
   if (!value) {
@@ -694,6 +775,10 @@ const syncPromptSelectionFromDom = () => {
   if (!activeSlashMatchKey.value || activeSlashMatchKey.value !== dismissedSlashMatchKey.value) {
     dismissedSlashMatchKey.value = null
   }
+
+  if (!activeFileAutocompleteMatchKey.value || activeFileAutocompleteMatchKey.value !== dismissedFileAutocompleteMatchKey.value) {
+    dismissedFileAutocompleteMatchKey.value = null
+  }
 }
 
 const focusPromptAt = async (position?: number) => {
@@ -713,12 +798,12 @@ const focusPromptAt = async (position?: number) => {
 
 const shouldRetainPromptFocus = (nextFocused: EventTarget | null | undefined) =>
   isFocusWithinContainer(nextFocused, slashDropdownRef.value)
+  || isFocusWithinContainer(nextFocused, fileAutocompleteDropdownRef.value)
 
 const handlePromptBlur = (event: FocusEvent) => {
-  // Slash suggestions must stay focusless. If focus ever moves into the popup,
-  // the composer stops matching slash commands and the menu collapses while the
-  // textarea still contains `/`. Keep this blur guard aligned with the inert
-  // popup template below.
+  // Composer suggestion popups must stay focusless. If focus ever moves into
+  // the overlay, the textarea selection state no longer matches the active
+  // token and the menu collapses while the draft still contains `/` or `@`.
   if (shouldRetainPromptFocus(event.relatedTarget)) {
     void focusPromptAt(promptSelectionStart.value)
     return
@@ -731,6 +816,14 @@ const handleSlashDropdownPointerDown = (event: PointerEvent) => {
   // Fundamental rule for slash commands: the popup is only a visual chooser.
   // Selection happens through the textarea's keyboard handlers, and mouse/touch
   // clicks must not transfer DOM focus into popup items.
+  event.preventDefault()
+  void focusPromptAt(promptSelectionStart.value)
+}
+
+const handleFileAutocompletePointerDown = (event: PointerEvent) => {
+  // File suggestions follow the same inert-overlay rule as slash commands.
+  // Keeping focus anchored in the textarea avoids collapsing the popup while
+  // the active `@token` is still being edited.
   event.preventDefault()
   void focusPromptAt(promptSelectionStart.value)
 }
@@ -791,6 +884,27 @@ const moveSlashHighlight = (delta: number) => {
   slashHighlightIndex.value = nextIndex
 }
 
+const moveFileAutocompleteHighlight = (delta: number) => {
+  if (!visibleFileAutocompleteResults.value.length) {
+    fileAutocompleteHighlightIndex.value = 0
+    return
+  }
+
+  const maxIndex = visibleFileAutocompleteResults.value.length - 1
+  const nextIndex = fileAutocompleteHighlightIndex.value + delta
+  if (nextIndex < 0) {
+    fileAutocompleteHighlightIndex.value = maxIndex
+    return
+  }
+
+  if (nextIndex > maxIndex) {
+    fileAutocompleteHighlightIndex.value = 0
+    return
+  }
+
+  fileAutocompleteHighlightIndex.value = nextIndex
+}
+
 const resolveSlashCommandIcon = (command: SlashCommandDefinition) => {
   if (command.name === 'review') {
     return 'i-lucide-search-check'
@@ -813,6 +927,24 @@ const completeSlashCommand = async (command: SlashCommandDefinition) => {
   const completion = toSlashCommandCompletion(command)
   input.value = `${input.value.slice(0, match.start)}${completion}${input.value.slice(match.end)}`
   await focusPromptAt(match.start + completion.length)
+}
+
+const resolveFileAutocompleteIcon = (match: Pick<NormalizedFuzzyFileSearchMatch, 'matchType'>) =>
+  match.matchType === 'directory' ? 'i-lucide-folder-open' : 'i-lucide-file-code-2'
+
+const selectFileAutocompleteResult = async (match: NormalizedFuzzyFileSearchMatch) => {
+  const activeMatch = activeFileAutocompleteMatch.value
+  if (!activeMatch) {
+    return
+  }
+
+  dismissedFileAutocompleteMatchKey.value = null
+  fileAutocompleteError.value = null
+  const replacement = toFileAutocompleteInsertion(match)
+  const nextDraft = replaceActiveFileAutocompleteMatch(input.value, activeMatch, replacement)
+  input.value = nextDraft.value
+  fileAutocompleteResults.value = []
+  await focusPromptAt(nextDraft.caret)
 }
 
 const fetchProjectGitBranches = async () => {
@@ -2414,6 +2546,47 @@ const respondToPendingRequest = (response: unknown) => {
 }
 
 const onPromptKeydown = (event: KeyboardEvent) => {
+  if (fileAutocompleteOpen.value) {
+    if (event.key === 'ArrowDown') {
+      if (visibleFileAutocompleteResults.value.length === 0) {
+        return
+      }
+
+      event.preventDefault()
+      moveFileAutocompleteHighlight(1)
+      return
+    }
+
+    if (event.key === 'ArrowUp') {
+      if (visibleFileAutocompleteResults.value.length === 0) {
+        return
+      }
+
+      event.preventDefault()
+      moveFileAutocompleteHighlight(-1)
+      return
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      dismissedFileAutocompleteMatchKey.value = activeFileAutocompleteMatchKey.value
+      isPromptFocused.value = true
+      void focusPromptAt(promptSelectionStart.value)
+      return
+    }
+
+    if (event.key === 'Tab') {
+      const match = highlightedFileAutocompleteResult.value
+      if (!match) {
+        return
+      }
+
+      event.preventDefault()
+      void selectFileAutocompleteResult(match)
+      return
+    }
+  }
+
   if (!slashDropdownOpen.value) {
     return
   }
@@ -2452,6 +2625,15 @@ const onPromptKeydown = (event: KeyboardEvent) => {
 const onPromptEnter = (event: KeyboardEvent) => {
   if (!shouldSubmit(event)) {
     return
+  }
+
+  if (fileAutocompleteOpen.value) {
+    const match = highlightedFileAutocompleteResult.value
+    if (match) {
+      event.preventDefault()
+      void selectFileAutocompleteResult(match)
+      return
+    }
   }
 
   if (slashDropdownOpen.value) {
@@ -2549,6 +2731,17 @@ watch(filteredSlashCommands, (commands) => {
   }
 }, { flush: 'sync' })
 
+watch(visibleFileAutocompleteResults, (results) => {
+  if (!results.length) {
+    fileAutocompleteHighlightIndex.value = 0
+    return
+  }
+
+  if (fileAutocompleteHighlightIndex.value >= results.length) {
+    fileAutocompleteHighlightIndex.value = 0
+  }
+}, { flush: 'sync' })
+
 watch([selectedModel, availableModels], () => {
   const nextSelection = coercePromptSelection(effectiveModelList.value, selectedModel.value, selectedEffort.value)
   if (selectedModel.value !== nextSelection.model) {
@@ -2565,6 +2758,65 @@ watch(input, async () => {
   await nextTick()
   syncPromptSelectionFromDom()
 }, { flush: 'post' })
+
+watch(
+  [fileAutocompleteOpen, normalizedFileAutocompleteQuery, () => selectedProject.value?.projectPath ?? null],
+  async ([open, query, projectPath]) => {
+    const requestSequence = ++fileAutocompleteRequestSequence
+
+    if (!open) {
+      fileAutocompleteLoading.value = false
+      fileAutocompleteError.value = null
+      fileAutocompleteResults.value = []
+      return
+    }
+
+    if (!projectPath) {
+      fileAutocompleteLoading.value = false
+      fileAutocompleteResults.value = []
+      return
+    }
+
+    fileAutocompleteError.value = null
+    if (!query) {
+      fileAutocompleteLoading.value = false
+      fileAutocompleteResults.value = []
+      return
+    }
+
+    fileAutocompleteLoading.value = true
+    fileAutocompleteResults.value = []
+
+    try {
+      await ensureProjectRuntime()
+      const response = await getClient(props.projectId).request('fuzzyFileSearch', {
+        query,
+        roots: [projectPath],
+        cancellationToken: `chat-file-autocomplete:${props.projectId}`
+      })
+
+      if (requestSequence !== fileAutocompleteRequestSequence) {
+        return
+      }
+
+      fileAutocompleteResults.value = normalizeFuzzyFileSearchMatches(response)
+    } catch (caughtError) {
+      if (requestSequence !== fileAutocompleteRequestSequence) {
+        return
+      }
+
+      fileAutocompleteResults.value = []
+      fileAutocompleteError.value = caughtError instanceof Error
+        ? caughtError.message
+        : 'Failed to search project files.'
+    } finally {
+      if (requestSequence === fileAutocompleteRequestSequence) {
+        fileAutocompleteLoading.value = false
+      }
+    }
+  },
+  { flush: 'post' }
+)
 </script>
 
 <template>
@@ -2683,6 +2935,50 @@ watch(input, async () => {
             class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-3xl border border-dashed border-primary/50 bg-primary/10 text-sm font-medium text-primary backdrop-blur-sm"
           >
             Drop images to attach them
+          </div>
+
+          <div
+            v-if="fileAutocompleteOpen"
+            ref="fileAutocompleteDropdownRef"
+            role="listbox"
+            aria-label="Project files"
+            class="absolute bottom-full left-0 z-20 mb-2 w-[90vw] max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-default bg-default/95 shadow-2xl backdrop-blur md:w-[min(50vw,52rem)] md:max-w-[min(50vw,52rem)]"
+            @pointerdown="handleFileAutocompletePointerDown"
+          >
+            <div class="max-h-72 overflow-y-auto p-2">
+              <div
+                v-if="fileAutocompleteEmptyState"
+                class="px-3 py-2 text-sm leading-6 text-muted"
+              >
+                {{ fileAutocompleteEmptyState }}
+              </div>
+              <div
+                v-for="(match, index) in visibleFileAutocompleteResults"
+                v-else
+                :key="`${match.matchType}:${match.path}`"
+                role="option"
+                :aria-selected="index === fileAutocompleteHighlightIndex"
+                data-file-autocomplete-option=""
+                class="group relative flex cursor-pointer items-start gap-1.5 px-3 py-2.5 text-sm text-highlighted outline-none transition-colors before:absolute before:inset-px before:z-[-1] before:rounded-md"
+                :class="index === fileAutocompleteHighlightIndex
+                  ? 'before:bg-elevated'
+                  : 'hover:before:bg-elevated/60'"
+                @click="void selectFileAutocompleteResult(match)"
+              >
+                <UIcon
+                  :name="resolveFileAutocompleteIcon(match)"
+                  class="mt-0.5 size-4 shrink-0 text-dimmed group-aria-selected:text-highlighted"
+                />
+                <div class="min-w-0">
+                  <div class="truncate text-sm font-medium">
+                    {{ match.fileName }}
+                  </div>
+                  <div class="truncate text-xs leading-5 text-toned">
+                    /{{ match.path }}
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
 
           <div

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -2838,6 +2838,7 @@ watch(
 
     if (!projectPath) {
       fileAutocompleteLoading.value = false
+      fileAutocompleteError.value = null
       fileAutocompleteResults.value = []
       return
     }

--- a/packages/client/app/components/LocalFileViewerModal.vue
+++ b/packages/client/app/components/LocalFileViewerModal.vue
@@ -1,8 +1,15 @@
 <script setup lang="ts">
+import { Comark } from '@comark/vue'
+import highlight from '@comark/vue/plugins/highlight'
 import { computed, nextTick, ref, watch } from 'vue'
 import { useRuntimeConfig } from '#imports'
 import { useLocalFileViewer } from '../composables/useLocalFileViewer'
 import { formatLocalFileSize, resolveProjectLocalFileUrl, type ProjectLocalFileResponse } from '../../shared/local-files'
+import {
+  buildHighlightedFileMarkdown,
+  inferLocalFileLanguage,
+  resolveLocalFileLanguageLabel
+} from '../../shared/file-highlighting'
 
 const runtimeConfig = useRuntimeConfig()
 const { state, closeViewer } = useLocalFileViewer()
@@ -11,6 +18,9 @@ const loading = ref(false)
 const error = ref<string | null>(null)
 const file = ref<ProjectLocalFileResponse['file'] | null>(null)
 const lineContainer = ref<HTMLElement | null>(null)
+const viewerPlugins = [
+  highlight({ preStyles: false })
+]
 
 const isOpen = computed({
   get: () => state.value.open,
@@ -37,17 +47,25 @@ const lineCount = computed(() => {
   return file.value.text.split('\n').length
 })
 
-const lineRows = computed(() => {
+const inferredLanguage = computed(() =>
+  file.value ? inferLocalFileLanguage(file.value.path, file.value.text) : null
+)
+
+const languageLabel = computed(() =>
+  resolveLocalFileLanguageLabel(inferredLanguage.value)
+)
+
+const highlightedMarkdown = computed(() => {
   if (!file.value) {
-    return []
+    return ''
   }
 
-  const lines = file.value.text.split('\n')
-  return lines.map((line, index) => ({
-    number: index + 1,
-    text: line
-  }))
+  return buildHighlightedFileMarkdown(file.value.text, inferredLanguage.value)
 })
+
+const lineNumberWidth = computed(() =>
+  `${Math.max(3, String(lineCount.value || 1).length + 1)}ch`
+)
 
 const updatedAtLabel = computed(() => {
   if (!file.value) {
@@ -62,16 +80,29 @@ const updatedAtLabel = computed(() => {
   }).format(new Date(file.value.updatedAt))
 })
 
-const scrollToRequestedLine = async () => {
-  const targetLine = state.value.line
-  if (!targetLine || !lineContainer.value) {
+const syncRenderedCodeLines = async () => {
+  if (!lineContainer.value) {
     return
   }
 
   await nextTick()
-  const target = lineContainer.value.querySelector<HTMLElement>(`[data-file-line="${targetLine}"]`)
-  target?.scrollIntoView({
-    block: 'center'
+  requestAnimationFrame(() => {
+    const renderedLines = Array.from(lineContainer.value?.querySelectorAll<HTMLElement>('.line') ?? [])
+    for (const [index, line] of renderedLines.entries()) {
+      const lineNumber = index + 1
+      line.dataset.fileLine = String(lineNumber)
+      line.classList.toggle('is-target-line', state.value.line === lineNumber)
+    }
+
+    const targetLine = state.value.line
+    if (!targetLine) {
+      return
+    }
+
+    const target = lineContainer.value?.querySelector<HTMLElement>(`[data-file-line="${targetLine}"]`)
+    target?.scrollIntoView({
+      block: 'center'
+    })
   })
 }
 
@@ -100,7 +131,7 @@ watch(
       }
 
       file.value = response.file
-      await scrollToRequestedLine()
+      await syncRenderedCodeLines()
     } catch (caughtError) {
       if (!state.value.open || state.value.projectId !== projectId || state.value.path !== path) {
         return
@@ -118,9 +149,15 @@ watch(
 
 watch(() => state.value.line, () => {
   if (file.value) {
-    void scrollToRequestedLine()
+    void syncRenderedCodeLines()
   }
 })
+
+watch(highlightedMarkdown, () => {
+  if (file.value) {
+    void syncRenderedCodeLines()
+  }
+}, { flush: 'post' })
 </script>
 
 <template>
@@ -146,7 +183,9 @@ watch(() => state.value.line, () => {
             </div>
             <div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted">
               <span v-if="file">{{ formatLocalFileSize(file.size) }}</span>
+              <span v-if="file">{{ lineCount }} lines</span>
               <span v-if="updatedAtLabel">{{ updatedAtLabel }}</span>
+              <span v-if="languageLabel">{{ languageLabel }}</span>
               <span v-if="state.line">Line {{ state.line }}</span>
             </div>
           </div>
@@ -184,30 +223,92 @@ watch(() => state.value.line, () => {
         <div
           v-else-if="file"
           ref="lineContainer"
-          class="min-h-0 flex-1 overflow-auto bg-elevated/20"
+          class="local-file-viewer-code min-h-0 flex-1 overflow-auto bg-elevated/15"
+          :style="{ '--lfv-line-number-width': lineNumberWidth }"
         >
-          <div class="min-w-max px-4 py-4 sm:px-6">
-            <div class="overflow-hidden rounded-2xl border border-default bg-default/85 shadow-sm">
-              <div class="flex items-center justify-between border-b border-default px-4 py-2 text-xs text-muted">
-                <span>{{ file.path }}</span>
-                <span>{{ lineCount }} lines</span>
-              </div>
-              <div class="overflow-x-auto font-mono text-[13px] leading-6 text-highlighted">
-                <div
-                  v-for="row in lineRows"
-                  :key="row.number"
-                  :data-file-line="row.number"
-                  class="grid grid-cols-[auto,1fr] gap-4 px-4"
-                  :class="state.line === row.number ? 'bg-primary/10' : ''"
-                >
-                  <span class="select-none py-0.5 text-right tabular-nums text-muted">{{ row.number }}</span>
-                  <span class="min-w-0 whitespace-pre-wrap break-all py-0.5">{{ row.text || ' ' }}</span>
-                </div>
-              </div>
-            </div>
-          </div>
+          <Suspense>
+            <Comark
+              class="local-file-viewer-markdown"
+              :markdown="highlightedMarkdown"
+              :plugins="viewerPlugins"
+            />
+          </Suspense>
         </div>
       </section>
     </template>
   </UModal>
 </template>
+
+<style scoped>
+.local-file-viewer-code :deep(.local-file-viewer-markdown) {
+  min-width: max-content;
+}
+
+.local-file-viewer-code :deep(.local-file-viewer-markdown > * + *) {
+  margin-top: 0;
+}
+
+.local-file-viewer-code :deep(pre),
+.local-file-viewer-code :deep(.shiki) {
+  margin: 0;
+  min-width: max-content;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+  background: transparent !important;
+}
+
+.local-file-viewer-code :deep(pre code),
+.local-file-viewer-code :deep(.shiki code) {
+  display: block;
+  min-width: max-content;
+  padding: 0;
+}
+
+.local-file-viewer-code :deep(.line) {
+  display: block;
+  min-width: max-content;
+  padding: 0 1.5rem 0 0;
+  padding-left: calc(var(--lfv-line-number-width) + 1.5rem);
+  position: relative;
+  white-space: pre;
+}
+
+.local-file-viewer-code :deep(.line::before) {
+  content: attr(data-file-line);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: var(--lfv-line-number-width);
+  padding-right: 0.75rem;
+  text-align: right;
+  color: var(--ui-text-muted);
+  user-select: none;
+  font-variant-numeric: tabular-nums;
+}
+
+.local-file-viewer-code :deep(.line.is-target-line) {
+  background: color-mix(in srgb, var(--ui-primary) 10%, transparent);
+}
+
+.local-file-viewer-code :deep(.line.is-target-line::before) {
+  color: var(--ui-primary);
+}
+
+.local-file-viewer-code :deep(.shiki),
+.local-file-viewer-code :deep(.shiki code),
+.local-file-viewer-code :deep(pre),
+.local-file-viewer-code :deep(pre code) {
+  font-size: 13px;
+  line-height: 1.75;
+}
+
+:global(.dark) .local-file-viewer-code :deep(.shiki),
+:global(.dark) .local-file-viewer-code :deep(.shiki span) {
+  color: var(--shiki-dark) !important;
+  background-color: var(--shiki-dark-bg) !important;
+  font-style: var(--shiki-dark-font-style) !important;
+  font-weight: var(--shiki-dark-font-weight) !important;
+  text-decoration: var(--shiki-dark-text-decoration) !important;
+}
+</style>

--- a/packages/client/app/components/LocalFileViewerModal.vue
+++ b/packages/client/app/components/LocalFileViewerModal.vue
@@ -1,0 +1,213 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue'
+import { useRuntimeConfig } from '#imports'
+import { useLocalFileViewer } from '../composables/useLocalFileViewer'
+import { formatLocalFileSize, resolveProjectLocalFileUrl, type ProjectLocalFileResponse } from '../../shared/local-files'
+
+const runtimeConfig = useRuntimeConfig()
+const { state, closeViewer } = useLocalFileViewer()
+
+const loading = ref(false)
+const error = ref<string | null>(null)
+const file = ref<ProjectLocalFileResponse['file'] | null>(null)
+const lineContainer = ref<HTMLElement | null>(null)
+
+const isOpen = computed({
+  get: () => state.value.open,
+  set: (open: boolean) => {
+    if (!open) {
+      closeViewer()
+    }
+  }
+})
+
+const relativePathLabel = computed(() => {
+  if (!file.value) {
+    return state.value.path ?? ''
+  }
+
+  return file.value.relativePath || file.value.name
+})
+
+const lineCount = computed(() => {
+  if (!file.value) {
+    return 0
+  }
+
+  return file.value.text.split('\n').length
+})
+
+const lineRows = computed(() => {
+  if (!file.value) {
+    return []
+  }
+
+  const lines = file.value.text.split('\n')
+  return lines.map((line, index) => ({
+    number: index + 1,
+    text: line
+  }))
+})
+
+const updatedAtLabel = computed(() => {
+  if (!file.value) {
+    return null
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  }).format(new Date(file.value.updatedAt))
+})
+
+const scrollToRequestedLine = async () => {
+  const targetLine = state.value.line
+  if (!targetLine || !lineContainer.value) {
+    return
+  }
+
+  await nextTick()
+  const target = lineContainer.value.querySelector<HTMLElement>(`[data-file-line="${targetLine}"]`)
+  target?.scrollIntoView({
+    block: 'center'
+  })
+}
+
+watch(
+  () => [state.value.open, state.value.projectId, state.value.path] as const,
+  async ([open, projectId, path]) => {
+    if (!open || !projectId || !path) {
+      loading.value = false
+      error.value = null
+      file.value = null
+      return
+    }
+
+    loading.value = true
+    error.value = null
+    file.value = null
+
+    try {
+      const response = await $fetch<ProjectLocalFileResponse>(resolveProjectLocalFileUrl({
+        projectId,
+        path,
+        configuredBase: String(runtimeConfig.public.serverBase ?? '')
+      }))
+      if (!state.value.open || state.value.projectId !== projectId || state.value.path !== path) {
+        return
+      }
+
+      file.value = response.file
+      await scrollToRequestedLine()
+    } catch (caughtError) {
+      if (!state.value.open || state.value.projectId !== projectId || state.value.path !== path) {
+        return
+      }
+
+      error.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
+    } finally {
+      if (state.value.open && state.value.projectId === projectId && state.value.path === path) {
+        loading.value = false
+      }
+    }
+  },
+  { immediate: true }
+)
+
+watch(() => state.value.line, () => {
+  if (file.value) {
+    void scrollToRequestedLine()
+  }
+})
+</script>
+
+<template>
+  <UModal
+    v-model:open="isOpen"
+    fullscreen
+    :ui="{
+      header: 'hidden',
+      close: 'hidden',
+      content: 'overflow-hidden bg-default',
+      body: '!h-full !p-0'
+    }"
+  >
+    <template #body>
+      <section class="flex h-full min-h-0 flex-col bg-default">
+        <header class="flex items-center justify-between gap-3 border-b border-default px-4 py-3">
+          <div class="min-w-0">
+            <div class="truncate text-xs font-medium uppercase tracking-[0.22em] text-primary">
+              Local File Viewer
+            </div>
+            <div class="truncate text-sm font-semibold text-highlighted">
+              {{ relativePathLabel }}
+            </div>
+            <div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted">
+              <span v-if="file">{{ formatLocalFileSize(file.size) }}</span>
+              <span v-if="updatedAtLabel">{{ updatedAtLabel }}</span>
+              <span v-if="state.line">Line {{ state.line }}</span>
+            </div>
+          </div>
+
+          <UButton
+            icon="i-lucide-x"
+            color="neutral"
+            variant="ghost"
+            size="sm"
+            aria-label="Close local file viewer"
+            @click="closeViewer"
+          />
+        </header>
+
+        <div
+          v-if="loading"
+          class="flex min-h-0 flex-1 items-center justify-center px-6 py-10 text-sm text-muted"
+        >
+          Loading local file preview...
+        </div>
+
+        <div
+          v-else-if="error"
+          class="flex min-h-0 flex-1 items-center justify-center px-6 py-10"
+        >
+          <UAlert
+            color="error"
+            variant="soft"
+            icon="i-lucide-circle-alert"
+            :title="error"
+            class="w-full max-w-2xl"
+          />
+        </div>
+
+        <div
+          v-else-if="file"
+          ref="lineContainer"
+          class="min-h-0 flex-1 overflow-auto bg-elevated/20"
+        >
+          <div class="min-w-max px-4 py-4 sm:px-6">
+            <div class="overflow-hidden rounded-2xl border border-default bg-default/85 shadow-sm">
+              <div class="flex items-center justify-between border-b border-default px-4 py-2 text-xs text-muted">
+                <span>{{ file.path }}</span>
+                <span>{{ lineCount }} lines</span>
+              </div>
+              <div class="overflow-x-auto font-mono text-[13px] leading-6 text-highlighted">
+                <div
+                  v-for="row in lineRows"
+                  :key="row.number"
+                  :data-file-line="row.number"
+                  class="grid grid-cols-[auto,1fr] gap-4 px-4"
+                  :class="state.line === row.number ? 'bg-primary/10' : ''"
+                >
+                  <span class="select-none py-0.5 text-right tabular-nums text-muted">{{ row.number }}</span>
+                  <span class="min-w-0 whitespace-pre-wrap break-all py-0.5">{{ row.text || ' ' }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </template>
+  </UModal>
+</template>

--- a/packages/client/app/components/MessagePartRenderer.ts
+++ b/packages/client/app/components/MessagePartRenderer.ts
@@ -32,6 +32,7 @@ export default defineComponent({
         case 'text':
           return h(MessagePartText, {
             role: props.message?.role,
+            projectId: props.projectId,
             part: props.part
           })
         case 'reasoning':

--- a/packages/client/app/components/SubagentTranscriptPanel.vue
+++ b/packages/client/app/components/SubagentTranscriptPanel.vue
@@ -10,6 +10,7 @@ import { resolveSubagentStatusMeta, type SubagentAccent } from '~~/shared/subage
 
 const props = withDefaults(defineProps<{
   agent: VisualSubagentPanel
+  projectId?: string | null
   accent?: SubagentAccent | null
   expanded?: boolean
   showExpandButton?: boolean
@@ -271,7 +272,10 @@ onBeforeUnmount(() => {
         compact
       >
         <template #content="{ message }">
-          <MessageContent :message="message as VisualSubagentPanel['messages'][number]" />
+          <MessageContent
+            :message="message as VisualSubagentPanel['messages'][number]"
+            :project-id="projectId ?? undefined"
+          />
         </template>
       </UChatMessages>
     </div>

--- a/packages/client/app/components/VisualSubagentStack.vue
+++ b/packages/client/app/components/VisualSubagentStack.vue
@@ -5,6 +5,7 @@ import { resolveSubagentAccent } from '~~/shared/subagent-panels'
 
 const props = defineProps<{
   agents: VisualSubagentPanel[]
+  projectId?: string | null
 }>()
 
 const emit = defineEmits<{
@@ -26,6 +27,7 @@ const paneSize = computed(() => {
       v-for="(agent, index) in agents"
       :key="agent.threadId"
       :agent="agent"
+      :project-id="projectId ?? null"
       :accent="resolveSubagentAccent(index)"
       scroll-scope="stack"
       show-expand-button

--- a/packages/client/app/components/message-part/LocalFileLink.vue
+++ b/packages/client/app/components/message-part/LocalFileLink.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useProjects } from '../../composables/useProjects'
+import { useLocalFileViewer } from '../../composables/useLocalFileViewer'
+import { isLocalFileWithinProject, parseLocalFileHref } from '../../../shared/local-files'
+
+const props = defineProps<{
+  href?: string | null
+  title?: string | null
+  projectId?: string | null
+}>()
+
+const { getProject } = useProjects()
+const { openViewer } = useLocalFileViewer()
+
+const parsedTarget = computed(() =>
+  props.href ? parseLocalFileHref(props.href) : null
+)
+const projectPath = computed(() =>
+  props.projectId ? getProject(props.projectId)?.projectPath ?? null : null
+)
+const isProjectLocalFile = computed(() =>
+  parsedTarget.value
+  && isLocalFileWithinProject(parsedTarget.value.path, projectPath.value)
+)
+
+const onClick = (event: MouseEvent) => {
+  if (!props.projectId || !parsedTarget.value || !isProjectLocalFile.value) {
+    return
+  }
+
+  event.preventDefault()
+  openViewer({
+    projectId: props.projectId,
+    path: parsedTarget.value.path,
+    line: parsedTarget.value.line,
+    column: parsedTarget.value.column
+  })
+}
+</script>
+
+<template>
+  <a
+    :href="href ?? undefined"
+    :title="title ?? undefined"
+    class="underline decoration-primary/35 underline-offset-3 transition hover:text-primary hover:decoration-primary"
+    @click="onClick"
+  >
+    <slot />
+  </a>
+</template>

--- a/packages/client/app/components/message-part/Text.vue
+++ b/packages/client/app/components/message-part/Text.vue
@@ -5,11 +5,13 @@ import math, { Math as ComarkMath } from '@comark/vue/plugins/math'
 import mermaid from '@comark/vue/plugins/mermaid'
 import { renderMermaidSVG, THEMES } from 'beautiful-mermaid'
 import { computed, defineComponent, h, onMounted, ref, watch } from 'vue'
+import LocalFileLink from './LocalFileLink.vue'
 import ReviewPriorityBadge from './ReviewPriorityBadge.vue'
 import { reviewPriorityBadgePlugin } from '../../utils/review-priority-badge'
 
 const props = defineProps<{
   role?: 'user' | 'assistant' | 'system'
+  projectId?: string | null
   part?: {
     type: 'text'
     text: string
@@ -126,7 +128,29 @@ const ChatMarkdownMermaid = defineComponent({
   }
 })
 
+const ChatMarkdownLocalFileLink = defineComponent({
+  name: 'ChatMarkdownLocalFileLink',
+  props: {
+    href: {
+      type: String,
+      default: ''
+    },
+    title: {
+      type: String,
+      default: ''
+    }
+  },
+  setup(linkProps, { slots }) {
+    return () => h(LocalFileLink, {
+      href: linkProps.href,
+      title: linkProps.title,
+      projectId: props.projectId ?? null
+    }, slots)
+  }
+})
+
 const components = {
+  a: ChatMarkdownLocalFileLink,
   math: ComarkMath,
   mermaid: ChatMarkdownMermaid,
   'review-priority-badge': ReviewPriorityBadge

--- a/packages/client/app/components/message-part/Text.vue
+++ b/packages/client/app/components/message-part/Text.vue
@@ -163,18 +163,17 @@ const plugins = [
   highlight({ preStyles: false })
 ]
 const isStreaming = computed(() => props.part?.state === 'streaming')
+const markdownClass = computed(() =>
+  props.role === 'user'
+    ? 'cd-markdown cd-markdown-user'
+    : 'cd-markdown'
+)
 </script>
 
 <template>
-  <p
-    v-if="role === 'user'"
-    class="whitespace-pre-wrap text-[15px] leading-7 text-highlighted"
-  >
-    {{ part?.text ?? '' }}
-  </p>
-  <Suspense v-else>
+  <Suspense>
     <Comark
-      class="cd-markdown"
+      :class="markdownClass"
       :markdown="part?.text ?? ''"
       :streaming="isStreaming"
       :components="components"

--- a/packages/client/app/composables/useLocalFileViewer.ts
+++ b/packages/client/app/composables/useLocalFileViewer.ts
@@ -1,0 +1,46 @@
+import { useState } from '#imports'
+
+export type LocalFileViewerState = {
+  open: boolean
+  projectId: string | null
+  path: string | null
+  line: number | null
+  column: number | null
+}
+
+const createClosedState = (): LocalFileViewerState => ({
+  open: false,
+  projectId: null,
+  path: null,
+  line: null,
+  column: null
+})
+
+export const useLocalFileViewer = () => {
+  const state = useState<LocalFileViewerState>('codori-local-file-viewer', createClosedState)
+
+  const openViewer = (input: {
+    projectId: string
+    path: string
+    line?: number | null
+    column?: number | null
+  }) => {
+    state.value = {
+      open: true,
+      projectId: input.projectId,
+      path: input.path,
+      line: input.line ?? null,
+      column: input.column ?? null
+    }
+  }
+
+  const closeViewer = () => {
+    state.value = createClosedState()
+  }
+
+  return {
+    state,
+    openViewer,
+    closeViewer
+  }
+}

--- a/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
+++ b/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
@@ -376,6 +376,7 @@ watch(
       <template #body>
         <VisualSubagentStack
           :agents="availablePanels"
+          :project-id="projectId"
           class="h-full min-h-0"
           @expand="openExpandedSubagent"
         />
@@ -441,6 +442,7 @@ watch(
         <SubagentTranscriptPanel
           v-if="expandedSubagentPanel"
           :agent="expandedSubagentPanel"
+          :project-id="projectId"
           :accent="expandedSubagentAccent"
           scroll-scope="expanded"
           expanded

--- a/packages/client/server/api/codori/projects/[projectId]/local-file.get.ts
+++ b/packages/client/server/api/codori/projects/[projectId]/local-file.get.ts
@@ -1,0 +1,44 @@
+import {
+  createError,
+  defineEventHandler,
+  getQuery,
+  getRouterParam
+} from 'h3'
+import { encodeProjectIdSegment } from '~~/shared/codori'
+import type { ProjectLocalFileResponse } from '~~/shared/local-files'
+import { proxyServerRequest } from '../../../../utils/server-proxy'
+
+export default defineEventHandler(async (event) => {
+  const projectId = getRouterParam(event, 'projectId')
+  if (!projectId) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Missing project id.'
+    })
+  }
+
+  const queryValue = getQuery(event).path
+  const path = typeof queryValue === 'string'
+    ? queryValue
+    : ''
+
+  if (!path) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Missing local file path.'
+    })
+  }
+
+  try {
+    return await proxyServerRequest<ProjectLocalFileResponse>(
+      event,
+      `/api/projects/${encodeProjectIdSegment(projectId)}/local-file?${new URLSearchParams({ path }).toString()}`
+    )
+  } catch (error) {
+    const details = error as { statusCode?: number, statusMessage?: string }
+    throw createError({
+      statusCode: details.statusCode ?? 500,
+      statusMessage: details.statusMessage ?? 'Local file preview failed.'
+    })
+  }
+})

--- a/packages/client/shared/file-autocomplete.ts
+++ b/packages/client/shared/file-autocomplete.ts
@@ -14,6 +14,11 @@ export type NormalizedFuzzyFileSearchMatch = {
   indices: number[] | null
 }
 
+export type FileAutocompletePathSegment = {
+  text: string
+  isMatch: boolean
+}
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object'
   && value !== null
@@ -111,6 +116,37 @@ export const toFileAutocompleteHandle = (
 ) => {
   const absolutePath = toAbsoluteAutocompletePath(match)
   return `[${match.fileName}](${encodeURI(absolutePath)})`
+}
+
+export const buildFileAutocompletePathSegments = (
+  match: Pick<NormalizedFuzzyFileSearchMatch, 'path' | 'indices'>
+): FileAutocompletePathSegment[] => {
+  const highlightedIndices = new Set(
+    (match.indices ?? [])
+      .filter(index => Number.isInteger(index) && index >= 0 && index < match.path.length)
+  )
+
+  const characters = match.path.split('')
+  const segments: FileAutocompletePathSegment[] = [{
+    text: '/',
+    isMatch: false
+  }]
+
+  for (const [index, character] of characters.entries()) {
+    const isMatch = highlightedIndices.has(index)
+    const previousSegment = segments[segments.length - 1]
+    if (previousSegment && previousSegment.isMatch === isMatch) {
+      previousSegment.text += character
+      continue
+    }
+
+    segments.push({
+      text: character,
+      isMatch
+    })
+  }
+
+  return segments
 }
 
 export const replaceActiveFileAutocompleteMatch = (

--- a/packages/client/shared/file-autocomplete.ts
+++ b/packages/client/shared/file-autocomplete.ts
@@ -98,13 +98,19 @@ export const findActiveFileAutocompleteMatch = (
 export const normalizeFileAutocompleteQuery = (query: string) =>
   query.trim().replace(/^\/+/, '')
 
-export const toFileAutocompleteInsertion = (match: Pick<NormalizedFuzzyFileSearchMatch, 'path' | 'matchType'>) => {
-  const normalizedPath = `/${match.path.replace(/^\/+/, '')}`
-  if (match.matchType === 'directory') {
-    return `${normalizedPath.replace(/\/?$/, '/')}`
-  }
+const toAbsoluteAutocompletePath = (match: Pick<NormalizedFuzzyFileSearchMatch, 'root' | 'path'>) => {
+  const normalizedRoot = match.root.replace(/\\/g, '/').replace(/\/+$/, '')
+  const normalizedPath = match.path.replace(/\\/g, '/').replace(/^\/+/, '')
+  return normalizedRoot
+    ? `${normalizedRoot}/${normalizedPath}`
+    : `/${normalizedPath}`
+}
 
-  return normalizedPath
+export const toFileAutocompleteHandle = (
+  match: Pick<NormalizedFuzzyFileSearchMatch, 'root' | 'path' | 'fileName'>
+) => {
+  const absolutePath = toAbsoluteAutocompletePath(match)
+  return `[${match.fileName}](${encodeURI(absolutePath)})`
 }
 
 export const replaceActiveFileAutocompleteMatch = (
@@ -112,12 +118,10 @@ export const replaceActiveFileAutocompleteMatch = (
   match: Pick<ActiveFileAutocompleteMatch, 'start' | 'end'>,
   replacement: string
 ) => {
-  const needsQuotes = /\s/u.test(replacement) && !replacement.includes('"')
-  const inserted = needsQuotes ? `"${replacement}"` : replacement
   const suffix = input.slice(match.end)
-  const trailingSpace = inserted.endsWith('/') || /^\s/u.test(suffix) || suffix.length === 0 ? '' : ' '
-  const nextValue = `${input.slice(0, match.start)}${inserted}${trailingSpace}${suffix}`
-  const nextCaret = match.start + inserted.length + trailingSpace.length
+  const trailingSpace = /^\s/u.test(suffix) || suffix.length === 0 ? '' : ' '
+  const nextValue = `${input.slice(0, match.start)}${replacement}${trailingSpace}${suffix}`
+  const nextCaret = match.start + replacement.length + trailingSpace.length
 
   return {
     value: nextValue,

--- a/packages/client/shared/file-autocomplete.ts
+++ b/packages/client/shared/file-autocomplete.ts
@@ -1,0 +1,126 @@
+export type ActiveFileAutocompleteMatch = {
+  start: number
+  end: number
+  raw: string
+  query: string
+}
+
+export type NormalizedFuzzyFileSearchMatch = {
+  path: string
+  root: string
+  fileName: string
+  matchType: 'file' | 'directory'
+  score: number
+  indices: number[] | null
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object'
+  && value !== null
+  && !Array.isArray(value)
+
+const normalizeMatch = (value: unknown): NormalizedFuzzyFileSearchMatch | null => {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const path = value.path
+  const root = value.root
+  const fileName = value.file_name ?? value.fileName
+  const matchType = value.match_type ?? value.matchType
+  const score = value.score
+  const indices = value.indices
+
+  if (
+    typeof path !== 'string'
+    || typeof root !== 'string'
+    || typeof fileName !== 'string'
+    || (matchType !== 'file' && matchType !== 'directory')
+    || typeof score !== 'number'
+  ) {
+    return null
+  }
+
+  return {
+    path,
+    root,
+    fileName,
+    matchType,
+    score,
+    indices: Array.isArray(indices) ? indices.filter(index => typeof index === 'number') : null
+  }
+}
+
+export const normalizeFuzzyFileSearchMatches = (value: unknown): NormalizedFuzzyFileSearchMatch[] => {
+  if (!isRecord(value) || !Array.isArray(value.files)) {
+    return []
+  }
+
+  return value.files
+    .map(normalizeMatch)
+    .filter((match): match is NormalizedFuzzyFileSearchMatch => match !== null)
+}
+
+export const findActiveFileAutocompleteMatch = (
+  input: string,
+  selectionStart: number | null | undefined,
+  selectionEnd: number | null | undefined
+): ActiveFileAutocompleteMatch | null => {
+  if (selectionStart == null || selectionEnd == null || selectionStart !== selectionEnd) {
+    return null
+  }
+
+  const caret = selectionStart
+  let start = caret
+  while (start > 0 && !/\s/u.test(input[start - 1] ?? '')) {
+    start -= 1
+  }
+
+  let end = caret
+  while (end < input.length && !/\s/u.test(input[end] ?? '')) {
+    end += 1
+  }
+
+  const raw = input.slice(start, end)
+
+  if (!raw.startsWith('@')) {
+    return null
+  }
+
+  return {
+    start,
+    end,
+    raw,
+    query: raw.slice(1)
+  }
+}
+
+export const normalizeFileAutocompleteQuery = (query: string) =>
+  query.trim().replace(/^\/+/, '')
+
+export const toFileAutocompleteInsertion = (match: Pick<NormalizedFuzzyFileSearchMatch, 'path' | 'matchType'>) => {
+  const normalizedPath = `/${match.path.replace(/^\/+/, '')}`
+  if (match.matchType === 'directory') {
+    return `${normalizedPath.replace(/\/?$/, '/')}`
+  }
+
+  return normalizedPath
+}
+
+export const replaceActiveFileAutocompleteMatch = (
+  input: string,
+  match: Pick<ActiveFileAutocompleteMatch, 'start' | 'end'>,
+  replacement: string
+) => {
+  const needsQuotes = /\s/u.test(replacement) && !replacement.includes('"')
+  const inserted = needsQuotes ? `"${replacement}"` : replacement
+  const suffix = input.slice(match.end)
+  const trailingSpace = inserted.endsWith('/') || /^\s/u.test(suffix) || suffix.length === 0 ? '' : ' '
+  const nextValue = `${input.slice(0, match.start)}${inserted}${trailingSpace}${suffix}`
+  const nextCaret = match.start + inserted.length + trailingSpace.length
+
+  return {
+    value: nextValue,
+    caret: nextCaret
+  }
+}

--- a/packages/client/shared/file-highlighting.ts
+++ b/packages/client/shared/file-highlighting.ts
@@ -1,0 +1,127 @@
+import { bundledLanguagesInfo } from 'shiki'
+
+const specialBasenameLanguages = new Map<string, string>([
+  ['dockerfile', 'docker'],
+  ['makefile', 'make'],
+  ['cmakelists.txt', 'cmake'],
+  ['gemfile', 'ruby'],
+  ['rakefile', 'ruby'],
+  ['podfile', 'ruby'],
+  ['brewfile', 'ruby'],
+  ['jenkinsfile', 'groovy']
+])
+
+const specialSuffixLanguages = new Map<string, string>([
+  ['.d.ts', 'typescript'],
+  ['.d.mts', 'typescript'],
+  ['.d.cts', 'typescript']
+])
+
+const languageInfoById = new Map(
+  bundledLanguagesInfo.map((info) => [info.id.toLowerCase(), info])
+)
+
+const languageAliasToId = new Map<string, string>()
+
+for (const info of bundledLanguagesInfo) {
+  languageAliasToId.set(info.id.toLowerCase(), info.id)
+
+  for (const alias of info.aliases ?? []) {
+    languageAliasToId.set(alias.toLowerCase(), info.id)
+  }
+}
+
+const findShebangLanguage = (text: string) => {
+  const firstLine = text.split('\n', 1)[0]?.trim() ?? ''
+  if (!firstLine.startsWith('#!')) {
+    return null
+  }
+
+  const normalized = firstLine.toLowerCase()
+  if (/python/.test(normalized)) {
+    return 'python'
+  }
+
+  if (/(node|deno|bun)/.test(normalized)) {
+    return 'javascript'
+  }
+
+  if (/(bash|zsh|\/sh\b|shell)/.test(normalized)) {
+    return 'shellscript'
+  }
+
+  if (/ruby/.test(normalized)) {
+    return 'ruby'
+  }
+
+  if (/php/.test(normalized)) {
+    return 'php'
+  }
+
+  if (/perl/.test(normalized)) {
+    return 'perl'
+  }
+
+  return null
+}
+
+const resolveExtensionLanguage = (filePath: string) => {
+  const normalizedPath = filePath.toLowerCase()
+
+  for (const [suffix, language] of specialSuffixLanguages.entries()) {
+    if (normalizedPath.endsWith(suffix)) {
+      return language
+    }
+  }
+
+  const basename = normalizedPath.split(/[\\/]/u).pop() ?? normalizedPath
+  const segments = basename.split('.')
+  if (segments.length < 2) {
+    return null
+  }
+
+  for (let index = 1; index < segments.length; index += 1) {
+    const candidate = segments.slice(index).join('.')
+    const resolved = languageAliasToId.get(candidate)
+    if (resolved) {
+      return resolved
+    }
+  }
+
+  return null
+}
+
+export const inferLocalFileLanguage = (filePath: string, text = '') => {
+  const basename = filePath.toLowerCase().split(/[\\/]/u).pop() ?? ''
+  const specialBasenameLanguage = specialBasenameLanguages.get(basename)
+  if (specialBasenameLanguage) {
+    return specialBasenameLanguage
+  }
+
+  const extensionLanguage = resolveExtensionLanguage(filePath)
+  if (extensionLanguage) {
+    return extensionLanguage
+  }
+
+  return findShebangLanguage(text)
+}
+
+export const resolveLocalFileLanguageLabel = (language: string | null) => {
+  if (!language) {
+    return null
+  }
+
+  return languageInfoById.get(language.toLowerCase())?.name ?? language
+}
+
+export const buildHighlightedFileMarkdown = (text: string, language: string | null) => {
+  const longestBacktickRun = Math.max(
+    2,
+    ...Array.from(text.matchAll(/`+/g), (match) => match[0].length)
+  )
+  const fence = '`'.repeat(longestBacktickRun + 1)
+  const languageSuffix = language ?? ''
+  const body = text.endsWith('\n') ? text : `${text}\n`
+
+  return `${fence}${languageSuffix}\n${body}${fence}`
+}

--- a/packages/client/shared/local-files.ts
+++ b/packages/client/shared/local-files.ts
@@ -1,0 +1,112 @@
+import { encodeProjectIdSegment } from './codori'
+import { resolveApiUrl, shouldUseServerProxy } from './network'
+
+export type LocalFileLinkTarget = {
+  path: string
+  line: number | null
+  column: number | null
+}
+
+export type ProjectLocalFileResponse = {
+  file: {
+    path: string
+    relativePath: string
+    name: string
+    size: number
+    updatedAt: number
+    text: string
+  }
+}
+
+const WINDOWS_ABSOLUTE_PATH_RE = /^[A-Za-z]:[\\/]/u
+
+const normalizeComparablePath = (value: string) => {
+  const normalized = value.replace(/\\/g, '/').replace(/\/+$/, '')
+  return WINDOWS_ABSOLUTE_PATH_RE.test(normalized)
+    ? normalized.toLowerCase()
+    : normalized
+}
+
+export const parseLocalFileHref = (href: string): LocalFileLinkTarget | null => {
+  const trimmed = href.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  const decoded = decodeURIComponent(trimmed)
+  if (decoded.startsWith('file://')) {
+    return parseLocalFileHref(decoded.slice('file://'.length))
+  }
+
+  if (decoded.startsWith('http://') || decoded.startsWith('https://') || decoded.startsWith('mailto:')) {
+    return null
+  }
+
+  if (WINDOWS_ABSOLUTE_PATH_RE.test(decoded)) {
+    const match = /^(?<path>[A-Za-z]:[\\/].*?)(?::(?<line>\d+))?(?::(?<column>\d+))?$/u.exec(decoded)
+    if (!match?.groups?.path) {
+      return null
+    }
+
+    return {
+      path: match.groups.path,
+      line: match.groups.line ? Number.parseInt(match.groups.line, 10) : null,
+      column: match.groups.column ? Number.parseInt(match.groups.column, 10) : null
+    }
+  }
+
+  if (!decoded.startsWith('/')) {
+    return null
+  }
+
+  const match = /^(?<path>\/.*?)(?::(?<line>\d+))?(?::(?<column>\d+))?$/u.exec(decoded)
+  if (!match?.groups?.path) {
+    return null
+  }
+
+  return {
+    path: match.groups.path,
+    line: match.groups.line ? Number.parseInt(match.groups.line, 10) : null,
+    column: match.groups.column ? Number.parseInt(match.groups.column, 10) : null
+  }
+}
+
+export const isLocalFileWithinProject = (
+  path: string,
+  projectPath: string | null | undefined
+) => {
+  if (!projectPath) {
+    return false
+  }
+
+  const normalizedPath = normalizeComparablePath(path)
+  const normalizedProjectPath = normalizeComparablePath(projectPath)
+  return normalizedPath === normalizedProjectPath || normalizedPath.startsWith(`${normalizedProjectPath}/`)
+}
+
+export const resolveProjectLocalFileUrl = (input: {
+  projectId: string
+  path: string
+  configuredBase?: string | null
+}) => {
+  const query = new URLSearchParams({ path: input.path })
+  const requestPath = `/projects/${encodeProjectIdSegment(input.projectId)}/local-file?${query.toString()}`
+
+  if (shouldUseServerProxy(input.configuredBase)) {
+    return `/api/codori${requestPath}`
+  }
+
+  return resolveApiUrl(requestPath, input.configuredBase)
+}
+
+export const formatLocalFileSize = (bytes: number) => {
+  if (bytes < 1024) {
+    return `${bytes} B`
+  }
+
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(bytes < 10 * 1024 ? 1 : 0)} KB`
+  }
+
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}

--- a/packages/client/shared/local-files.ts
+++ b/packages/client/shared/local-files.ts
@@ -33,9 +33,19 @@ export const parseLocalFileHref = (href: string): LocalFileLinkTarget | null => 
     return null
   }
 
-  const decoded = decodeURIComponent(trimmed)
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(trimmed)
+  } catch {
+    return null
+  }
+
   if (decoded.startsWith('file://')) {
-    return parseLocalFileHref(decoded.slice('file://'.length))
+    const filePath = decoded
+      .slice('file://'.length)
+      .replace(/^\/(?=[A-Za-z]:[\\/])/u, '')
+
+    return parseLocalFileHref(filePath)
   }
 
   if (decoded.startsWith('http://') || decoded.startsWith('https://') || decoded.startsWith('mailto:')) {

--- a/packages/client/test/file-autocomplete.test.ts
+++ b/packages/client/test/file-autocomplete.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildFileAutocompletePathSegments,
   findActiveFileAutocompleteMatch,
   normalizeFileAutocompleteQuery,
   normalizeFuzzyFileSearchMatches,
@@ -113,5 +114,18 @@ describe('file autocomplete helpers', () => {
       value: 'Open [my file.ts](/dir/my%20file.ts)',
       caret: 36
     })
+  })
+
+  it('builds compact path segments with highlighted fuzzy matches', () => {
+    expect(buildFileAutocompletePathSegments({
+      path: 'src/components/LocalFileViewerModal.vue',
+      indices: [0, 1, 2, 15, 16, 17, 18]
+    })).toEqual([
+      { text: '/', isMatch: false },
+      { text: 'src', isMatch: true },
+      { text: '/components/', isMatch: false },
+      { text: 'Loca', isMatch: true },
+      { text: 'lFileViewerModal.vue', isMatch: false }
+    ])
   })
 })

--- a/packages/client/test/file-autocomplete.test.ts
+++ b/packages/client/test/file-autocomplete.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import {
+  findActiveFileAutocompleteMatch,
+  normalizeFileAutocompleteQuery,
+  normalizeFuzzyFileSearchMatches,
+  replaceActiveFileAutocompleteMatch,
+  toFileAutocompleteInsertion
+} from '../shared/file-autocomplete'
+
+describe('file autocomplete helpers', () => {
+  it('detects the active @file token at the caret', () => {
+    expect(findActiveFileAutocompleteMatch('@/src/app.ts', 11, 11)).toEqual({
+      start: 0,
+      end: 12,
+      raw: '@/src/app.ts',
+      query: '/src/app.ts'
+    })
+
+    expect(findActiveFileAutocompleteMatch('/review @baz.ts', 15, 15)).toEqual({
+      start: 8,
+      end: 15,
+      raw: '@baz.ts',
+      query: 'baz.ts'
+    })
+
+    expect(findActiveFileAutocompleteMatch('Inspect\t@src/lib.ts', 19, 19)).toEqual({
+      start: 8,
+      end: 19,
+      raw: '@src/lib.ts',
+      query: 'src/lib.ts'
+    })
+  })
+
+  it('normalizes fuzzy file search responses and insertion text', () => {
+    expect(normalizeFuzzyFileSearchMatches({
+      files: [{
+        path: 'src/components',
+        root: '/Users/demo/project',
+        file_name: 'components',
+        match_type: 'directory',
+        score: 42,
+        indices: [0, 1]
+      }, {
+        path: 'src/app.ts',
+        root: '/Users/demo/project',
+        fileName: 'app.ts',
+        matchType: 'file',
+        score: 99,
+        indices: null
+      }]
+    })).toEqual([{
+      path: 'src/components',
+      root: '/Users/demo/project',
+      fileName: 'components',
+      matchType: 'directory',
+      score: 42,
+      indices: [0, 1]
+    }, {
+      path: 'src/app.ts',
+      root: '/Users/demo/project',
+      fileName: 'app.ts',
+      matchType: 'file',
+      score: 99,
+      indices: null
+    }])
+
+    expect(normalizeFileAutocompleteQuery('/src/app.ts')).toBe('src/app.ts')
+    expect(toFileAutocompleteInsertion({
+      path: 'src/components',
+      matchType: 'directory'
+    })).toBe('/src/components/')
+    expect(toFileAutocompleteInsertion({
+      path: 'src/app.ts',
+      matchType: 'file'
+    })).toBe('/src/app.ts')
+  })
+
+  it('replaces the active token and preserves follow-up typing ergonomics', () => {
+    expect(replaceActiveFileAutocompleteMatch(
+      'Please inspect @baz.ts soon',
+      {
+        start: 15,
+        end: 22
+      },
+      '/src/lib/baz.ts'
+    )).toEqual({
+      value: 'Please inspect /src/lib/baz.ts soon',
+      caret: 30
+    })
+
+    expect(replaceActiveFileAutocompleteMatch(
+      '@src/components',
+      {
+        start: 0,
+        end: 15
+      },
+      '/src/components/'
+    )).toEqual({
+      value: '/src/components/',
+      caret: 16
+    })
+
+    expect(replaceActiveFileAutocompleteMatch(
+      'Open @my file.ts',
+      {
+        start: 5,
+        end: 16
+      },
+      '/dir/my file.ts'
+    )).toEqual({
+      value: 'Open "/dir/my file.ts"',
+      caret: 22
+    })
+  })
+})

--- a/packages/client/test/file-autocomplete.test.ts
+++ b/packages/client/test/file-autocomplete.test.ts
@@ -4,7 +4,7 @@ import {
   normalizeFileAutocompleteQuery,
   normalizeFuzzyFileSearchMatches,
   replaceActiveFileAutocompleteMatch,
-  toFileAutocompleteInsertion
+  toFileAutocompleteHandle
 } from '../shared/file-autocomplete'
 
 describe('file autocomplete helpers', () => {
@@ -31,7 +31,7 @@ describe('file autocomplete helpers', () => {
     })
   })
 
-  it('normalizes fuzzy file search responses and insertion text', () => {
+  it('normalizes fuzzy file search responses and builds markdown file handles', () => {
     expect(normalizeFuzzyFileSearchMatches({
       files: [{
         path: 'src/components',
@@ -65,14 +65,16 @@ describe('file autocomplete helpers', () => {
     }])
 
     expect(normalizeFileAutocompleteQuery('/src/app.ts')).toBe('src/app.ts')
-    expect(toFileAutocompleteInsertion({
-      path: 'src/components',
-      matchType: 'directory'
-    })).toBe('/src/components/')
-    expect(toFileAutocompleteInsertion({
+    expect(toFileAutocompleteHandle({
+      root: '/Users/demo/project',
       path: 'src/app.ts',
-      matchType: 'file'
-    })).toBe('/src/app.ts')
+      fileName: 'app.ts'
+    })).toBe('[app.ts](/Users/demo/project/src/app.ts)')
+    expect(toFileAutocompleteHandle({
+      root: '/Users/demo/project',
+      path: 'docs/My File.md',
+      fileName: 'My File.md'
+    })).toBe('[My File.md](/Users/demo/project/docs/My%20File.md)')
   })
 
   it('replaces the active token and preserves follow-up typing ergonomics', () => {
@@ -82,22 +84,22 @@ describe('file autocomplete helpers', () => {
         start: 15,
         end: 22
       },
-      '/src/lib/baz.ts'
+      '[baz.ts](/src/lib/baz.ts)'
     )).toEqual({
-      value: 'Please inspect /src/lib/baz.ts soon',
-      caret: 30
+      value: 'Please inspect [baz.ts](/src/lib/baz.ts) soon',
+      caret: 40
     })
 
     expect(replaceActiveFileAutocompleteMatch(
-      '@src/components',
+      '@src/app.ts',
       {
         start: 0,
-        end: 15
+        end: 11
       },
-      '/src/components/'
+      '[app.ts](/src/app.ts)'
     )).toEqual({
-      value: '/src/components/',
-      caret: 16
+      value: '[app.ts](/src/app.ts)',
+      caret: 21
     })
 
     expect(replaceActiveFileAutocompleteMatch(
@@ -106,10 +108,10 @@ describe('file autocomplete helpers', () => {
         start: 5,
         end: 16
       },
-      '/dir/my file.ts'
+      '[my file.ts](/dir/my%20file.ts)'
     )).toEqual({
-      value: 'Open "/dir/my file.ts"',
-      caret: 22
+      value: 'Open [my file.ts](/dir/my%20file.ts)',
+      caret: 36
     })
   })
 })

--- a/packages/client/test/file-highlighting.test.ts
+++ b/packages/client/test/file-highlighting.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildHighlightedFileMarkdown,
+  inferLocalFileLanguage,
+  resolveLocalFileLanguageLabel
+} from '../shared/file-highlighting'
+
+describe('local file highlighting helpers', () => {
+  it('infers languages from special filenames, extensions, and shebangs', () => {
+    expect(inferLocalFileLanguage('/workspace/Dockerfile', '')).toBe('docker')
+    expect(inferLocalFileLanguage('/workspace/src/App.vue', '')).toBe('vue')
+    expect(inferLocalFileLanguage('/workspace/types/env.d.ts', '')).toBe('typescript')
+    expect(inferLocalFileLanguage('/workspace/bin/dev', '#!/usr/bin/env bash\necho ok\n')).toBe('shellscript')
+    expect(inferLocalFileLanguage('/workspace/README', 'plain text')).toBe(null)
+  })
+
+  it('resolves human-friendly labels for inferred languages', () => {
+    expect(resolveLocalFileLanguageLabel('typescript')).toBe('TypeScript')
+    expect(resolveLocalFileLanguageLabel('shellscript')).toBe('Shell')
+    expect(resolveLocalFileLanguageLabel(null)).toBe(null)
+  })
+
+  it('builds a fenced markdown block with a safe fence length', () => {
+    const markdown = buildHighlightedFileMarkdown('```\nconst value = 1\n```\n', 'typescript')
+
+    expect(markdown.startsWith('````typescript\n')).toBe(true)
+    expect(markdown.endsWith('\n````')).toBe(true)
+    expect(markdown).toContain('const value = 1')
+  })
+})

--- a/packages/client/test/message-part-text.test.ts
+++ b/packages/client/test/message-part-text.test.ts
@@ -5,6 +5,26 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { defineComponent, h, nextTick, type Component } from 'vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+const openViewerMock = vi.fn()
+
+vi.mock('../app/composables/useProjects', () => {
+  return {
+    useProjects: () => ({
+      getProject: (projectId?: string | null) => projectId
+        ? { projectPath: '/Users/comfuture/Project/codori' }
+        : null
+    })
+  }
+})
+
+vi.mock('../app/composables/useLocalFileViewer', () => {
+  return {
+    useLocalFileViewer: () => ({
+      openViewer: openViewerMock
+    })
+  }
+})
+
 vi.mock('beautiful-mermaid', () => {
   return {
     THEMES: {
@@ -94,6 +114,18 @@ vi.mock('@comark/vue', () => {
             ])
           }
 
+          const linkMatch = text.match(/^\[(.+?)\]\((.+?)\)$/)
+          if (linkMatch && components.a) {
+            return h('div', { class: 'mock-comark', 'data-streaming': String(props.streaming) }, [
+              h(components.a, {
+                href: linkMatch[2],
+                title: ''
+              }, {
+                default: () => [linkMatch[1]]
+              })
+            ])
+          }
+
           return h('div', { class: 'mock-comark', 'data-streaming': String(props.streaming) }, text)
         }
       }
@@ -172,6 +204,7 @@ const mountAssistantText = async (text: string, state: 'done' | 'streaming' = 'd
 afterEach(() => {
   document.body.innerHTML = ''
   document.documentElement.className = ''
+  openViewerMock.mockReset()
 })
 
 describe('message part text markdown rendering', () => {
@@ -241,5 +274,30 @@ describe('message part text markdown rendering', () => {
     expect(wrapper.find('.cd-markdown-mermaid-fallback').exists()).toBe(true)
     expect(wrapper.find('pre code.language-mermaid').exists()).toBe(true)
     expect(wrapper.find('.mermaid svg').exists()).toBe(false)
+  })
+
+  it('routes project-local absolute file links to the in-app viewer', async () => {
+    const wrapper = mount(MessagePartText, {
+      attachTo: document.body,
+      props: {
+        role: 'assistant',
+        projectId: 'demo',
+        part: {
+          type: 'text',
+          text: '[ChatWorkspace.vue](/Users/comfuture/Project/codori/packages/client/app/components/ChatWorkspace.vue:12)',
+          state: 'done'
+        }
+      }
+    })
+
+    await settle()
+    await wrapper.get('a').trigger('click')
+
+    expect(openViewerMock).toHaveBeenCalledWith({
+      projectId: 'demo',
+      path: '/Users/comfuture/Project/codori/packages/client/app/components/ChatWorkspace.vue',
+      line: 12,
+      column: null
+    })
   })
 })

--- a/packages/client/test/message-part-text.test.ts
+++ b/packages/client/test/message-part-text.test.ts
@@ -183,11 +183,15 @@ const settle = async () => {
   await flushPromises()
 }
 
-const mountAssistantText = async (text: string, state: 'done' | 'streaming' = 'done') => {
+const mountText = async (
+  role: 'user' | 'assistant' | 'system',
+  text: string,
+  state: 'done' | 'streaming' = 'done'
+) => {
   const wrapper = mount(MessagePartText, {
     attachTo: document.body,
     props: {
-      role: 'assistant',
+      role,
       part: {
         type: 'text',
         text,
@@ -209,7 +213,7 @@ afterEach(() => {
 
 describe('message part text markdown rendering', () => {
   it('renders inline LaTeX formulas with KaTeX markup', async () => {
-    const wrapper = await mountAssistantText('Energy stays concise: $E = mc^2$.')
+    const wrapper = await mountText('assistant', 'Energy stays concise: $E = mc^2$.')
 
     expect(wrapper.find('.math.inline').exists()).toBe(true)
     expect(wrapper.find('.math.inline .katex').exists()).toBe(true)
@@ -217,7 +221,8 @@ describe('message part text markdown rendering', () => {
   })
 
   it('renders block LaTeX formulas with display math markup', async () => {
-    const wrapper = await mountAssistantText(
+    const wrapper = await mountText(
+      'assistant',
       'Solve this first.\n\n$$x = \\\\frac{-b \\\\pm \\\\sqrt{b^2 - 4ac}}{2a}$$\n\nThen continue.'
     )
 
@@ -228,7 +233,7 @@ describe('message part text markdown rendering', () => {
   })
 
   it('renders Mermaid code fences as diagrams while streaming', async () => {
-    const wrapper = await mountAssistantText([
+    const wrapper = await mountText('assistant', [
       'Diagram:',
       '',
       '```mermaid',
@@ -264,7 +269,7 @@ describe('message part text markdown rendering', () => {
   })
 
   it('falls back unsupported Mermaid blocks to plain code blocks', async () => {
-    const wrapper = await mountAssistantText([
+    const wrapper = await mountText('assistant', [
       '```mermaid',
       'gantt',
       '  title Unsupported here',
@@ -297,6 +302,31 @@ describe('message part text markdown rendering', () => {
       projectId: 'demo',
       path: '/Users/comfuture/Project/codori/packages/client/app/components/ChatWorkspace.vue',
       line: 12,
+      column: null
+    })
+  })
+
+  it('renders markdown links in user messages and routes local files to the viewer', async () => {
+    const wrapper = mount(MessagePartText, {
+      attachTo: document.body,
+      props: {
+        role: 'user',
+        projectId: 'demo',
+        part: {
+          type: 'text',
+          text: '[LocalFileViewerModal.vue](/Users/comfuture/Project/codori/packages/client/app/components/LocalFileViewerModal.vue)',
+          state: 'done'
+        }
+      }
+    })
+
+    await settle()
+    await wrapper.get('a').trigger('click')
+
+    expect(openViewerMock).toHaveBeenCalledWith({
+      projectId: 'demo',
+      path: '/Users/comfuture/Project/codori/packages/client/app/components/LocalFileViewerModal.vue',
+      line: null,
       column: null
     })
   })

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -26,6 +26,11 @@ import {
   validateAttachmentSelection
 } from '../shared/chat-attachments'
 import {
+  isLocalFileWithinProject,
+  parseLocalFileHref,
+  resolveProjectLocalFileUrl
+} from '../shared/local-files'
+import {
   formatRateLimitWindowDuration,
   normalizeAccountRateLimits,
   type RateLimitBucket
@@ -257,6 +262,30 @@ describe('client package', () => {
       path: '/tmp/screenshot.png',
       configuredBase: 'https://codori.example.com'
     })).toBe('/api/codori/projects/team%2Fapi/attachments/file?path=%2Ftmp%2Fscreenshot.png')
+
+    expect(resolveProjectLocalFileUrl({
+      projectId: 'team/api',
+      path: '/Users/demo/Project/codori/src/app.ts',
+      configuredBase: 'https://codori.example.com'
+    })).toBe('/api/codori/projects/team%2Fapi/local-file?path=%2FUsers%2Fdemo%2FProject%2Fcodori%2Fsrc%2Fapp.ts')
+  })
+
+  it('detects project-local absolute file links and optional line suffixes', () => {
+    expect(parseLocalFileHref('/Users/demo/Project/codori/src/app.ts:18')).toEqual({
+      path: '/Users/demo/Project/codori/src/app.ts',
+      line: 18,
+      column: null
+    })
+
+    expect(parseLocalFileHref('https://example.com/docs')).toBeNull()
+    expect(isLocalFileWithinProject(
+      '/Users/demo/Project/codori/src/app.ts',
+      '/Users/demo/Project/codori'
+    )).toBe(true)
+    expect(isLocalFileWithinProject(
+      '/Users/demo/Project/other/app.ts',
+      '/Users/demo/Project/codori'
+    )).toBe(false)
   })
 
   it('keeps direct attachment requests when bundled with the codori server', () => {

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -278,6 +278,12 @@ describe('client package', () => {
     })
 
     expect(parseLocalFileHref('https://example.com/docs')).toBeNull()
+    expect(parseLocalFileHref('%')).toBeNull()
+    expect(parseLocalFileHref('file:///C:/Users/demo/Project/codori/src/app.ts:9:2')).toEqual({
+      path: 'C:/Users/demo/Project/codori/src/app.ts',
+      line: 9,
+      column: 2
+    })
     expect(isLocalFileWithinProject(
       '/Users/demo/Project/codori/src/app.ts',
       '/Users/demo/Project/codori'
@@ -286,6 +292,10 @@ describe('client package', () => {
       '/Users/demo/Project/other/app.ts',
       '/Users/demo/Project/codori'
     )).toBe(false)
+    expect(isLocalFileWithinProject(
+      'C:/Users/demo/Project/codori/src/app.ts',
+      'C:/Users/demo/Project/codori'
+    )).toBe(true)
   })
 
   it('keeps direct attachment requests when bundled with the codori server', () => {

--- a/packages/server/src/http-server.ts
+++ b/packages/server/src/http-server.ts
@@ -22,6 +22,7 @@ import {
 } from './attachment-store.js'
 import { CodoriError } from './errors.js'
 import { listGitBranches } from './git.js'
+import { LocalFileViewError, readProjectLocalFile } from './local-file-viewer.js'
 import { createRuntimeManager } from './process-manager.js'
 import {
   createServiceUpdateController,
@@ -66,6 +67,17 @@ type ServiceUpdateResponse = {
 type ProjectGitBranchesResponse = {
   currentBranch: string | null
   branches: string[]
+}
+
+type ProjectLocalFileResponse = {
+  file: {
+    path: string
+    relativePath: string
+    name: string
+    size: number
+    updatedAt: number
+    text: string
+  }
 }
 
 export type HttpServerOptions = {
@@ -472,6 +484,52 @@ export const createHttpServer = async (
       reply.header('content-disposition', `inline; filename="${basename(resolvedPath).replace(/"/g, '')}"`)
 
       return await readFile(resolvedPath)
+    }
+  )
+
+  app.get<{ Params: { projectId: string }, Querystring: { path?: string } }>(
+    '/api/projects/:projectId/local-file',
+    async (request, reply): Promise<ProjectLocalFileResponse | { error: { code: string, message: string } }> => {
+      const projectId = getProjectIdFromRequest(request.params.projectId)
+      const requestedPath = typeof request.query.path === 'string'
+        ? request.query.path.trim()
+        : ''
+
+      if (!requestedPath) {
+        reply.status(400)
+        return {
+          error: {
+            code: 'INVALID_LOCAL_FILE',
+            message: 'Missing local file path.'
+          }
+        }
+      }
+
+      const project = await resolveValue(manager.getProjectStatus(projectId))
+      await touchProjectActivity(manager, projectId)
+
+      try {
+        const file = await readProjectLocalFile(project.projectPath, requestedPath)
+        reply.header('cache-control', 'no-store')
+        return { file }
+      } catch (error) {
+        if (error instanceof LocalFileViewError) {
+          const statusCode = error.code === 'FORBIDDEN'
+            ? 403
+            : error.code === 'NOT_FOUND' || error.code === 'NOT_A_FILE'
+              ? 404
+              : 415
+          reply.status(statusCode)
+          return {
+            error: {
+              code: error.code,
+              message: error.message
+            }
+          }
+        }
+
+        throw error
+      }
     }
   )
 

--- a/packages/server/src/local-file-viewer.ts
+++ b/packages/server/src/local-file-viewer.ts
@@ -1,0 +1,86 @@
+import { basename, resolve } from 'node:path'
+import { readFile, realpath, stat } from 'node:fs/promises'
+import { isPathInsideDirectory } from './attachment-store.js'
+
+export const MAX_LOCAL_FILE_VIEW_BYTES = 1024 * 1024
+
+export type LocalFileReadResult = {
+  path: string
+  relativePath: string
+  name: string
+  size: number
+  updatedAt: number
+  text: string
+}
+
+export class LocalFileViewError extends Error {
+  readonly code: 'FORBIDDEN' | 'NOT_FOUND' | 'NOT_A_FILE' | 'TOO_LARGE' | 'BINARY'
+
+  constructor(
+    code: LocalFileViewError['code'],
+    message: string
+  ) {
+    super(message)
+    this.name = 'LocalFileViewError'
+    this.code = code
+  }
+}
+
+const hasBinaryContent = (buffer: Buffer) => {
+  for (const byte of buffer) {
+    if (byte === 0) {
+      return true
+    }
+  }
+
+  return false
+}
+
+export const readProjectLocalFile = async (
+  projectRoot: string,
+  requestedPath: string
+): Promise<LocalFileReadResult> => {
+  const resolvedProjectRoot = await realpath(resolve(projectRoot))
+  const resolvedRequestPath = resolve(requestedPath)
+
+  let resolvedTargetPath: string
+  try {
+    resolvedTargetPath = await realpath(resolvedRequestPath)
+  } catch {
+    throw new LocalFileViewError('NOT_FOUND', 'Local file not found.')
+  }
+
+  if (!isPathInsideDirectory(resolvedTargetPath, resolvedProjectRoot)) {
+    throw new LocalFileViewError('FORBIDDEN', 'Local file access is limited to the active project root.')
+  }
+
+  const fileStat = await stat(resolvedTargetPath).catch(() => null)
+  if (!fileStat) {
+    throw new LocalFileViewError('NOT_FOUND', 'Local file not found.')
+  }
+
+  if (!fileStat.isFile()) {
+    throw new LocalFileViewError('NOT_A_FILE', 'Only regular files can be previewed.')
+  }
+
+  if (fileStat.size > MAX_LOCAL_FILE_VIEW_BYTES) {
+    throw new LocalFileViewError(
+      'TOO_LARGE',
+      `Local file preview is limited to ${Math.floor(MAX_LOCAL_FILE_VIEW_BYTES / 1024)} KB.`
+    )
+  }
+
+  const buffer = await readFile(resolvedTargetPath)
+  if (hasBinaryContent(buffer)) {
+    throw new LocalFileViewError('BINARY', 'Binary files are not supported by the local file viewer.')
+  }
+
+  return {
+    path: resolvedTargetPath,
+    relativePath: resolvedTargetPath.slice(resolvedProjectRoot.length).replace(/^[/\\]+/, ''),
+    name: basename(resolvedTargetPath),
+    size: fileStat.size,
+    updatedAt: fileStat.mtimeMs,
+    text: buffer.toString('utf8')
+  }
+}

--- a/packages/server/test/http-server.test.ts
+++ b/packages/server/test/http-server.test.ts
@@ -463,8 +463,9 @@ describe('createHttpServer', () => {
       client.once('message', () => {
         client.close()
       })
-      client.once('close', () => {
+      client.once('close', async () => {
         try {
+          await new Promise(resolvePromise => setTimeout(resolvePromise, 0))
           expect(events[0]).toBe('acquire')
           expect(events).toContain('touch')
           expect(events.at(-1)).toBe('release')
@@ -743,6 +744,97 @@ describe('createHttpServer', () => {
       error: {
         code: 'UNSUPPORTED_MEDIA_TYPE',
         message: 'Attachment preview is only available for image files.'
+      }
+    })
+  })
+
+  it('returns a read-only preview for text files inside the active project root', async () => {
+    const projectPath = mkdtempSync(join(os.tmpdir(), 'codori-local-file-'))
+    tempDirs.push(projectPath)
+    const filePath = join(projectPath, 'src', 'viewer.ts')
+    mkdirSync(join(projectPath, 'src'), { recursive: true })
+    writeFileSync(filePath, 'export const viewer = true\n', 'utf8')
+
+    const app = await createHttpServer(createManager({
+      getProjectStatus: () => ({
+        ...createProjectRecord(),
+        projectPath
+      })
+    }))
+    startedApps.push(app)
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/projects/demo/local-file?path=${encodeURIComponent(filePath)}`
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({
+      file: {
+        path: expect.stringMatching(/src\/viewer\.ts$/),
+        relativePath: 'src/viewer.ts',
+        name: 'viewer.ts',
+        size: 'export const viewer = true\n'.length,
+        updatedAt: expect.any(Number),
+        text: 'export const viewer = true\n'
+      }
+    })
+  })
+
+  it('rejects local file previews outside the active project root', async () => {
+    const projectPath = mkdtempSync(join(os.tmpdir(), 'codori-local-file-'))
+    tempDirs.push(projectPath)
+    const outsidePath = join(os.tmpdir(), 'codori-local-file-outside.txt')
+    writeFileSync(outsidePath, 'outside\n', 'utf8')
+    tempDirs.push(outsidePath)
+
+    const app = await createHttpServer(createManager({
+      getProjectStatus: () => ({
+        ...createProjectRecord(),
+        projectPath
+      })
+    }))
+    startedApps.push(app)
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/projects/demo/local-file?path=${encodeURIComponent(outsidePath)}`
+    })
+
+    expect(response.statusCode).toBe(403)
+    expect(response.json()).toEqual({
+      error: {
+        code: 'FORBIDDEN',
+        message: 'Local file access is limited to the active project root.'
+      }
+    })
+  })
+
+  it('rejects binary local file previews', async () => {
+    const projectPath = mkdtempSync(join(os.tmpdir(), 'codori-local-file-'))
+    tempDirs.push(projectPath)
+    const filePath = join(projectPath, 'dist', 'blob.bin')
+    mkdirSync(join(projectPath, 'dist'), { recursive: true })
+    writeFileSync(filePath, Buffer.from([0x00, 0x01, 0x02]))
+
+    const app = await createHttpServer(createManager({
+      getProjectStatus: () => ({
+        ...createProjectRecord(),
+        projectPath
+      })
+    }))
+    startedApps.push(app)
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/projects/demo/local-file?path=${encodeURIComponent(filePath)}`
+    })
+
+    expect(response.statusCode).toBe(415)
+    expect(response.json()).toEqual({
+      error: {
+        code: 'BINARY',
+        message: 'Binary files are not supported by the local file viewer.'
       }
     })
   })


### PR DESCRIPTION
## Summary
- add a secure local file viewer and wire local file links in chat to open it
- add `@`-triggered fuzzy local file autocomplete that inserts markdown file handles instead of sending immediately
- render markdown in user message bubbles so selected file handles stay clickable in the transcript
- add syntax-highlighted file rendering and harden the file palette `Enter` path so selection never falls through to chat submission

## Why
- implement the local file viewer requested in issue #7
- land the agreed local-file handle autocomplete slice from issue #31 in the same flow

## Review Follow-up
- `4ec0d30` intercepts exact `Enter` in the prompt capture phase so file palette selection cannot race into message submission
- `3ab18a2` clears stale file autocomplete errors when project runtime context disappears and hardens local file href parsing for malformed escapes and Windows `file:///` paths

## Verification
- `pnpm --filter @codori/client test -- --runInBand packages/client/test/file-autocomplete.test.ts packages/client/test/message-part-text.test.ts packages/client/test/file-highlighting.test.ts packages/client/test/smoke.test.ts`
- `pnpm --filter @codori/client typecheck`
- `pnpm --filter @codori/client build`
- `pnpm --filter @codori/server build`
- Chrome DevTools MCP repro on `http://localhost:4310` confirming `@ChatWorkspace` + `Enter` inserts a file handle without submitting the message

Closes #7
Partially addresses #31
