### PR TITLE
Add sticky task list UI for plan updates

### DIFF
--- a/packages/client/app/app.vue
+++ b/packages/client/app/app.vue
@@ -1,3 +1,35 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted } from 'vue'
+
+let visualViewportRef: VisualViewport | null = null
+
+const setViewportHeightCssVar = () => {
+  if (!import.meta.client) {
+    return
+  }
+
+  const nextHeight = window.visualViewport?.height ?? window.innerHeight
+  document.documentElement.style.setProperty('--app-viewport-height', `${Math.round(nextHeight)}px`)
+}
+
+onMounted(() => {
+  setViewportHeightCssVar()
+
+  visualViewportRef = window.visualViewport
+  visualViewportRef?.addEventListener('resize', setViewportHeightCssVar)
+  visualViewportRef?.addEventListener('scroll', setViewportHeightCssVar)
+  window.addEventListener('resize', setViewportHeightCssVar)
+  window.addEventListener('orientationchange', setViewportHeightCssVar)
+})
+
+onBeforeUnmount(() => {
+  visualViewportRef?.removeEventListener('resize', setViewportHeightCssVar)
+  visualViewportRef?.removeEventListener('scroll', setViewportHeightCssVar)
+  window.removeEventListener('resize', setViewportHeightCssVar)
+  window.removeEventListener('orientationchange', setViewportHeightCssVar)
+})
+</script>
+
 <template>
   <UApp>
     <NuxtLayout>

--- a/packages/client/app/assets/css/main.css
+++ b/packages/client/app/assets/css/main.css
@@ -2,6 +2,10 @@
 @import "@nuxt/ui";
 @import "katex/dist/katex.min.css";
 
+:root {
+  --app-viewport-height: 100dvh;
+}
+
 html,
 body,
 #__nuxt {
@@ -10,6 +14,14 @@ body,
 
 body {
   margin: 0;
+}
+
+.app-shell-min-height {
+  min-height: var(--app-viewport-height, 100dvh);
+}
+
+.app-shell-height {
+  height: var(--app-viewport-height, 100dvh);
 }
 
 .cd-markdown {

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -4104,7 +4104,7 @@ watch(
 
     <div
       ref="stickyFooterRef"
-      class="sticky bottom-0 shrink-0 px-4 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] pt-10 md:px-6 md:pt-8"
+      class="sticky bottom-0 shrink-0 px-4 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] pt-2 md:px-6 md:pt-2"
     >
       <div class="pointer-events-none absolute inset-x-0 inset-y-0 bg-gradient-to-b from-transparent via-default/88 to-default" />
 
@@ -4343,6 +4343,10 @@ watch(
             :placeholder="composerPlaceholder"
             :error="submitError"
             :disabled="isComposerDisabled"
+            :ui="{
+              root: 'px-2.5 pt-1 pb-2',
+              base: 'px-2.5 pt-1 pb-1.5'
+            }"
             autoresize
             @submit.prevent="sendMessage"
             @keydown.enter.exact.capture="onPromptEnterCapture"
@@ -4358,9 +4362,11 @@ watch(
             @compositionend="onCompositionEnd"
             @paste="onPaste"
           >
-            <template #header>
+            <template
+              v-if="attachments.length"
+              #header
+            >
               <div
-                v-if="attachments.length"
                 class="flex flex-wrap gap-2 pb-2"
               >
                 <div

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -145,7 +145,8 @@ import {
 } from '~~/shared/subagent-panels'
 import {
   applyTurnPlanUpdate,
-  normalizeTurnPlanUpdate
+  normalizeTurnPlanUpdate,
+  shouldResetThreadPlanState
 } from '~~/shared/turn-plan'
 
 const props = defineProps<{
@@ -1858,6 +1859,16 @@ const setThreadPlanPanelOpen = (open: boolean) => {
   }
 }
 
+const clearThreadPlanState = (threadId: string) => {
+  if (!(threadId in threadPlans.value)) {
+    return
+  }
+
+  const nextThreadPlans = { ...threadPlans.value }
+  delete nextThreadPlans[threadId]
+  threadPlans.value = nextThreadPlans
+}
+
 const handleSlashCommandSubmission = async (
   rawText: string,
   submittedAttachments: DraftAttachment[]
@@ -2984,12 +2995,17 @@ const applyNotification = (notification: CodexRpcNotification) => {
       return
     }
     case 'turn/started': {
+      const threadId = notificationThreadId(notification) ?? currentLiveStream()?.threadId ?? activeThreadId.value
       const nextTurnId = notificationTurnId(notification)
       if (liveStream && !shouldAdvanceLiveStreamTurn({
         lockedTurnId: liveStream.lockedTurnId,
         nextTurnId
       })) {
         return
+      }
+
+      if (threadId && shouldResetThreadPlanState(threadPlans.value[threadId], nextTurnId)) {
+        clearThreadPlanState(threadId)
       }
 
       if (liveStream) {
@@ -3678,7 +3694,9 @@ onMounted(() => {
 
   if (import.meta.client) {
     footerResizeObserver = new ResizeObserver((entries) => {
-      const nextHeight = entries[0]?.contentRect.height
+      const entry = entries[0]
+      const borderBoxSize = entry?.borderBoxSize[0]?.blockSize
+      const nextHeight = borderBoxSize ?? entry?.target.getBoundingClientRect().height
       if (typeof nextHeight === 'number' && Number.isFinite(nextHeight)) {
         stickyFooterHeight.value = Math.ceil(nextHeight)
       }

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -10,6 +10,7 @@ import {
 } from 'vue'
 import LocalFileViewerModal from './LocalFileViewerModal.vue'
 import MessageContent from './MessageContent.vue'
+import PlanTaskListPanel from './PlanTaskListPanel.vue'
 import ReviewStartDrawer from './ReviewStartDrawer.vue'
 import PendingUserRequestDrawer from './PendingUserRequestDrawer.vue'
 import UsageStatusModal from './UsageStatusModal.vue'
@@ -142,6 +143,10 @@ import {
   resolveSubagentAccent,
   toSubagentAvatarText
 } from '~~/shared/subagent-panels'
+import {
+  applyTurnPlanUpdate,
+  normalizeTurnPlanUpdate
+} from '~~/shared/turn-plan'
 
 const props = defineProps<{
   projectId: string
@@ -191,12 +196,15 @@ const skillAutocompleteListRef = ref<HTMLElement | null>(null)
 const mentionAutocompleteDropdownRef = ref<HTMLElement | null>(null)
 const mentionAutocompleteListRef = ref<HTMLElement | null>(null)
 const scrollViewport = ref<HTMLElement | null>(null)
+const stickyFooterRef = ref<HTMLElement | null>(null)
+const stickyFooterHeight = ref(140)
 const pinnedToBottom = ref(true)
 const session = useChatSession(props.projectId)
 const { syncThreadSummary, updateThreadSummaryTitle } = useThreadSummaries(props.projectId)
 const {
   messages,
   subagentPanels,
+  threadPlans,
   status,
   error,
   activeThreadId,
@@ -334,6 +342,9 @@ const projectTitle = computed(() => selectedProject.value?.projectId ?? props.pr
 const chatMessagesStatus = computed(() =>
   resolveChatMessagesStatus(status.value, awaitingAssistantOutput.value)
 )
+const chatSpacingOffset = computed(() =>
+  Math.max(140, stickyFooterHeight.value + 24)
+)
 const showWelcomeState = computed(() =>
   !routeThreadId.value
   && !activeThreadId.value
@@ -420,6 +431,15 @@ const activeAgentMentionEntries = computed(() =>
       status: panel.status
     } satisfies AgentMentionAutocompleteEntry))
 )
+
+const currentThreadPlan = computed(() => {
+  const threadId = activeThreadId.value ?? routeThreadId.value
+  if (!threadId) {
+    return null
+  }
+
+  return threadPlans.value[threadId] ?? null
+})
 
 const agentMentionAccentIndexByThreadId = computed(() => {
   const entries = new Map<string, number>()
@@ -825,6 +845,7 @@ let promptControlsPromise: Promise<void> | null = null
 let pendingThreadHydration: Promise<void> | null = null
 let releaseServerRequestHandler: (() => void) | null = null
 let releaseSkillNotificationSubscription: (() => void) | null = null
+let footerResizeObserver: ResizeObserver | null = null
 let skipNextSkillMentionSync = false
 let skipNextMentionSelectionSync = false
 let skillAutocompleteRequestSequence = 0
@@ -1797,6 +1818,43 @@ const startReview = async (target: ReviewTarget) => {
     setComposerError(caughtError instanceof Error ? caughtError.message : String(caughtError))
   } finally {
     reviewStartPending.value = false
+  }
+}
+
+const updateThreadPlanState = (threadId: string, params: unknown) => {
+  const nextPlanUpdate = normalizeTurnPlanUpdate(params)
+  if (!nextPlanUpdate) {
+    return
+  }
+
+  const nextPlanState = applyTurnPlanUpdate(threadPlans.value[threadId], {
+    ...nextPlanUpdate,
+    threadId
+  })
+  if (!nextPlanState) {
+    const nextThreadPlans = { ...threadPlans.value }
+    delete nextThreadPlans[threadId]
+    threadPlans.value = nextThreadPlans
+    return
+  }
+
+  threadPlans.value = {
+    ...threadPlans.value,
+    [threadId]: nextPlanState
+  }
+}
+
+const setThreadPlanPanelOpen = (open: boolean) => {
+  if (!currentThreadPlan.value?.threadId) {
+    return
+  }
+
+  threadPlans.value = {
+    ...threadPlans.value,
+    [currentThreadPlan.value.threadId]: {
+      ...currentThreadPlan.value,
+      panelOpen: open
+    }
   }
 }
 
@@ -3127,6 +3185,15 @@ const applyNotification = (notification: CodexRpcNotification) => {
       }
       return
     }
+    case 'turn/plan/updated': {
+      const threadId = notificationThreadId(notification) ?? currentLiveStream()?.threadId ?? activeThreadId.value
+      if (!threadId) {
+        return
+      }
+
+      updateThreadPlanState(threadId, notification.params)
+      return
+    }
     case 'error': {
       const params = notification.params as { error?: { message?: string } }
       const messageText = params.error?.message ?? 'The stream failed.'
@@ -3608,6 +3675,20 @@ onMounted(() => {
   void getClient(props.projectId).connect().catch(() => {})
   void loadPromptControls()
   void scheduleScrollToBottom('auto')
+
+  if (import.meta.client) {
+    footerResizeObserver = new ResizeObserver((entries) => {
+      const nextHeight = entries[0]?.contentRect.height
+      if (typeof nextHeight === 'number' && Number.isFinite(nextHeight)) {
+        stickyFooterHeight.value = Math.ceil(nextHeight)
+      }
+    })
+
+    if (stickyFooterRef.value) {
+      footerResizeObserver.observe(stickyFooterRef.value)
+      stickyFooterHeight.value = Math.ceil(stickyFooterRef.value.getBoundingClientRect().height)
+    }
+  }
 })
 
 onBeforeUnmount(() => {
@@ -3616,6 +3697,8 @@ onBeforeUnmount(() => {
   releaseServerRequestHandler = null
   releaseSkillNotificationSubscription?.()
   releaseSkillNotificationSubscription = null
+  footerResizeObserver?.disconnect()
+  footerResizeObserver = null
 })
 
 watch(() => props.threadId ?? null, (threadId) => {
@@ -3988,7 +4071,7 @@ watch(
         :should-auto-scroll="false"
         :should-scroll-to-bottom="false"
         :auto-scroll="false"
-        :spacing-offset="140"
+        :spacing-offset="chatSpacingOffset"
         :user="{
           ui: {
             root: 'scroll-mt-4',
@@ -4019,8 +4102,20 @@ watch(
       </UChatMessages>
     </div>
 
-    <div class="sticky bottom-0 shrink-0 border-t border-default bg-default/95 px-4 py-3 backdrop-blur md:px-6">
-      <div class="mx-auto w-full max-w-5xl">
+    <div
+      ref="stickyFooterRef"
+      class="sticky bottom-0 shrink-0 px-4 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] pt-10 md:px-6 md:pt-8"
+    >
+      <div class="pointer-events-none absolute inset-x-0 inset-y-0 bg-gradient-to-b from-transparent via-default/88 to-default" />
+
+      <div class="relative mx-auto w-full max-w-5xl">
+        <PlanTaskListPanel
+          v-if="currentThreadPlan"
+          :plan="currentThreadPlan"
+          class="mb-3"
+          @toggle="setThreadPlanPanelOpen"
+        />
+
         <UAlert
           v-if="composerError"
           color="error"

--- a/packages/client/app/components/PlanTaskListPanel.vue
+++ b/packages/client/app/components/PlanTaskListPanel.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import {
+  resolveTurnPlanStepMeta,
+  type ThreadPlanState
+} from '../../shared/turn-plan'
+
+const props = defineProps<{
+  plan: ThreadPlanState
+}>()
+
+const emit = defineEmits<{
+  toggle: [open: boolean]
+}>()
+
+const completedCount = computed(() =>
+  props.plan.plan.filter(step => step.status === 'completed').length
+)
+
+const inProgressCount = computed(() =>
+  props.plan.plan.filter(step => step.status === 'inProgress').length
+)
+
+const pendingCount = computed(() =>
+  props.plan.plan.filter(step => step.status === 'pending').length
+)
+
+const summaryText = computed(() => {
+  const segments: string[] = []
+
+  if (inProgressCount.value > 0) {
+    segments.push(`${inProgressCount.value} active`)
+  }
+
+  if (completedCount.value > 0) {
+    segments.push(`${completedCount.value} done`)
+  }
+
+  if (pendingCount.value > 0) {
+    segments.push(`${pendingCount.value} pending`)
+  }
+
+  return segments.length > 0 ? segments.join(' · ') : 'No tasks'
+})
+
+const toggle = () => {
+  emit('toggle', !props.plan.panelOpen)
+}
+</script>
+
+<template>
+  <section class="overflow-hidden rounded-lg border border-default bg-default">
+    <button
+      type="button"
+      class="flex w-full items-center gap-3 px-3 py-2 text-left transition hover:bg-elevated/40"
+      :aria-expanded="plan.panelOpen"
+      @click="toggle"
+    >
+      <div class="min-w-0 flex-1">
+        <div class="flex items-center gap-2">
+          <span class="text-sm font-medium text-highlighted">
+            Task list
+          </span>
+          <span class="text-xs text-muted">
+            {{ plan.plan.length }}
+          </span>
+        </div>
+        <p
+          v-if="plan.explanation"
+          class="truncate text-xs leading-5 text-muted"
+        >
+          {{ plan.explanation }}
+        </p>
+      </div>
+
+      <div class="flex shrink-0 items-center gap-2 text-xs text-muted">
+        <span>{{ summaryText }}</span>
+        <UIcon
+          name="i-lucide-chevron-up"
+          class="size-4 text-muted transition-transform"
+          :class="plan.panelOpen ? '' : 'rotate-180'"
+        />
+      </div>
+    </button>
+
+    <div
+      v-if="plan.panelOpen"
+      class="border-t border-default px-3 py-2"
+    >
+      <ol class="max-h-[40vh] space-y-1.5 overflow-y-auto text-sm">
+        <li
+          v-for="(step, index) in plan.plan"
+          :key="`${index}-${step.step}`"
+          class="leading-5 text-highlighted"
+        >
+          <div class="flex items-start gap-2">
+            <template v-if="resolveTurnPlanStepMeta(step.status).kind === 'icon'">
+              <UIcon
+                :name="resolveTurnPlanStepMeta(step.status).icon!"
+                class="mt-1 size-3.5 shrink-0"
+                :class="resolveTurnPlanStepMeta(step.status).markerClass"
+              />
+            </template>
+            <span
+              v-else
+              class="mt-[0.45rem] size-2 shrink-0 rounded-full"
+              :class="resolveTurnPlanStepMeta(step.status).markerClass"
+            />
+
+            <p
+              class="min-w-0 flex-1"
+              :class="step.status === 'completed'
+                ? 'text-muted'
+                : step.status === 'pending'
+                  ? 'text-toned'
+                  : 'text-highlighted'"
+            >
+              <span class="text-toned">{{ `${index + 1}. ` }}</span>
+              <span>{{ step.step }}</span>
+            </p>
+          </div>
+        </li>
+      </ol>
+    </div>
+  </section>
+</template>

--- a/packages/client/app/composables/useChatSession.ts
+++ b/packages/client/app/composables/useChatSession.ts
@@ -1,6 +1,7 @@
 import { ref, type Ref } from 'vue'
 import type { ChatMessage, SubagentAgentStatus, VisualSubagentPanel } from '~~/shared/codex-chat'
 import type { CodexRpcNotification } from '~~/shared/codex-rpc'
+import type { ThreadPlanState } from '~~/shared/turn-plan'
 import {
   FALLBACK_MODELS,
   type ModelOption,
@@ -38,6 +39,7 @@ export type SubagentPanelState = VisualSubagentPanel & {
 export type ChatSession = {
   messages: Ref<ChatMessage[]>
   subagentPanels: Ref<SubagentPanelState[]>
+  threadPlans: Ref<Record<string, ThreadPlanState>>
   status: Ref<ChatStatus>
   error: Ref<string | null>
   activeThreadId: Ref<string | null>
@@ -61,6 +63,7 @@ const sessions = new Map<string, ChatSession>()
 const createSession = (): ChatSession => ({
   messages: ref<ChatMessage[]>([]),
   subagentPanels: ref<SubagentPanelState[]>([]),
+  threadPlans: ref<Record<string, ThreadPlanState>>({}),
   status: ref<ChatStatus>('ready'),
   error: ref<string | null>(null),
   activeThreadId: ref<string | null>(null),

--- a/packages/client/app/layouts/default.vue
+++ b/packages/client/app/layouts/default.vue
@@ -39,7 +39,7 @@ const sidebarUi = computed(() =>
 
 <template>
   <UDashboardGroup
-    class="min-h-screen"
+    class="min-h-screen min-h-dvh"
     storage="local"
     storage-key="codori-dashboard"
     :persistent="true"

--- a/packages/client/app/layouts/default.vue
+++ b/packages/client/app/layouts/default.vue
@@ -39,7 +39,7 @@ const sidebarUi = computed(() =>
 
 <template>
   <UDashboardGroup
-    class="min-h-screen min-h-dvh"
+    class="app-shell-min-height min-h-screen min-h-dvh"
     storage="local"
     storage-key="codori-dashboard"
     :persistent="true"

--- a/packages/client/app/pages/projects/[...projectId]/index.vue
+++ b/packages/client/app/pages/projects/[...projectId]/index.vue
@@ -48,7 +48,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="flex h-screen min-h-0 flex-1 min-w-0">
+  <div class="flex h-screen h-dvh min-h-0 flex-1 min-w-0">
     <UDashboardPanel
       id="project-shell"
       class="min-h-0 min-w-0 flex-1"

--- a/packages/client/app/pages/projects/[...projectId]/index.vue
+++ b/packages/client/app/pages/projects/[...projectId]/index.vue
@@ -48,7 +48,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="flex h-screen h-dvh min-h-0 flex-1 min-w-0">
+  <div class="app-shell-height flex h-screen h-dvh min-h-0 flex-1 min-w-0">
     <UDashboardPanel
       id="project-shell"
       class="min-h-0 min-w-0 flex-1"

--- a/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
+++ b/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
@@ -233,7 +233,7 @@ watch(
 </script>
 
 <template>
-  <div class="flex h-screen min-h-0 flex-1 min-w-0">
+  <div class="flex h-screen h-dvh min-h-0 flex-1 min-w-0">
     <UDashboardPanel
       id="thread-shell"
       class="min-h-0 min-w-0 flex-1"

--- a/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
+++ b/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
@@ -233,7 +233,7 @@ watch(
 </script>
 
 <template>
-  <div class="flex h-screen h-dvh min-h-0 flex-1 min-w-0">
+  <div class="app-shell-height flex h-screen h-dvh min-h-0 flex-1 min-w-0">
     <UDashboardPanel
       id="thread-shell"
       class="min-h-0 min-w-0 flex-1"

--- a/packages/client/app/utils/chat-turn-engagement.ts
+++ b/packages/client/app/utils/chat-turn-engagement.ts
@@ -6,6 +6,7 @@ const interruptIgnoredMethods = new Set([
   'item/started',
   'item/agentMessage/delta',
   'item/plan/delta',
+  'turn/plan/updated',
   'item/reasoning/textDelta',
   'item/reasoning/summaryTextDelta',
   'item/commandExecution/outputDelta',

--- a/packages/client/shared/codex-chat.ts
+++ b/packages/client/shared/codex-chat.ts
@@ -145,6 +145,14 @@ export const isSubagentActiveStatus = (status: SubagentAgentStatus) =>
 
 const streamingState = (pending?: boolean) => pending ? 'streaming' : 'done'
 
+const attachmentNameFromPath = (path: string) =>
+  path.split(/[\\/]/).pop() || 'image'
+
+const attachmentMediaTypeFromUrl = (url: string) => {
+  const match = /^data:([^;,]+)[;,]/i.exec(url)
+  return match?.[1] || 'image/*'
+}
+
 const userInputToParts = (input: CodexUserInput): ChatPart[] => {
   if (input.type === 'text') {
     if (!input.text.trim()) {
@@ -162,11 +170,23 @@ const userInputToParts = (input: CodexUserInput): ChatPart[] => {
     return []
   }
 
+  if (input.type === 'image') {
+    return [{
+      type: 'attachment',
+      attachment: {
+        kind: 'image',
+        name: 'image',
+        mediaType: attachmentMediaTypeFromUrl(input.url),
+        url: input.url
+      }
+    }]
+  }
+
   return [{
     type: 'attachment',
     attachment: {
       kind: 'image',
-      name: input.path.split(/[\\/]/).pop() || 'image',
+      name: attachmentNameFromPath(input.path),
       mediaType: 'image/*',
       localPath: input.path
     }

--- a/packages/client/shared/codex-rpc.ts
+++ b/packages/client/shared/codex-rpc.ts
@@ -55,6 +55,10 @@ export type CodexUserInput =
       type: 'localImage'
       path: string
     }
+  | {
+      type: 'image'
+      url: string
+    }
 
 export type CodexThreadItem =
   | {

--- a/packages/client/shared/turn-plan.ts
+++ b/packages/client/shared/turn-plan.ts
@@ -78,6 +78,12 @@ export const normalizeTurnPlanUpdate = (value: unknown): TurnPlanUpdate | null =
 export const getTurnPlanStructureSignature = (plan: TurnPlanStep[]) =>
   JSON.stringify(plan.map(step => step.step))
 
+export const shouldResetThreadPlanState = (
+  previous: ThreadPlanState | null | undefined,
+  nextTurnId: string | null | undefined
+) =>
+  Boolean(previous?.turnId && nextTurnId && previous.turnId !== nextTurnId)
+
 export const applyTurnPlanUpdate = (
   previous: ThreadPlanState | null | undefined,
   update: TurnPlanUpdate,
@@ -87,13 +93,16 @@ export const applyTurnPlanUpdate = (
     return null
   }
 
+  const previousState = shouldResetThreadPlanState(previous, update.turnId)
+    ? null
+    : previous
   const structuralSignature = getTurnPlanStructureSignature(update.plan)
-  const shouldAutoOpen = !previous || previous.structuralSignature !== structuralSignature
+  const shouldAutoOpen = !previousState || previousState.structuralSignature !== structuralSignature
 
   return {
     ...update,
     structuralSignature,
-    panelOpen: shouldAutoOpen ? true : previous.panelOpen,
+    panelOpen: shouldAutoOpen ? true : previousState.panelOpen,
     updatedAt
   }
 }

--- a/packages/client/shared/turn-plan.ts
+++ b/packages/client/shared/turn-plan.ts
@@ -1,0 +1,128 @@
+type ObjectRecord = Record<string, unknown>
+
+const isObjectRecord = (value: unknown): value is ObjectRecord =>
+  typeof value === 'object' && value !== null
+
+export type TurnPlanStepStatus = 'pending' | 'inProgress' | 'completed'
+
+export type TurnPlanStep = {
+  step: string
+  status: TurnPlanStepStatus
+}
+
+export type TurnPlanUpdate = {
+  threadId: string | null
+  turnId: string | null
+  explanation: string | null
+  plan: TurnPlanStep[]
+}
+
+export type ThreadPlanState = TurnPlanUpdate & {
+  structuralSignature: string
+  panelOpen: boolean
+  updatedAt: number
+}
+
+const normalizeTurnPlanStatus = (value: unknown): TurnPlanStepStatus | null => {
+  switch (value) {
+    case 'pending':
+    case 'inProgress':
+    case 'completed':
+      return value
+    default:
+      return null
+  }
+}
+
+const normalizeTurnPlanStep = (value: unknown): TurnPlanStep | null => {
+  if (!isObjectRecord(value)) {
+    return null
+  }
+
+  const step = typeof value.step === 'string' ? value.step.trim() : ''
+  const status = normalizeTurnPlanStatus(value.status)
+  if (!step || !status) {
+    return null
+  }
+
+  return {
+    step,
+    status
+  }
+}
+
+export const normalizeTurnPlanUpdate = (value: unknown): TurnPlanUpdate | null => {
+  if (!isObjectRecord(value)) {
+    return null
+  }
+
+  const rawPlan = Array.isArray(value.plan) ? value.plan : []
+  const plan = rawPlan
+    .map(normalizeTurnPlanStep)
+    .filter((step): step is TurnPlanStep => step !== null)
+
+  return {
+    threadId: typeof value.threadId === 'string' && value.threadId.trim()
+      ? value.threadId
+      : null,
+    turnId: typeof value.turnId === 'string' && value.turnId.trim()
+      ? value.turnId
+      : null,
+    explanation: typeof value.explanation === 'string' && value.explanation.trim()
+      ? value.explanation.trim()
+      : null,
+    plan
+  }
+}
+
+export const getTurnPlanStructureSignature = (plan: TurnPlanStep[]) =>
+  JSON.stringify(plan.map(step => step.step))
+
+export const applyTurnPlanUpdate = (
+  previous: ThreadPlanState | null | undefined,
+  update: TurnPlanUpdate,
+  updatedAt = Date.now()
+): ThreadPlanState | null => {
+  if (update.plan.length === 0) {
+    return null
+  }
+
+  const structuralSignature = getTurnPlanStructureSignature(update.plan)
+  const shouldAutoOpen = !previous || previous.structuralSignature !== structuralSignature
+
+  return {
+    ...update,
+    structuralSignature,
+    panelOpen: shouldAutoOpen ? true : previous.panelOpen,
+    updatedAt
+  }
+}
+
+export const resolveTurnPlanStepMeta = (status: TurnPlanStepStatus) => {
+  switch (status) {
+    case 'completed':
+      return {
+        kind: 'icon' as const,
+        color: 'success' as const,
+        label: 'done',
+        icon: 'i-lucide-check',
+        markerClass: 'text-success'
+      }
+    case 'inProgress':
+      return {
+        kind: 'icon' as const,
+        color: 'info' as const,
+        label: 'in progress',
+        icon: 'i-lucide-loader-circle',
+        markerClass: 'animate-spin text-info'
+      }
+    default:
+      return {
+        kind: 'dot' as const,
+        color: 'neutral' as const,
+        label: 'pending',
+        icon: null,
+        markerClass: 'bg-muted/70'
+      }
+  }
+}

--- a/packages/client/test/chat-transcript.test.ts
+++ b/packages/client/test/chat-transcript.test.ts
@@ -176,6 +176,29 @@ describe('chat transcript stability', () => {
     }])
   })
 
+  it('hydrates server-provided image inputs without assuming a local path', () => {
+    expect(itemToMessages({
+      type: 'userMessage',
+      id: 'user-image-1',
+      content: [{
+        type: 'image',
+        url: 'data:image/png;base64,abc123'
+      }]
+    })).toEqual<ChatMessage[]>([{
+      id: 'user-image-1',
+      role: 'user',
+      parts: [{
+        type: 'attachment',
+        attachment: {
+          kind: 'image',
+          name: 'image',
+          mediaType: 'image/png',
+          url: 'data:image/png;base64,abc123'
+        }
+      }]
+    }])
+  })
+
   it('hides the synthetic review bootstrap user message when hydrating a thread', () => {
     expect(threadToMessages({
       id: 'thread-1',

--- a/packages/client/test/plan-task-list-panel.test.ts
+++ b/packages/client/test/plan-task-list-panel.test.ts
@@ -1,0 +1,90 @@
+/* eslint-disable vue/one-component-per-file */
+// @vitest-environment jsdom
+
+import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { describe, expect, it } from 'vitest'
+import PlanTaskListPanel from '../app/components/PlanTaskListPanel.vue'
+
+const IconStub = defineComponent({
+  name: 'IconStub',
+  props: {
+    name: {
+      type: String,
+      default: ''
+    },
+    class: {
+      type: String,
+      default: ''
+    }
+  },
+  setup(props) {
+    return () => h('span', {
+      class: props.class,
+      'data-icon': props.name
+    })
+  }
+})
+
+const BadgeStub = defineComponent({
+  name: 'BadgeStub',
+  setup(_, { slots }) {
+    return () => h('span', { class: 'badge-stub' }, slots.default?.())
+  }
+})
+
+const mountPanel = (panelOpen: boolean) =>
+  mount(PlanTaskListPanel, {
+    props: {
+      plan: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        explanation: 'Keep the task list pinned while the transcript scrolls.',
+        plan: [{
+          step: 'Inspect upstream signals',
+          status: 'completed'
+        }, {
+          step: 'Render sticky task list',
+          status: 'inProgress'
+        }, {
+          step: 'Capture screenshot',
+          status: 'pending'
+        }],
+        structuralSignature: '["Inspect upstream signals","Render sticky task list","Capture screenshot"]',
+        panelOpen,
+        updatedAt: 1
+      }
+    },
+    global: {
+      stubs: {
+        UIcon: IconStub,
+        UBadge: BadgeStub
+      }
+    }
+  })
+
+describe('plan task list panel', () => {
+  it('renders explanation, status labels, and visible tasks when expanded', () => {
+    const wrapper = mountPanel(true)
+
+    expect(wrapper.text()).toContain('Task list')
+    expect(wrapper.text()).toContain('Keep the task list pinned while the transcript scrolls.')
+    expect(wrapper.text()).toContain('1. Inspect upstream signals')
+    expect(wrapper.text()).toContain('1 active')
+    expect(wrapper.text()).toContain('1 done')
+    expect(wrapper.text()).toContain('1 pending')
+    expect(wrapper.findAll('li')).toHaveLength(3)
+    expect(wrapper.find('[data-icon="i-lucide-check"]').exists()).toBe(true)
+    expect(wrapper.find('[data-icon="i-lucide-loader-circle"]').exists()).toBe(true)
+  })
+
+  it('emits toggle requests and hides the list body when collapsed', async () => {
+    const wrapper = mountPanel(false)
+
+    expect(wrapper.findAll('li')).toHaveLength(0)
+
+    await wrapper.get('button').trigger('click')
+
+    expect(wrapper.emitted('toggle')?.[0]).toEqual([true])
+  })
+})

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -723,6 +723,7 @@ describe('client package', () => {
   it('ignores further streaming deltas after interruption is acknowledged', () => {
     expect(shouldIgnoreNotificationAfterInterrupt('item/agentMessage/delta')).toBe(true)
     expect(shouldIgnoreNotificationAfterInterrupt('item/started')).toBe(true)
+    expect(shouldIgnoreNotificationAfterInterrupt('turn/plan/updated')).toBe(true)
     expect(shouldIgnoreNotificationAfterInterrupt('item/completed')).toBe(false)
     expect(shouldIgnoreNotificationAfterInterrupt('turn/completed')).toBe(false)
   })

--- a/packages/client/test/turn-plan.test.ts
+++ b/packages/client/test/turn-plan.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyTurnPlanUpdate,
+  normalizeTurnPlanUpdate
+} from '../shared/turn-plan'
+
+describe('turn plan state', () => {
+  it('normalizes valid turn plan updates and drops malformed steps', () => {
+    expect(normalizeTurnPlanUpdate({
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      explanation: ' Keep the list visible ',
+      plan: [{
+        step: 'Implement sticky panel',
+        status: 'inProgress'
+      }, {
+        step: '  ',
+        status: 'pending'
+      }, {
+        step: 'Ship tests',
+        status: 'completed'
+      }, {
+        step: 'Invalid status',
+        status: 'done'
+      }]
+    })).toEqual({
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      explanation: 'Keep the list visible',
+      plan: [{
+        step: 'Implement sticky panel',
+        status: 'inProgress'
+      }, {
+        step: 'Ship tests',
+        status: 'completed'
+      }]
+    })
+  })
+
+  it('auto-opens when the first task list arrives', () => {
+    const firstPlan = applyTurnPlanUpdate(null, {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      explanation: null,
+      plan: [{
+        step: 'Inspect upstream events',
+        status: 'pending'
+      }]
+    }, 100)
+
+    expect(firstPlan).toMatchObject({
+      panelOpen: true,
+      structuralSignature: '["Inspect upstream events"]',
+      updatedAt: 100
+    })
+  })
+
+  it('preserves manual collapse on status-only changes', () => {
+    const initialPlan = applyTurnPlanUpdate(null, {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      explanation: null,
+      plan: [{
+        step: 'Inspect upstream events',
+        status: 'pending'
+      }, {
+        step: 'Implement sticky panel',
+        status: 'pending'
+      }]
+    }, 100)
+
+    const collapsedPlan = {
+      ...initialPlan!,
+      panelOpen: false
+    }
+
+    const nextPlan = applyTurnPlanUpdate(collapsedPlan, {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      explanation: 'Status moved forward',
+      plan: [{
+        step: 'Inspect upstream events',
+        status: 'completed'
+      }, {
+        step: 'Implement sticky panel',
+        status: 'inProgress'
+      }]
+    }, 200)
+
+    expect(nextPlan).toMatchObject({
+      panelOpen: false,
+      explanation: 'Status moved forward'
+    })
+  })
+
+  it('re-opens when the task structure changes', () => {
+    const collapsedPlan = applyTurnPlanUpdate(null, {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      explanation: null,
+      plan: [{
+        step: 'Inspect upstream events',
+        status: 'completed'
+      }]
+    }, 100)
+
+    const nextPlan = applyTurnPlanUpdate({
+      ...collapsedPlan!,
+      panelOpen: false
+    }, {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      explanation: null,
+      plan: [{
+        step: 'Inspect upstream events',
+        status: 'completed'
+      }, {
+        step: 'Capture screenshot',
+        status: 'pending'
+      }]
+    }, 200)
+
+    expect(nextPlan).toMatchObject({
+      panelOpen: true,
+      structuralSignature: '["Inspect upstream events","Capture screenshot"]'
+    })
+  })
+})

--- a/packages/client/test/turn-plan.test.ts
+++ b/packages/client/test/turn-plan.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   applyTurnPlanUpdate,
-  normalizeTurnPlanUpdate
+  normalizeTurnPlanUpdate,
+  shouldResetThreadPlanState
 } from '../shared/turn-plan'
 
 describe('turn plan state', () => {
@@ -124,5 +125,52 @@ describe('turn plan state', () => {
       panelOpen: true,
       structuralSignature: '["Inspect upstream events","Capture screenshot"]'
     })
+  })
+
+  it('treats a new turn id as fresh plan state', () => {
+    const previousPlan = applyTurnPlanUpdate(null, {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      explanation: null,
+      plan: [{
+        step: 'Inspect upstream events',
+        status: 'completed'
+      }]
+    }, 100)
+
+    const nextPlan = applyTurnPlanUpdate({
+      ...previousPlan!,
+      panelOpen: false
+    }, {
+      threadId: 'thread-1',
+      turnId: 'turn-2',
+      explanation: 'Fresh turn plan',
+      plan: [{
+        step: 'Inspect upstream events',
+        status: 'completed'
+      }]
+    }, 200)
+
+    expect(nextPlan).toMatchObject({
+      turnId: 'turn-2',
+      panelOpen: true,
+      explanation: 'Fresh turn plan'
+    })
+  })
+
+  it('resets thread plan state when a new turn starts', () => {
+    const previousPlan = applyTurnPlanUpdate(null, {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      explanation: null,
+      plan: [{
+        step: 'Inspect upstream events',
+        status: 'pending'
+      }]
+    }, 100)
+
+    expect(shouldResetThreadPlanState(previousPlan, 'turn-2')).toBe(true)
+    expect(shouldResetThreadPlanState(previousPlan, 'turn-1')).toBe(false)
+    expect(shouldResetThreadPlanState(previousPlan, null)).toBe(false)
   })
 })


### PR DESCRIPTION
Closes #39

## Summary
- add a dedicated sticky task list panel below the chat transcript
- normalize streamed turn plan updates into per-thread task list state
- preserve manual collapse state unless the task structure changes
- support server-provided image inputs when hydrating saved transcripts
- track the mobile visual viewport height so the chat shell follows the visible browser area more closely
- tighten sticky composer spacing so the footer and prompt do not reserve extra vertical space when idle
- add regression coverage for plan normalization, transcript hydration, auto-open behavior, and interruption handling

## Tests
- `pnpm --filter @codori/client test`
- `pnpm --filter @codori/client typecheck`
- `pnpm --filter @codori/client lint`
