### PR TITLE
feat: add skill autocomplete to chat composer

### DIFF
--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -1111,7 +1111,7 @@ const resolveSkillAutocompleteIcon = (skill: SkillAutocompleteEntry) => {
     .join(' ')
     .toLowerCase()
 
-  if (haystack.includes('github') || haystack.includes('gh-') || haystack.includes(' ci ') || haystack.includes('actions')) {
+  if (haystack.includes('github') || haystack.includes('gh-') || /\bci\b/.test(haystack) || haystack.includes('actions')) {
     return 'i-lucide-github'
   }
 
@@ -1226,9 +1226,13 @@ const shouldReloadSkillAutocompleteCatalog = (projectPath: string) =>
   skillAutocompleteCatalogCwd.value !== projectPath
   || skillAutocompleteCatalogVersion.value !== skillAutocompleteInvalidationVersion.value
 
+const isLatestSkillAutocompleteRequest = (requestSequence?: number | null) =>
+  requestSequence == null || requestSequence === skillAutocompleteRequestSequence
+
 const loadSkillAutocompleteCatalog = async (options?: {
   forceReload?: boolean
   projectPath?: string | null
+  requestSequence?: number | null
 }) => {
   const projectPath = options?.projectPath ?? selectedProject.value?.projectPath ?? null
   if (!projectPath) {
@@ -1252,6 +1256,10 @@ const loadSkillAutocompleteCatalog = async (options?: {
     ? entry.errors.map(errorEntry => errorEntry.message).join('\n')
     : null
 
+  if (!isLatestSkillAutocompleteRequest(options?.requestSequence)) {
+    return skillAutocompleteCatalog.value
+  }
+
   skillAutocompleteCatalog.value = skills
   skillAutocompleteCatalogCwd.value = projectPath
   skillAutocompleteCatalogVersion.value = skillAutocompleteInvalidationVersion.value
@@ -1270,9 +1278,11 @@ const ensureSkillAutocompleteCatalogCurrent = async () => {
     return skillAutocompleteCatalog.value
   }
 
+  const requestSequence = ++skillAutocompleteRequestSequence
   return await loadSkillAutocompleteCatalog({
     forceReload: skillAutocompleteCatalogCwd.value === projectPath,
-    projectPath
+    projectPath,
+    requestSequence
   })
 }
 
@@ -3274,7 +3284,8 @@ watch(
     try {
       await loadSkillAutocompleteCatalog({
         forceReload: skillAutocompleteCatalogCwd.value === projectPath,
-        projectPath
+        projectPath,
+        requestSequence
       })
     } catch (caughtError) {
       if (requestSequence !== skillAutocompleteRequestSequence) {

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -111,6 +111,18 @@ import {
   type FileAutocompletePathSegment,
   type NormalizedFuzzyFileSearchMatch
 } from '~~/shared/file-autocomplete'
+import {
+  filterSkillAutocompleteEntries,
+  findActiveSkillAutocompleteMatch,
+  hasSkillAutocompleteMentions,
+  normalizeSkillsListResponse,
+  preprocessSkillMentionsForSubmission,
+  reconcileSkillAutocompleteSelections,
+  replaceActiveSkillAutocompleteMatch,
+  toSkillAutocompleteCompletion,
+  type SkillAutocompleteEntry,
+  type SkillAutocompleteSelection
+} from '~~/shared/skill-autocomplete'
 
 const props = defineProps<{
   projectId: string
@@ -155,6 +167,8 @@ const chatPromptRef = ref<{
   textareaRef?: unknown
 } | null>(null)
 const slashDropdownRef = ref<HTMLElement | null>(null)
+const skillAutocompleteDropdownRef = ref<HTMLElement | null>(null)
+const skillAutocompleteListRef = ref<HTMLElement | null>(null)
 const fileAutocompleteDropdownRef = ref<HTMLElement | null>(null)
 const fileAutocompleteListRef = ref<HTMLElement | null>(null)
 const scrollViewport = ref<HTMLElement | null>(null)
@@ -198,8 +212,17 @@ const promptSelectionStart = ref(0)
 const promptSelectionEnd = ref(0)
 const isPromptFocused = ref(false)
 const dismissedSlashMatchKey = ref<string | null>(null)
+const dismissedSkillAutocompleteMatchKey = ref<string | null>(null)
 const dismissedFileAutocompleteMatchKey = ref<string | null>(null)
 const slashHighlightIndex = ref(0)
+const skillAutocompleteHighlightIndex = ref(0)
+const skillAutocompleteLoading = ref(false)
+const skillAutocompleteError = ref<string | null>(null)
+const skillAutocompleteCatalog = ref<SkillAutocompleteEntry[]>([])
+const skillAutocompleteCatalogCwd = ref<string | null>(null)
+const skillAutocompleteCatalogVersion = ref(-1)
+const skillAutocompleteInvalidationVersion = ref(0)
+const insertedSkillMentions = ref<SkillAutocompleteSelection[]>([])
 const fileAutocompleteHighlightIndex = ref(0)
 const fileAutocompleteLoading = ref(false)
 const fileAutocompleteError = ref<string | null>(null)
@@ -276,6 +299,28 @@ const filteredSlashCommands = computed(() =>
     : []
 )
 
+const activeSkillAutocompleteMatch = computed(() =>
+  isPromptFocused.value
+    ? findActiveSkillAutocompleteMatch(input.value, promptSelectionStart.value, promptSelectionEnd.value)
+    : null
+)
+
+const activeSkillAutocompleteMatchKey = computed(() => {
+  const match = activeSkillAutocompleteMatch.value
+  if (!match) {
+    return null
+  }
+
+  return `${match.start}:${match.end}:${match.raw}`
+})
+
+const filteredSkillAutocompleteResults = computed(() =>
+  activeSkillAutocompleteMatch.value
+    ? filterSkillAutocompleteEntries(skillAutocompleteCatalog.value, activeSkillAutocompleteMatch.value.query)
+      .slice(0, 8)
+    : []
+)
+
 const activeFileAutocompleteMatch = computed(() =>
   isPromptFocused.value
     ? findActiveFileAutocompleteMatch(input.value, promptSelectionStart.value, promptSelectionEnd.value)
@@ -315,8 +360,22 @@ const highlightedFileAutocompleteResult = computed(() =>
   ?? null
 )
 
+const skillAutocompleteOpen = computed(() =>
+  !reviewDrawerOpen.value
+  && !fileAutocompleteOpen.value
+  && Boolean(activeSkillAutocompleteMatch.value)
+  && activeSkillAutocompleteMatchKey.value !== dismissedSkillAutocompleteMatchKey.value
+)
+
+const highlightedSkillAutocompleteResult = computed(() =>
+  filteredSkillAutocompleteResults.value[skillAutocompleteHighlightIndex.value]
+  ?? filteredSkillAutocompleteResults.value[0]
+  ?? null
+)
+
 const slashDropdownOpen = computed(() =>
   !reviewDrawerOpen.value
+  && !skillAutocompleteOpen.value
   && !fileAutocompleteOpen.value
   && Boolean(activeSlashMatch.value)
   && activeSlashMatchKey.value !== dismissedSlashMatchKey.value
@@ -409,6 +468,32 @@ const fileAutocompleteEmptyState = computed(() => {
 
   if (visibleFileAutocompleteResults.value.length === 0) {
     return 'No matching project files.'
+  }
+
+  return null
+})
+
+const skillAutocompleteEmptyState = computed(() => {
+  if (!skillAutocompleteOpen.value) {
+    return null
+  }
+
+  if (!selectedProject.value?.projectPath) {
+    return 'Project runtime is not ready yet.'
+  }
+
+  if (skillAutocompleteLoading.value) {
+    return 'Loading available skills...'
+  }
+
+  if (skillAutocompleteError.value && filteredSkillAutocompleteResults.value.length === 0) {
+    return skillAutocompleteError.value
+  }
+
+  if (filteredSkillAutocompleteResults.value.length === 0) {
+    return activeSkillAutocompleteMatch.value?.query
+      ? 'No matching skills.'
+      : 'No available skills were found for this workspace.'
   }
 
   return null
@@ -508,6 +593,9 @@ const optimisticAttachmentSnapshots = new Map<string, DraftAttachment[]>()
 let promptControlsPromise: Promise<void> | null = null
 let pendingThreadHydration: Promise<void> | null = null
 let releaseServerRequestHandler: (() => void) | null = null
+let releaseSkillNotificationSubscription: (() => void) | null = null
+let skipNextSkillMentionSync = false
+let skillAutocompleteRequestSequence = 0
 let fileAutocompleteRequestSequence = 0
 
 const isActiveTurnStatus = (value: string | null | undefined) => {
@@ -781,6 +869,10 @@ const syncPromptSelectionFromDom = () => {
     dismissedSlashMatchKey.value = null
   }
 
+  if (!activeSkillAutocompleteMatchKey.value || activeSkillAutocompleteMatchKey.value !== dismissedSkillAutocompleteMatchKey.value) {
+    dismissedSkillAutocompleteMatchKey.value = null
+  }
+
   if (!activeFileAutocompleteMatchKey.value || activeFileAutocompleteMatchKey.value !== dismissedFileAutocompleteMatchKey.value) {
     dismissedFileAutocompleteMatchKey.value = null
   }
@@ -803,6 +895,7 @@ const focusPromptAt = async (position?: number) => {
 
 const shouldRetainPromptFocus = (nextFocused: EventTarget | null | undefined) =>
   isFocusWithinContainer(nextFocused, slashDropdownRef.value)
+  || isFocusWithinContainer(nextFocused, skillAutocompleteDropdownRef.value)
   || isFocusWithinContainer(nextFocused, fileAutocompleteDropdownRef.value)
 
 const handlePromptBlur = (event: FocusEvent) => {
@@ -825,6 +918,11 @@ const handleSlashDropdownPointerDown = (event: PointerEvent) => {
   void focusPromptAt(promptSelectionStart.value)
 }
 
+const handleSkillAutocompletePointerDown = (event: PointerEvent) => {
+  event.preventDefault()
+  void focusPromptAt(promptSelectionStart.value)
+}
+
 const handleFileAutocompletePointerDown = (event: PointerEvent) => {
   // File suggestions follow the same inert-overlay rule as slash commands.
   // Keeping focus anchored in the textarea avoids collapsing the popup while
@@ -834,6 +932,18 @@ const handleFileAutocompletePointerDown = (event: PointerEvent) => {
 }
 
 const onPromptEnterCapture = (event: KeyboardEvent) => {
+  if (skillAutocompleteOpen.value) {
+    event.preventDefault()
+    event.stopPropagation()
+    event.stopImmediatePropagation()
+
+    const skill = highlightedSkillAutocompleteResult.value
+    if (skill) {
+      void selectSkillAutocompleteResult(skill)
+    }
+    return
+  }
+
   if (!fileAutocompleteOpen.value) {
     return
   }
@@ -882,8 +992,21 @@ const clearSlashCommandDraft = () => {
   // or `/review` in the prompt after opening the modal/drawer makes the next
   // edit start from stale command text and feels like the action did not finish.
   input.value = ''
+  insertedSkillMentions.value = []
   clearAttachments({ revoke: false })
   dismissedSlashMatchKey.value = null
+}
+
+const cloneSkillMentions = (mentions = insertedSkillMentions.value) =>
+  mentions.map(mention => ({ ...mention }))
+
+const applyDraftTextState = (
+  nextText: string,
+  nextMentions: SkillAutocompleteSelection[] = []
+) => {
+  skipNextSkillMentionSync = true
+  input.value = nextText
+  insertedSkillMentions.value = cloneSkillMentions(nextMentions)
 }
 
 const moveSlashHighlight = (delta: number) => {
@@ -905,6 +1028,27 @@ const moveSlashHighlight = (delta: number) => {
   }
 
   slashHighlightIndex.value = nextIndex
+}
+
+const moveSkillAutocompleteHighlight = (delta: number) => {
+  if (!filteredSkillAutocompleteResults.value.length) {
+    skillAutocompleteHighlightIndex.value = 0
+    return
+  }
+
+  const maxIndex = filteredSkillAutocompleteResults.value.length - 1
+  const nextIndex = skillAutocompleteHighlightIndex.value + delta
+  if (nextIndex < 0) {
+    skillAutocompleteHighlightIndex.value = maxIndex
+    return
+  }
+
+  if (nextIndex > maxIndex) {
+    skillAutocompleteHighlightIndex.value = 0
+    return
+  }
+
+  skillAutocompleteHighlightIndex.value = nextIndex
 }
 
 const moveFileAutocompleteHighlight = (delta: number) => {
@@ -952,6 +1096,36 @@ const completeSlashCommand = async (command: SlashCommandDefinition) => {
   await focusPromptAt(match.start + completion.length)
 }
 
+const resolveSkillAutocompleteDescription = (skill: SkillAutocompleteEntry) =>
+  skill.shortDescription ?? skill.description
+
+const selectSkillAutocompleteResult = async (skill: SkillAutocompleteEntry) => {
+  const activeMatch = activeSkillAutocompleteMatch.value
+  if (!activeMatch) {
+    return
+  }
+
+  dismissedSkillAutocompleteMatchKey.value = null
+  skillAutocompleteError.value = null
+  const completion = toSkillAutocompleteCompletion(skill)
+  const nextDraft = replaceActiveSkillAutocompleteMatch(input.value, activeMatch, completion)
+  const nextMentions = reconcileSkillAutocompleteSelections(
+    input.value,
+    nextDraft.value,
+    insertedSkillMentions.value
+  )
+
+  nextMentions.push({
+    start: nextDraft.tokenStart,
+    end: nextDraft.tokenEnd,
+    name: skill.name,
+    path: skill.path
+  })
+
+  applyDraftTextState(nextDraft.value, nextMentions)
+  await focusPromptAt(nextDraft.caret)
+}
+
 const resolveFileAutocompleteIcon = (match: Pick<NormalizedFuzzyFileSearchMatch, 'matchType'>) =>
   match.matchType === 'directory' ? 'i-lucide-folder-open' : 'i-lucide-file-code-2'
 
@@ -983,6 +1157,71 @@ const syncFileAutocompleteScroll = async () => {
   )
   selected?.scrollIntoView({
     block: 'nearest'
+  })
+}
+
+const syncSkillAutocompleteScroll = async () => {
+  await nextTick()
+
+  const selected = skillAutocompleteListRef.value?.querySelector<HTMLElement>(
+    '[data-skill-autocomplete-option][aria-selected="true"]'
+  )
+  selected?.scrollIntoView({
+    block: 'nearest'
+  })
+}
+
+const shouldReloadSkillAutocompleteCatalog = (projectPath: string) =>
+  skillAutocompleteCatalogCwd.value !== projectPath
+  || skillAutocompleteCatalogVersion.value !== skillAutocompleteInvalidationVersion.value
+
+const loadSkillAutocompleteCatalog = async (options?: {
+  forceReload?: boolean
+  projectPath?: string | null
+}) => {
+  const projectPath = options?.projectPath ?? selectedProject.value?.projectPath ?? null
+  if (!projectPath) {
+    skillAutocompleteCatalog.value = []
+    skillAutocompleteCatalogCwd.value = null
+    skillAutocompleteCatalogVersion.value = -1
+    skillAutocompleteError.value = null
+    return []
+  }
+
+  await ensureProjectRuntime()
+  const response = await getClient(props.projectId).request('skills/list', {
+    cwds: [projectPath],
+    forceReload: options?.forceReload ? true : undefined
+  })
+
+  const entries = normalizeSkillsListResponse(response)
+  const entry = entries.find(candidate => candidate.cwd === projectPath) ?? entries[0] ?? null
+  const skills = entry?.skills.filter(skill => skill.enabled) ?? []
+  const nextError = skills.length === 0 && entry?.errors.length
+    ? entry.errors.map(errorEntry => errorEntry.message).join('\n')
+    : null
+
+  skillAutocompleteCatalog.value = skills
+  skillAutocompleteCatalogCwd.value = projectPath
+  skillAutocompleteCatalogVersion.value = skillAutocompleteInvalidationVersion.value
+  skillAutocompleteError.value = nextError
+
+  return skills
+}
+
+const ensureSkillAutocompleteCatalogCurrent = async () => {
+  const projectPath = selectedProject.value?.projectPath ?? null
+  if (!projectPath) {
+    return skillAutocompleteCatalog.value
+  }
+
+  if (!shouldReloadSkillAutocompleteCatalog(projectPath)) {
+    return skillAutocompleteCatalog.value
+  }
+
+  return await loadSkillAutocompleteCatalog({
+    forceReload: skillAutocompleteCatalogCwd.value === projectPath,
+    projectPath
   })
 }
 
@@ -1174,9 +1413,13 @@ const markAssistantOutputStartedForItem = (item: CodexThreadItem) => {
   }
 }
 
-const restoreDraftIfPristine = (text: string, submittedAttachments: DraftAttachment[]) => {
+const restoreDraftIfPristine = (
+  text: string,
+  submittedAttachments: DraftAttachment[],
+  submittedSkillMentions: SkillAutocompleteSelection[] = []
+) => {
   if (!input.value.trim()) {
-    input.value = text
+    applyDraftTextState(text, submittedSkillMentions)
   }
 
   if (attachments.value.length === 0 && submittedAttachments.length > 0) {
@@ -2410,6 +2653,15 @@ const sendMessage = async () => {
   // `keydown.enter.exact` handler, so guarding only in our keydown callback is
   // not sufficient to stop Enter from racing into a send while the file palette
   // is open. Keep the submit path itself aware of the palette state.
+  if (skillAutocompleteOpen.value) {
+    const skill = highlightedSkillAutocompleteResult.value
+    if (skill) {
+      await selectSkillAutocompleteResult(skill)
+    }
+
+    return
+  }
+
   if (fileAutocompleteOpen.value) {
     const match = highlightedFileAutocompleteResult.value
     if (match) {
@@ -2425,10 +2677,10 @@ const sendMessage = async () => {
 
   sendMessageLocked.value = true
   const rawText = input.value
-  const text = rawText.trim()
   const submittedAttachments = attachments.value.slice()
+  const submittedSkillMentions = cloneSkillMentions()
 
-  if (!text && submittedAttachments.length === 0) {
+  if (!rawText.trim() && submittedAttachments.length === 0) {
     sendMessageLocked.value = false
     return
   }
@@ -2438,13 +2690,34 @@ const sendMessage = async () => {
     return
   }
 
-  input.value = ''
+  if (hasSkillAutocompleteMentions(rawText)) {
+    try {
+      await ensureSkillAutocompleteCatalogCurrent()
+    } catch (caughtError) {
+      error.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
+      status.value = 'error'
+      sendMessageLocked.value = false
+      return
+    }
+  }
+
+  const text = preprocessSkillMentionsForSubmission(
+    rawText,
+    submittedSkillMentions,
+    skillAutocompleteCatalog.value
+  ).trim()
+  if (!text && submittedAttachments.length === 0) {
+    sendMessageLocked.value = false
+    return
+  }
+
+  applyDraftTextState('')
   clearAttachments({ revoke: false })
 
   try {
     await loadPromptControls()
   } catch (caughtError) {
-    restoreDraftIfPristine(text, submittedAttachments)
+    restoreDraftIfPristine(rawText, submittedAttachments, submittedSkillMentions)
     error.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
     status.value = 'error'
     sendMessageLocked.value = false
@@ -2539,13 +2812,13 @@ const sendMessage = async () => {
           clearPendingOptimisticMessages(clearLiveStream(new Error(messageText)))
         }
         session.pendingLiveStream = null
-        restoreDraftIfPristine(text, submittedAttachments)
+        restoreDraftIfPristine(rawText, submittedAttachments, submittedSkillMentions)
         error.value = messageText
         status.value = 'error'
         return
       }
 
-      restoreDraftIfPristine(text, submittedAttachments)
+      restoreDraftIfPristine(rawText, submittedAttachments, submittedSkillMentions)
       error.value = messageText
     }
   } finally {
@@ -2598,6 +2871,47 @@ const respondToPendingRequest = (response: unknown) => {
 }
 
 const onPromptKeydown = (event: KeyboardEvent) => {
+  if (skillAutocompleteOpen.value) {
+    if (event.key === 'ArrowDown') {
+      if (filteredSkillAutocompleteResults.value.length === 0) {
+        return
+      }
+
+      event.preventDefault()
+      moveSkillAutocompleteHighlight(1)
+      return
+    }
+
+    if (event.key === 'ArrowUp') {
+      if (filteredSkillAutocompleteResults.value.length === 0) {
+        return
+      }
+
+      event.preventDefault()
+      moveSkillAutocompleteHighlight(-1)
+      return
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      dismissedSkillAutocompleteMatchKey.value = activeSkillAutocompleteMatchKey.value
+      isPromptFocused.value = true
+      void focusPromptAt(promptSelectionStart.value)
+      return
+    }
+
+    if (event.key === 'Tab') {
+      const skill = highlightedSkillAutocompleteResult.value
+      if (!skill) {
+        return
+      }
+
+      event.preventDefault()
+      void selectSkillAutocompleteResult(skill)
+      return
+    }
+  }
+
   if (fileAutocompleteOpen.value) {
     if (event.key === 'ArrowDown') {
       if (visibleFileAutocompleteResults.value.length === 0) {
@@ -2679,6 +2993,16 @@ const onPromptEnter = (event: KeyboardEvent) => {
     return
   }
 
+  if (skillAutocompleteOpen.value) {
+    event.preventDefault()
+    const skill = highlightedSkillAutocompleteResult.value
+    if (skill) {
+      void selectSkillAutocompleteResult(skill)
+    }
+
+    return
+  }
+
   if (fileAutocompleteOpen.value) {
     event.preventDefault()
     const match = highlightedFileAutocompleteResult.value
@@ -2708,10 +3032,18 @@ const onPromptEnter = (event: KeyboardEvent) => {
 
 onMounted(() => {
   releaseServerRequestHandler = getClient(props.projectId).setServerRequestHandler(handleServerRequest)
+  releaseSkillNotificationSubscription = getClient(props.projectId).subscribe((notification) => {
+    if (notification.method !== 'skills/changed') {
+      return
+    }
+
+    skillAutocompleteInvalidationVersion.value += 1
+  })
   if (!loaded.value) {
     void refreshProjects()
   }
 
+  void getClient(props.projectId).connect().catch(() => {})
   void loadPromptControls()
   void scheduleScrollToBottom('auto')
 })
@@ -2720,6 +3052,8 @@ onBeforeUnmount(() => {
   cancelAllPendingRequests()
   releaseServerRequestHandler?.()
   releaseServerRequestHandler = null
+  releaseSkillNotificationSubscription?.()
+  releaseSkillNotificationSubscription = null
 })
 
 watch(() => props.threadId ?? null, (threadId) => {
@@ -2784,6 +3118,17 @@ watch(filteredSlashCommands, (commands) => {
   }
 }, { flush: 'sync' })
 
+watch(filteredSkillAutocompleteResults, (results) => {
+  if (!results.length) {
+    skillAutocompleteHighlightIndex.value = 0
+    return
+  }
+
+  if (skillAutocompleteHighlightIndex.value >= results.length) {
+    skillAutocompleteHighlightIndex.value = 0
+  }
+}, { flush: 'sync' })
+
 watch(visibleFileAutocompleteResults, (results) => {
   if (!results.length) {
     fileAutocompleteHighlightIndex.value = 0
@@ -2807,6 +3152,18 @@ watch(
   { flush: 'post' }
 )
 
+watch(
+  [skillAutocompleteOpen, skillAutocompleteHighlightIndex, filteredSkillAutocompleteResults],
+  async ([open, highlightIndex, results]) => {
+    if (!open || !results.length || highlightIndex >= results.length) {
+      return
+    }
+
+    await syncSkillAutocompleteScroll()
+  },
+  { flush: 'post' }
+)
+
 watch([selectedModel, availableModels], () => {
   const nextSelection = coercePromptSelection(effectiveModelList.value, selectedModel.value, selectedEffort.value)
   if (selectedModel.value !== nextSelection.model) {
@@ -2819,10 +3176,71 @@ watch([selectedModel, availableModels], () => {
   }
 }, { flush: 'sync' })
 
-watch(input, async () => {
+watch(input, async (nextValue, previousValue) => {
+  if (skipNextSkillMentionSync) {
+    skipNextSkillMentionSync = false
+  } else {
+    insertedSkillMentions.value = reconcileSkillAutocompleteSelections(
+      previousValue,
+      nextValue,
+      insertedSkillMentions.value
+    )
+  }
+
   await nextTick()
   syncPromptSelectionFromDom()
 }, { flush: 'post' })
+
+watch(
+  [skillAutocompleteOpen, () => selectedProject.value?.projectPath ?? null, skillAutocompleteInvalidationVersion],
+  async ([open, projectPath]) => {
+    const requestSequence = ++skillAutocompleteRequestSequence
+
+    if (!open) {
+      skillAutocompleteLoading.value = false
+      skillAutocompleteError.value = null
+      return
+    }
+
+    if (!projectPath) {
+      skillAutocompleteLoading.value = false
+      skillAutocompleteCatalog.value = []
+      skillAutocompleteCatalogCwd.value = null
+      skillAutocompleteCatalogVersion.value = -1
+      skillAutocompleteError.value = null
+      return
+    }
+
+    if (!shouldReloadSkillAutocompleteCatalog(projectPath)) {
+      skillAutocompleteLoading.value = false
+      skillAutocompleteError.value = null
+      return
+    }
+
+    skillAutocompleteLoading.value = true
+    skillAutocompleteError.value = null
+
+    try {
+      await loadSkillAutocompleteCatalog({
+        forceReload: skillAutocompleteCatalogCwd.value === projectPath,
+        projectPath
+      })
+    } catch (caughtError) {
+      if (requestSequence !== skillAutocompleteRequestSequence) {
+        return
+      }
+
+      skillAutocompleteError.value = caughtError instanceof Error
+        ? caughtError.message
+        : 'Failed to load available skills.'
+    } finally {
+      if (requestSequence === skillAutocompleteRequestSequence) {
+        skillAutocompleteLoading.value = false
+      }
+    }
+  },
+  { flush: 'post' }
+)
 
 watch(
   [fileAutocompleteOpen, normalizedFileAutocompleteQuery, () => selectedProject.value?.projectPath ?? null],
@@ -3047,6 +3465,64 @@ watch(
                   >
                     {{ segment.text }}
                   </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div
+            v-if="skillAutocompleteOpen"
+            ref="skillAutocompleteDropdownRef"
+            role="listbox"
+            aria-label="Skills"
+            class="absolute bottom-full left-0 z-20 mb-2 w-[90vw] max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-default bg-default/95 shadow-2xl backdrop-blur md:w-[min(50vw,52rem)] md:max-w-[min(50vw,52rem)]"
+            @pointerdown="handleSkillAutocompletePointerDown"
+          >
+            <div
+              ref="skillAutocompleteListRef"
+              class="max-h-72 overflow-y-auto p-2"
+            >
+              <div
+                v-if="skillAutocompleteEmptyState"
+                class="px-3 py-2 text-sm leading-6 text-muted"
+              >
+                {{ skillAutocompleteEmptyState }}
+              </div>
+              <div
+                v-for="(skill, index) in filteredSkillAutocompleteResults"
+                v-else
+                :key="`${skill.scope}:${skill.path}`"
+                role="option"
+                :aria-selected="index === skillAutocompleteHighlightIndex"
+                data-skill-autocomplete-option=""
+                class="group relative flex cursor-pointer items-start gap-2 px-3 py-2.5 text-sm text-highlighted outline-none transition-colors before:absolute before:inset-px before:z-[-1] before:rounded-md"
+                :class="index === skillAutocompleteHighlightIndex
+                  ? 'before:bg-elevated'
+                  : 'hover:before:bg-elevated/60'"
+                @click="void selectSkillAutocompleteResult(skill)"
+              >
+                <UIcon
+                  name="i-lucide-badge-plus"
+                  class="mt-0.5 size-4 shrink-0 text-dimmed group-aria-selected:text-highlighted"
+                />
+                <div class="min-w-0 flex-1">
+                  <div class="flex min-w-0 items-center gap-2">
+                    <span class="truncate font-mono text-[13px] leading-6">
+                      ${{ skill.name }}
+                    </span>
+                    <span
+                      v-if="skill.displayName && skill.displayName !== skill.name"
+                      class="truncate text-xs text-toned"
+                    >
+                      {{ skill.displayName }}
+                    </span>
+                  </div>
+                  <div class="truncate text-xs leading-5 text-toned">
+                    {{ resolveSkillAutocompleteDescription(skill) }}
+                  </div>
+                  <div class="truncate font-mono text-[11px] leading-5 text-muted">
+                    {{ skill.scope }} · {{ skill.path }}
+                  </div>
                 </div>
               </div>
             </div>

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -1099,6 +1099,57 @@ const completeSlashCommand = async (command: SlashCommandDefinition) => {
 const resolveSkillAutocompleteDescription = (skill: SkillAutocompleteEntry) =>
   skill.shortDescription ?? skill.description
 
+const resolveSkillAutocompleteIcon = (skill: SkillAutocompleteEntry) => {
+  const haystack = [
+    skill.name,
+    skill.displayName,
+    skill.shortDescription,
+    skill.description,
+    skill.path
+  ]
+    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+    .join(' ')
+    .toLowerCase()
+
+  if (haystack.includes('github') || haystack.includes('gh-') || haystack.includes(' ci ') || haystack.includes('actions')) {
+    return 'i-lucide-github'
+  }
+
+  if (haystack.includes('image') || haystack.includes('figma') || haystack.includes('bitmap')) {
+    return 'i-lucide-image'
+  }
+
+  if (haystack.includes('calendar') || haystack.includes('schedule')) {
+    return 'i-lucide-calendar'
+  }
+
+  if (haystack.includes('gmail') || haystack.includes('email') || haystack.includes('mailbox')) {
+    return 'i-lucide-mail'
+  }
+
+  if (haystack.includes('slack')) {
+    return 'i-lucide-message-square'
+  }
+
+  if (haystack.includes('excel') || haystack.includes('sheet') || haystack.includes('csv') || haystack.includes('spreadsheet')) {
+    return 'i-lucide-table-properties'
+  }
+
+  if (haystack.includes('powerpoint') || haystack.includes('slide') || haystack.includes('presentation') || haystack.includes('canva')) {
+    return 'i-lucide-presentation'
+  }
+
+  if (haystack.includes('cloudflare') || haystack.includes('worker')) {
+    return 'i-lucide-cloud'
+  }
+
+  if (haystack.includes('plugin')) {
+    return 'i-lucide-plug'
+  }
+
+  return 'i-lucide-badge-plus'
+}
+
 const selectSkillAutocompleteResult = async (skill: SkillAutocompleteEntry) => {
   const activeMatch = activeSkillAutocompleteMatch.value
   if (!activeMatch) {
@@ -3475,7 +3526,7 @@ watch(
             ref="skillAutocompleteDropdownRef"
             role="listbox"
             aria-label="Skills"
-            class="absolute bottom-full left-0 z-20 mb-2 w-[90vw] max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-default bg-default/95 shadow-2xl backdrop-blur md:w-[min(50vw,52rem)] md:max-w-[min(50vw,52rem)]"
+            class="absolute bottom-full left-0 z-20 mb-2 w-full overflow-hidden rounded-lg border border-default bg-default/95 shadow-2xl backdrop-blur"
             @pointerdown="handleSkillAutocompletePointerDown"
           >
             <div
@@ -3502,12 +3553,12 @@ watch(
                 @click="void selectSkillAutocompleteResult(skill)"
               >
                 <UIcon
-                  name="i-lucide-badge-plus"
+                  :name="resolveSkillAutocompleteIcon(skill)"
                   class="size-4 shrink-0 text-dimmed group-aria-selected:text-highlighted"
                 />
                 <div class="min-w-0 flex flex-1 items-center gap-2">
                   <span class="shrink-0 font-mono text-[13px] leading-6">
-                    ${{ skill.name }}
+                    {{ skill.name }}
                   </span>
                   <span class="min-w-0 truncate text-xs text-muted">
                     {{ resolveSkillAutocompleteDescription(skill) }}

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -1099,6 +1099,9 @@ const completeSlashCommand = async (command: SlashCommandDefinition) => {
 const resolveSkillAutocompleteDescription = (skill: SkillAutocompleteEntry) =>
   skill.shortDescription ?? skill.description
 
+const resolveSkillAutocompleteLabel = (skill: SkillAutocompleteEntry) =>
+  skill.displayName?.trim() || skill.name
+
 const resolveSkillAutocompleteIcon = (skill: SkillAutocompleteEntry) => {
   const haystack = [
     skill.name,
@@ -3569,7 +3572,7 @@ watch(
                 />
                 <div class="min-w-0 flex flex-1 items-center gap-2">
                   <span class="shrink-0 font-mono text-[13px] leading-6">
-                    {{ skill.name }}
+                    {{ resolveSkillAutocompleteLabel(skill) }}
                   </span>
                   <span class="min-w-0 truncate text-xs text-muted">
                     {{ resolveSkillAutocompleteDescription(skill) }}

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -3495,7 +3495,7 @@ watch(
                 role="option"
                 :aria-selected="index === skillAutocompleteHighlightIndex"
                 data-skill-autocomplete-option=""
-                class="group relative flex cursor-pointer items-start gap-2 px-3 py-2.5 text-sm text-highlighted outline-none transition-colors before:absolute before:inset-px before:z-[-1] before:rounded-md"
+                class="group relative flex cursor-pointer items-center gap-2 px-3 py-2 text-sm text-highlighted outline-none transition-colors before:absolute before:inset-px before:z-[-1] before:rounded-md"
                 :class="index === skillAutocompleteHighlightIndex
                   ? 'before:bg-elevated'
                   : 'hover:before:bg-elevated/60'"
@@ -3503,26 +3503,18 @@ watch(
               >
                 <UIcon
                   name="i-lucide-badge-plus"
-                  class="mt-0.5 size-4 shrink-0 text-dimmed group-aria-selected:text-highlighted"
+                  class="size-4 shrink-0 text-dimmed group-aria-selected:text-highlighted"
                 />
-                <div class="min-w-0 flex-1">
-                  <div class="flex min-w-0 items-center gap-2">
-                    <span class="truncate font-mono text-[13px] leading-6">
-                      ${{ skill.name }}
-                    </span>
-                    <span
-                      v-if="skill.displayName && skill.displayName !== skill.name"
-                      class="truncate text-xs text-toned"
-                    >
-                      {{ skill.displayName }}
-                    </span>
-                  </div>
-                  <div class="truncate text-xs leading-5 text-toned">
+                <div class="min-w-0 flex flex-1 items-center gap-2">
+                  <span class="shrink-0 font-mono text-[13px] leading-6">
+                    ${{ skill.name }}
+                  </span>
+                  <span class="min-w-0 truncate text-xs text-muted">
                     {{ resolveSkillAutocompleteDescription(skill) }}
-                  </div>
-                  <div class="truncate font-mono text-[11px] leading-5 text-muted">
-                    {{ skill.scope }} · {{ skill.path }}
-                  </div>
+                  </span>
+                </div>
+                <div class="shrink-0 text-[11px] uppercase tracking-[0.12em] text-muted">
+                  {{ skill.scope }}
                 </div>
               </div>
             </div>

--- a/packages/client/shared/skill-autocomplete.ts
+++ b/packages/client/shared/skill-autocomplete.ts
@@ -232,12 +232,63 @@ export const hasSkillAutocompleteMentions = (input: string) => {
   return SUBMITTED_SKILL_MENTION_PATTERN.test(input)
 }
 
+const getSubsequenceMatchScore = (candidate: string, query: string) => {
+  if (!query) {
+    return 0
+  }
+
+  const prefixIndex = candidate.indexOf(query)
+  if (prefixIndex === 0) {
+    return 400 - Math.max(0, candidate.length - query.length)
+  }
+
+  if (prefixIndex > 0) {
+    return 300 - prefixIndex
+  }
+
+  let previousIndex = -1
+  let gapPenalty = 0
+  let startIndex = -1
+
+  for (const character of query) {
+    const nextIndex = candidate.indexOf(character, previousIndex + 1)
+    if (nextIndex === -1) {
+      return null
+    }
+
+    if (startIndex === -1) {
+      startIndex = nextIndex
+    } else {
+      gapPenalty += Math.max(0, nextIndex - previousIndex - 1)
+    }
+
+    previousIndex = nextIndex
+  }
+
+  return 200 - startIndex - gapPenalty
+}
+
+const resolveSkillAutocompleteScore = (
+  entry: SkillAutocompleteEntry,
+  normalizedQuery: string
+) => {
+  const nameScore = getSubsequenceMatchScore(entry.name.toLowerCase(), normalizedQuery)
+  const displayNameScore = entry.displayName
+    ? getSubsequenceMatchScore(entry.displayName.toLowerCase(), normalizedQuery)
+    : null
+
+  return Math.max(
+    nameScore == null ? Number.NEGATIVE_INFINITY : nameScore + 25,
+    displayNameScore ?? Number.NEGATIVE_INFINITY
+  )
+}
+
 export const filterSkillAutocompleteEntries = (
   entries: SkillAutocompleteEntry[],
   query: string
 ) => {
   const normalizedQuery = query.trim().toLowerCase()
-  return entries.filter((entry) => {
+  const filteredEntries = entries.filter((entry) => {
     if (!entry.enabled) {
       return false
     }
@@ -246,8 +297,21 @@ export const filterSkillAutocompleteEntries = (
       return true
     }
 
-    return entry.name.toLowerCase().startsWith(normalizedQuery)
-      || entry.displayName?.toLowerCase().startsWith(normalizedQuery)
+    return resolveSkillAutocompleteScore(entry, normalizedQuery) > Number.NEGATIVE_INFINITY
+  })
+
+  if (!normalizedQuery) {
+    return filteredEntries
+  }
+
+  return filteredEntries.sort((left, right) => {
+    const scoreDelta = resolveSkillAutocompleteScore(right, normalizedQuery)
+      - resolveSkillAutocompleteScore(left, normalizedQuery)
+    if (scoreDelta !== 0) {
+      return scoreDelta
+    }
+
+    return left.name.localeCompare(right.name)
   })
 }
 

--- a/packages/client/shared/skill-autocomplete.ts
+++ b/packages/client/shared/skill-autocomplete.ts
@@ -1,0 +1,386 @@
+export type ActiveSkillAutocompleteMatch = {
+  start: number
+  end: number
+  raw: string
+  query: string
+}
+
+export type SkillAutocompleteScope = 'user' | 'repo' | 'system' | 'admin'
+
+export type SkillAutocompleteEntry = {
+  name: string
+  description: string
+  enabled: boolean
+  path: string
+  scope: SkillAutocompleteScope
+  shortDescription: string | null
+  displayName: string | null
+  brandColor: string | null
+  iconSmall: string | null
+  iconLarge: string | null
+}
+
+export type SkillAutocompleteError = {
+  message: string
+  path: string
+}
+
+export type SkillsListEntry = {
+  cwd: string
+  errors: SkillAutocompleteError[]
+  skills: SkillAutocompleteEntry[]
+}
+
+export type SkillAutocompleteSelection = {
+  start: number
+  end: number
+  name: string
+  path: string
+}
+
+export type SkillAutocompleteReplacement = {
+  value: string
+  caret: number
+  tokenStart: number
+  tokenEnd: number
+}
+
+const SKILL_SCOPE_VALUES = new Set<SkillAutocompleteScope>(['user', 'repo', 'system', 'admin'])
+const SKILL_TOKEN_PATTERN = /^[a-z0-9][a-z0-9:._/-]*$/i
+const SUBMITTED_SKILL_MENTION_PATTERN = /(^|\s)(\$([a-z0-9][a-z0-9:._/-]*))/gi
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object'
+  && value !== null
+  && !Array.isArray(value)
+
+const normalizeNullableString = (value: unknown) =>
+  typeof value === 'string' ? value : null
+
+const normalizeSkillInterface = (value: unknown) => {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  return {
+    brandColor: normalizeNullableString(value.brandColor),
+    displayName: normalizeNullableString(value.displayName),
+    iconLarge: normalizeNullableString(value.iconLarge),
+    iconSmall: normalizeNullableString(value.iconSmall),
+    shortDescription: normalizeNullableString(value.shortDescription)
+  }
+}
+
+const normalizeSkillAutocompleteEntry = (value: unknown): SkillAutocompleteEntry | null => {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const name = value.name
+  const description = value.description
+  const enabled = value.enabled
+  const path = value.path
+  const scope = value.scope
+  if (
+    typeof name !== 'string'
+    || typeof description !== 'string'
+    || typeof enabled !== 'boolean'
+    || typeof path !== 'string'
+    || !SKILL_SCOPE_VALUES.has(scope as SkillAutocompleteScope)
+  ) {
+    return null
+  }
+
+  const skillInterface = normalizeSkillInterface(value.interface)
+  return {
+    name,
+    description,
+    enabled,
+    path,
+    scope: scope as SkillAutocompleteScope,
+    shortDescription: normalizeNullableString(value.shortDescription) ?? skillInterface?.shortDescription ?? null,
+    displayName: skillInterface?.displayName ?? null,
+    brandColor: skillInterface?.brandColor ?? null,
+    iconSmall: skillInterface?.iconSmall ?? null,
+    iconLarge: skillInterface?.iconLarge ?? null
+  }
+}
+
+const normalizeSkillAutocompleteError = (value: unknown): SkillAutocompleteError | null => {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const message = value.message
+  const path = value.path
+  if (typeof message !== 'string' || typeof path !== 'string') {
+    return null
+  }
+
+  return {
+    message,
+    path
+  }
+}
+
+const normalizeSkillsListEntry = (value: unknown): SkillsListEntry | null => {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const cwd = value.cwd
+  if (typeof cwd !== 'string') {
+    return null
+  }
+
+  const skills = Array.isArray(value.skills)
+    ? value.skills
+      .map(normalizeSkillAutocompleteEntry)
+      .filter((entry): entry is SkillAutocompleteEntry => entry !== null)
+    : []
+
+  const errors = Array.isArray(value.errors)
+    ? value.errors
+      .map(normalizeSkillAutocompleteError)
+      .filter((entry): entry is SkillAutocompleteError => entry !== null)
+    : []
+
+  return {
+    cwd,
+    errors,
+    skills
+  }
+}
+
+const buildUniqueSkillPathMap = (skills: SkillAutocompleteEntry[]) => {
+  const nextPaths = new Map<string, string | null>()
+
+  for (const skill of skills) {
+    if (!skill.enabled) {
+      continue
+    }
+
+    const key = skill.name.toLowerCase()
+    const existing = nextPaths.get(key)
+    if (existing == null && nextPaths.has(key)) {
+      continue
+    }
+
+    if (!nextPaths.has(key)) {
+      nextPaths.set(key, skill.path)
+      continue
+    }
+
+    if (existing !== skill.path) {
+      nextPaths.set(key, null)
+    }
+  }
+
+  return nextPaths
+}
+
+export const normalizeSkillsListResponse = (value: unknown): SkillsListEntry[] => {
+  if (!isRecord(value) || !Array.isArray(value.data)) {
+    return []
+  }
+
+  return value.data
+    .map(normalizeSkillsListEntry)
+    .filter((entry): entry is SkillsListEntry => entry !== null)
+}
+
+export const findActiveSkillAutocompleteMatch = (
+  input: string,
+  selectionStart: number | null | undefined,
+  selectionEnd: number | null | undefined
+): ActiveSkillAutocompleteMatch | null => {
+  if (selectionStart == null || selectionEnd == null || selectionStart !== selectionEnd) {
+    return null
+  }
+
+  const caret = selectionStart
+  let start = caret
+  while (start > 0 && !/\s/u.test(input[start - 1] ?? '')) {
+    start -= 1
+  }
+
+  let end = caret
+  while (end < input.length && !/\s/u.test(input[end] ?? '')) {
+    end += 1
+  }
+
+  const raw = input.slice(start, end)
+  if (!raw.startsWith('$')) {
+    return null
+  }
+
+  const query = raw.slice(1)
+  if (query && !SKILL_TOKEN_PATTERN.test(query)) {
+    return null
+  }
+
+  return {
+    start,
+    end,
+    raw,
+    query
+  }
+}
+
+export const hasSkillAutocompleteMentions = (input: string) => {
+  SUBMITTED_SKILL_MENTION_PATTERN.lastIndex = 0
+  return SUBMITTED_SKILL_MENTION_PATTERN.test(input)
+}
+
+export const filterSkillAutocompleteEntries = (
+  entries: SkillAutocompleteEntry[],
+  query: string
+) => {
+  const normalizedQuery = query.trim().toLowerCase()
+  return entries.filter((entry) => {
+    if (!entry.enabled) {
+      return false
+    }
+
+    if (!normalizedQuery) {
+      return true
+    }
+
+    return entry.name.toLowerCase().startsWith(normalizedQuery)
+      || entry.displayName?.toLowerCase().startsWith(normalizedQuery)
+  })
+}
+
+export const toSkillAutocompleteCompletion = (entry: Pick<SkillAutocompleteEntry, 'name'>) =>
+  `$${entry.name}`
+
+export const replaceActiveSkillAutocompleteMatch = (
+  input: string,
+  match: Pick<ActiveSkillAutocompleteMatch, 'start' | 'end'>,
+  replacement: string
+): SkillAutocompleteReplacement => {
+  const suffix = input.slice(match.end)
+  const trailingSpace = suffix.length === 0 || !/^\s/u.test(suffix) ? ' ' : ''
+  const value = `${input.slice(0, match.start)}${replacement}${trailingSpace}${suffix}`
+
+  return {
+    value,
+    caret: match.start + replacement.length + trailingSpace.length,
+    tokenStart: match.start,
+    tokenEnd: match.start + replacement.length
+  }
+}
+
+export const reconcileSkillAutocompleteSelections = (
+  previousInput: string,
+  nextInput: string,
+  selections: SkillAutocompleteSelection[]
+) => {
+  if (!selections.length || previousInput === nextInput) {
+    return selections
+  }
+
+  let prefixLength = 0
+  const prefixLimit = Math.min(previousInput.length, nextInput.length)
+  while (
+    prefixLength < prefixLimit
+    && previousInput[prefixLength] === nextInput[prefixLength]
+  ) {
+    prefixLength += 1
+  }
+
+  let suffixLength = 0
+  const previousRemainder = previousInput.length - prefixLength
+  const nextRemainder = nextInput.length - prefixLength
+  while (
+    suffixLength < previousRemainder
+    && suffixLength < nextRemainder
+    && previousInput[previousInput.length - 1 - suffixLength] === nextInput[nextInput.length - 1 - suffixLength]
+  ) {
+    suffixLength += 1
+  }
+
+  const previousChangedEnd = previousInput.length - suffixLength
+  const nextChangedEnd = nextInput.length - suffixLength
+  const delta = nextChangedEnd - previousChangedEnd
+
+  return selections
+    .flatMap((selection) => {
+      if (selection.end <= prefixLength) {
+        return [selection]
+      }
+
+      if (selection.start >= previousChangedEnd) {
+        const shiftedSelection = {
+          ...selection,
+          start: selection.start + delta,
+          end: selection.end + delta
+        }
+        return nextInput.slice(shiftedSelection.start, shiftedSelection.end) === `$${shiftedSelection.name}`
+          ? [shiftedSelection]
+          : []
+      }
+
+      return []
+    })
+    .sort((left, right) => left.start - right.start)
+}
+
+export const toSkillMarkdownLink = (input: {
+  token: string
+  path: string
+}) => `[${input.token}](${encodeURI(input.path)})`
+
+const replaceSelectedSkillMentionsWithMarkdownLinks = (
+  input: string,
+  selections: SkillAutocompleteSelection[]
+) => {
+  if (!selections.length) {
+    return input
+  }
+
+  let nextValue = input
+  const orderedSelections = [...selections].sort((left, right) => right.start - left.start)
+  for (const selection of orderedSelections) {
+    const token = nextValue.slice(selection.start, selection.end)
+    if (token !== `$${selection.name}`) {
+      continue
+    }
+
+    nextValue = `${nextValue.slice(0, selection.start)}${toSkillMarkdownLink({
+      token,
+      path: selection.path
+    })}${nextValue.slice(selection.end)}`
+  }
+
+  return nextValue
+}
+
+const replaceUniqueSkillMentionsWithMarkdownLinks = (
+  input: string,
+  skills: SkillAutocompleteEntry[]
+) => {
+  const uniquePaths = buildUniqueSkillPathMap(skills)
+  SUBMITTED_SKILL_MENTION_PATTERN.lastIndex = 0
+
+  return input.replace(SUBMITTED_SKILL_MENTION_PATTERN, (match, prefix: string, token: string, name: string) => {
+    const path = uniquePaths.get(String(name).toLowerCase())
+    if (!path) {
+      return match
+    }
+
+    return `${prefix}${toSkillMarkdownLink({
+      token,
+      path
+    })}`
+  })
+}
+
+export const preprocessSkillMentionsForSubmission = (
+  input: string,
+  selections: SkillAutocompleteSelection[],
+  skills: SkillAutocompleteEntry[]
+) => {
+  const withSelectedMentions = replaceSelectedSkillMentionsWithMarkdownLinks(input, selections)
+  return replaceUniqueSkillMentionsWithMarkdownLinks(withSelectedMentions, skills)
+}

--- a/packages/client/test/skill-autocomplete.test.ts
+++ b/packages/client/test/skill-autocomplete.test.ts
@@ -35,6 +35,17 @@ const TEST_SKILLS: SkillAutocompleteEntry[] = [{
   iconSmall: null,
   iconLarge: null
 }, {
+  name: 'gh-fix-ci',
+  description: 'Fix failing Github CI actions.',
+  enabled: true,
+  path: '/Users/demo/.codex/skills/gh-fix-ci/SKILL.md',
+  scope: 'user',
+  shortDescription: 'Fix failing Github CI actions',
+  displayName: null,
+  brandColor: null,
+  iconSmall: null,
+  iconLarge: null
+}, {
   name: 'duplicate',
   description: 'Repo-scoped duplicate',
   enabled: true,
@@ -120,10 +131,13 @@ describe('skill autocomplete helpers', () => {
     expect(filterSkillAutocompleteEntries(TEST_SKILLS, '').map(entry => entry.name)).toEqual([
       'imagegen',
       'linear',
+      'gh-fix-ci',
       'duplicate',
       'duplicate'
     ])
     expect(filterSkillAutocompleteEntries(TEST_SKILLS, 'im').map(entry => entry.name)).toEqual(['imagegen'])
+    expect(filterSkillAutocompleteEntries(TEST_SKILLS, 'fi').map(entry => entry.name)).toContain('gh-fix-ci')
+    expect(filterSkillAutocompleteEntries(TEST_SKILLS, 'FI').map(entry => entry.name)).toContain('gh-fix-ci')
     expect(toSkillAutocompleteCompletion(TEST_SKILLS[0]!)).toBe('$imagegen')
   })
 

--- a/packages/client/test/skill-autocomplete.test.ts
+++ b/packages/client/test/skill-autocomplete.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest'
+import {
+  filterSkillAutocompleteEntries,
+  findActiveSkillAutocompleteMatch,
+  hasSkillAutocompleteMentions,
+  normalizeSkillsListResponse,
+  preprocessSkillMentionsForSubmission,
+  reconcileSkillAutocompleteSelections,
+  replaceActiveSkillAutocompleteMatch,
+  toSkillAutocompleteCompletion,
+  type SkillAutocompleteEntry,
+  type SkillAutocompleteSelection
+} from '../shared/skill-autocomplete'
+
+const TEST_SKILLS: SkillAutocompleteEntry[] = [{
+  name: 'imagegen',
+  description: 'Generate or edit raster images.',
+  enabled: true,
+  path: '/Users/demo/.codex/skills/.system/imagegen/SKILL.md',
+  scope: 'system',
+  shortDescription: 'Create or edit bitmap assets.',
+  displayName: 'Image Generator',
+  brandColor: null,
+  iconSmall: null,
+  iconLarge: null
+}, {
+  name: 'linear',
+  description: 'Inspect and update Linear issues.',
+  enabled: true,
+  path: '/Users/demo/.codex/skills/linear/SKILL.md',
+  scope: 'user',
+  shortDescription: null,
+  displayName: null,
+  brandColor: null,
+  iconSmall: null,
+  iconLarge: null
+}, {
+  name: 'duplicate',
+  description: 'Repo-scoped duplicate',
+  enabled: true,
+  path: '/Users/demo/project/.agents/skills/duplicate/SKILL.md',
+  scope: 'repo',
+  shortDescription: null,
+  displayName: null,
+  brandColor: null,
+  iconSmall: null,
+  iconLarge: null
+}, {
+  name: 'duplicate',
+  description: 'User-scoped duplicate',
+  enabled: true,
+  path: '/Users/demo/.codex/skills/duplicate/SKILL.md',
+  scope: 'user',
+  shortDescription: null,
+  displayName: null,
+  brandColor: null,
+  iconSmall: null,
+  iconLarge: null
+}]
+
+describe('skill autocomplete helpers', () => {
+  it('detects the active $skill token at the caret', () => {
+    expect(findActiveSkillAutocompleteMatch('$imagegen', 9, 9)).toEqual({
+      start: 0,
+      end: 9,
+      raw: '$imagegen',
+      query: 'imagegen'
+    })
+
+    expect(findActiveSkillAutocompleteMatch('Use $lin', 8, 8)).toEqual({
+      start: 4,
+      end: 8,
+      raw: '$lin',
+      query: 'lin'
+    })
+
+    expect(findActiveSkillAutocompleteMatch('Check $linear!', 14, 14)).toBeNull()
+  })
+
+  it('normalizes skills/list responses and filters skills by prefix', () => {
+    expect(normalizeSkillsListResponse({
+      data: [{
+        cwd: '/Users/demo/project',
+        errors: [{
+          path: '/Users/demo/project/.agents/skills/bad/SKILL.md',
+          message: 'Invalid frontmatter'
+        }],
+        skills: [{
+          name: 'imagegen',
+          description: 'Generate or edit raster images.',
+          enabled: true,
+          path: '/Users/demo/.codex/skills/.system/imagegen/SKILL.md',
+          scope: 'system',
+          shortDescription: 'Create or edit bitmap assets.',
+          interface: {
+            displayName: 'Image Generator'
+          }
+        }]
+      }]
+    })).toEqual([{
+      cwd: '/Users/demo/project',
+      errors: [{
+        path: '/Users/demo/project/.agents/skills/bad/SKILL.md',
+        message: 'Invalid frontmatter'
+      }],
+      skills: [{
+        name: 'imagegen',
+        description: 'Generate or edit raster images.',
+        enabled: true,
+        path: '/Users/demo/.codex/skills/.system/imagegen/SKILL.md',
+        scope: 'system',
+        shortDescription: 'Create or edit bitmap assets.',
+        displayName: 'Image Generator',
+        brandColor: null,
+        iconSmall: null,
+        iconLarge: null
+      }]
+    }])
+
+    expect(filterSkillAutocompleteEntries(TEST_SKILLS, '').map(entry => entry.name)).toEqual([
+      'imagegen',
+      'linear',
+      'duplicate',
+      'duplicate'
+    ])
+    expect(filterSkillAutocompleteEntries(TEST_SKILLS, 'im').map(entry => entry.name)).toEqual(['imagegen'])
+    expect(toSkillAutocompleteCompletion(TEST_SKILLS[0]!)).toBe('$imagegen')
+  })
+
+  it('replaces the active token and inserts one trailing space for follow-up typing', () => {
+    expect(replaceActiveSkillAutocompleteMatch(
+      'Use $imag please',
+      {
+        start: 4,
+        end: 9
+      },
+      '$imagegen'
+    )).toEqual({
+      value: 'Use $imagegen please',
+      caret: 13,
+      tokenStart: 4,
+      tokenEnd: 13
+    })
+
+    expect(replaceActiveSkillAutocompleteMatch(
+      '$linear',
+      {
+        start: 0,
+        end: 7
+      },
+      '$linear'
+    )).toEqual({
+      value: '$linear ',
+      caret: 8,
+      tokenStart: 0,
+      tokenEnd: 7
+    })
+  })
+
+  it('shifts or invalidates tracked selections as the draft changes', () => {
+    const selections: SkillAutocompleteSelection[] = [{
+      start: 4,
+      end: 13,
+      name: 'imagegen',
+      path: '/Users/demo/.codex/skills/.system/imagegen/SKILL.md'
+    }]
+
+    expect(reconcileSkillAutocompleteSelections(
+      'Use $imagegen ',
+      'Please use $imagegen ',
+      selections
+    )).toEqual([{
+      start: 11,
+      end: 20,
+      name: 'imagegen',
+      path: '/Users/demo/.codex/skills/.system/imagegen/SKILL.md'
+    }])
+
+    expect(reconcileSkillAutocompleteSelections(
+      'Use $imagegen ',
+      'Use $image ',
+      selections
+    )).toEqual([])
+  })
+
+  it('preprocesses tracked selections first and falls back to unique skill names', () => {
+    const selections: SkillAutocompleteSelection[] = [{
+      start: 19,
+      end: 29,
+      name: 'duplicate',
+      path: '/Users/demo/project/.agents/skills/duplicate/SKILL.md'
+    }]
+
+    expect(hasSkillAutocompleteMentions('Use $imagegen with $duplicate')).toBe(true)
+    expect(hasSkillAutocompleteMentions('No skills here')).toBe(false)
+
+    expect(preprocessSkillMentionsForSubmission(
+      'Use $imagegen with $duplicate',
+      selections,
+      TEST_SKILLS
+    )).toBe(
+      'Use [$imagegen](/Users/demo/.codex/skills/.system/imagegen/SKILL.md) with [$duplicate](/Users/demo/project/.agents/skills/duplicate/SKILL.md)'
+    )
+
+    expect(preprocessSkillMentionsForSubmission(
+      'Keep $duplicate raw when unresolved',
+      [],
+      TEST_SKILLS
+    )).toBe('Keep $duplicate raw when unresolved')
+  })
+})


### PR DESCRIPTION
## Summary
- add `$` skill autocomplete helpers and submit-time SKILL.md link preprocessing
- implement skill autocomplete popup behavior in the chat composer with live `skills/list` loading and `skills/changed` invalidation
- improve skill matching to be case-insensitive fuzzy matching and simplify the skill palette presentation
- address review feedback for CI icon matching and stale `skills/list` response handling

## Testing
- `pnpm --filter @codori/client test -- --runInBand packages/client/test/skill-autocomplete.test.ts packages/client/test/slash-commands.test.ts packages/client/test/file-autocomplete.test.ts`
- `pnpm --filter @codori/client test -- --runInBand packages/client/test/skill-autocomplete.test.ts`
- `pnpm --filter @codori/client typecheck`

## Notes
- Part of #5
