### PR TITLE
refactor: align client with generated app-server types

### DIFF
--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -67,7 +67,13 @@ import {
   type CollaborationModeListResponse,
   type CollaborationModeMask
 } from '~~/shared/collaboration-mode'
+import type { ReviewStartResponse } from '~~/shared/generated/codex-app-server/v2/ReviewStartResponse'
+import type { Thread } from '~~/shared/generated/codex-app-server/v2/Thread'
+import type { ThreadReadResponse } from '~~/shared/generated/codex-app-server/v2/ThreadReadResponse'
 import type { ThreadItem } from '~~/shared/generated/codex-app-server/v2/ThreadItem'
+import type { ThreadResumeResponse } from '~~/shared/generated/codex-app-server/v2/ThreadResumeResponse'
+import type { ThreadStartResponse } from '~~/shared/generated/codex-app-server/v2/ThreadStartResponse'
+import type { TurnStartResponse } from '~~/shared/generated/codex-app-server/v2/TurnStartResponse'
 import {
   type ConfigReadResponse,
   notificationRequestId,
@@ -78,14 +84,8 @@ import {
   notificationThreadUpdatedAt,
   notificationTurnId,
   type CodexRpcNotification,
-  type CodexThread,
   type ReviewStartParams,
-  type ReviewStartResponse,
   type ReviewTarget,
-  type ThreadReadResponse,
-  type ThreadResumeResponse,
-  type ThreadStartResponse,
-  type TurnStartResponse
 } from '~~/shared/codex-rpc'
 import {
   buildTurnOverrides,
@@ -2440,7 +2440,7 @@ const shortThreadId = (value: string) => value.slice(0, 8)
 
 const resolveSubagentName = (
   threadId: string,
-  thread?: Pick<CodexThread, 'agentNickname' | 'name' | 'preview'> | null
+  thread?: Pick<Thread, 'agentNickname' | 'name' | 'preview'> | null
 ) => {
   const candidate = thread?.agentNickname?.trim()
     || thread?.name?.trim()
@@ -3129,7 +3129,7 @@ const applySubagentActivityItem = (item: Extract<ThreadItem, { type: 'collabAgen
   }
 }
 
-const rebuildSubagentPanelsFromThread = (thread: CodexThread) => {
+const rebuildSubagentPanelsFromThread = (thread: Thread) => {
   subagentPanels.value = []
   for (const turn of thread.turns) {
     for (const item of turn.items) {

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -63,13 +63,13 @@ import {
   findCollaborationModeMask,
   normalizeCollaborationModeListResponse,
   resolveThreadCollaborationModeKey,
-  type CollaborationMode
+  type CollaborationMode,
+  type CollaborationModeMask
 } from '~~/shared/collaboration-mode'
 import type { ReviewStartResponse } from '~~/shared/generated/codex-app-server/v2/ReviewStartResponse'
 import type { ReviewStartParams } from '~~/shared/generated/codex-app-server/v2/ReviewStartParams'
 import type { ReviewTarget } from '~~/shared/generated/codex-app-server/v2/ReviewTarget'
 import type { CollaborationModeListResponse } from '~~/shared/generated/codex-app-server/v2/CollaborationModeListResponse'
-import type { CollaborationModeMask } from '~~/shared/generated/codex-app-server/v2/CollaborationModeMask'
 import type { ConfigReadResponse } from '~~/shared/generated/codex-app-server/v2/ConfigReadResponse'
 import type { ModelListResponse } from '~~/shared/generated/codex-app-server/v2/ModelListResponse'
 import type { Thread } from '~~/shared/generated/codex-app-server/v2/Thread'

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -63,13 +63,13 @@ import {
   findCollaborationModeMask,
   normalizeCollaborationModeListResponse,
   resolveThreadCollaborationModeKey,
-  type CollaborationMode,
-  type CollaborationModeListResponse,
-  type CollaborationModeMask
+  type CollaborationMode
 } from '~~/shared/collaboration-mode'
 import type { ReviewStartResponse } from '~~/shared/generated/codex-app-server/v2/ReviewStartResponse'
 import type { ReviewStartParams } from '~~/shared/generated/codex-app-server/v2/ReviewStartParams'
 import type { ReviewTarget } from '~~/shared/generated/codex-app-server/v2/ReviewTarget'
+import type { CollaborationModeListResponse } from '~~/shared/generated/codex-app-server/v2/CollaborationModeListResponse'
+import type { CollaborationModeMask } from '~~/shared/generated/codex-app-server/v2/CollaborationModeMask'
 import type { ConfigReadResponse } from '~~/shared/generated/codex-app-server/v2/ConfigReadResponse'
 import type { ModelListResponse } from '~~/shared/generated/codex-app-server/v2/ModelListResponse'
 import type { Thread } from '~~/shared/generated/codex-app-server/v2/Thread'

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -67,6 +67,7 @@ import {
   type CollaborationModeListResponse,
   type CollaborationModeMask
 } from '~~/shared/collaboration-mode'
+import type { ThreadItem } from '~~/shared/generated/codex-app-server/v2/ThreadItem'
 import {
   type ConfigReadResponse,
   notificationRequestId,
@@ -78,7 +79,6 @@ import {
   notificationTurnId,
   type CodexRpcNotification,
   type CodexThread,
-  type CodexThreadItem,
   type ReviewStartParams,
   type ReviewStartResponse,
   type ReviewTarget,
@@ -2280,7 +2280,7 @@ const markAwaitingAssistantOutput = (nextValue: boolean) => {
   awaitingAssistantOutput.value = nextValue
 }
 
-const markAssistantOutputStartedForItem = (item: CodexThreadItem) => {
+const markAssistantOutputStartedForItem = (item: ThreadItem) => {
   if (item.type !== 'userMessage') {
     markAwaitingAssistantOutput(false)
   }
@@ -2745,7 +2745,7 @@ const ensureThread = async () => {
   }
 }
 
-const seedStreamingMessage = (item: CodexThreadItem) => {
+const seedStreamingMessage = (item: ThreadItem) => {
   const [seed] = itemToMessages(item)
   if (!seed) {
     return
@@ -2855,9 +2855,14 @@ const fallbackCommandMessage = (itemId: string): ChatMessage => ({
         type: 'commandExecution',
         id: itemId,
         command: 'Command',
+        cwd: '',
+        processId: null,
+        source: 'agent',
+        commandActions: [],
         aggregatedOutput: '',
         exitCode: null,
-        status: 'inProgress'
+        status: 'inProgress',
+        durationMs: null
       }
     }
   }]
@@ -2899,6 +2904,7 @@ const fallbackMcpToolMessage = (itemId: string): ChatMessage => ({
         result: null,
         error: null,
         status: 'inProgress',
+        durationMs: null,
         progressMessages: []
       }
     }
@@ -3029,7 +3035,7 @@ const pushSubagentEventMessage = (threadId: string, kind: 'turn.failed' | 'strea
   )
 }
 
-const seedSubagentStreamingMessage = (threadId: string, item: CodexThreadItem) => {
+const seedSubagentStreamingMessage = (threadId: string, item: ThreadItem) => {
   const [seed] = itemToMessages(item)
   if (!seed) {
     return
@@ -3099,7 +3105,7 @@ const bootstrapSubagentPanel = async (threadId: string) => {
   await bootstrapPromise
 }
 
-const applySubagentActivityItem = (item: Extract<CodexThreadItem, { type: 'collabAgentToolCall' }>) => {
+const applySubagentActivityItem = (item: Extract<ThreadItem, { type: 'collabAgentToolCall' }>) => {
   const orderedThreadIds = [
     ...item.receiverThreadIds,
     ...Object.keys(item.agentsStates).filter(threadId => !item.receiverThreadIds.includes(threadId))
@@ -3165,7 +3171,7 @@ const applySubagentNotification = (threadId: string, notification: CodexRpcNotif
       return
     }
     case 'item/started': {
-      const params = notification.params as { item: CodexThreadItem }
+      const params = notification.params as { item: ThreadItem }
       if (params.item.type === 'collabAgentToolCall') {
         applySubagentActivityItem(params.item)
       }
@@ -3173,7 +3179,7 @@ const applySubagentNotification = (threadId: string, notification: CodexRpcNotif
       return
     }
     case 'item/completed': {
-      const params = notification.params as { item: CodexThreadItem }
+      const params = notification.params as { item: ThreadItem }
       if (params.item.type === 'collabAgentToolCall') {
         applySubagentActivityItem(params.item)
       }
@@ -3412,7 +3418,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
       return
     }
     case 'item/started': {
-      const params = notification.params as { item: CodexThreadItem }
+      const params = notification.params as { item: ThreadItem }
       if (params.item.type === 'collabAgentToolCall') {
         applySubagentActivityItem(params.item)
       }
@@ -3435,7 +3441,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
       return
     }
     case 'item/completed': {
-      const params = notification.params as { item: CodexThreadItem }
+      const params = notification.params as { item: ThreadItem }
       if (params.item.type === 'collabAgentToolCall') {
         applySubagentActivityItem(params.item)
       }

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -2880,9 +2880,9 @@ const fallbackFileChangeMessage = (itemId: string): ChatMessage => ({
         type: 'fileChange',
         id: itemId,
         changes: [],
-        status: 'inProgress',
-        liveOutput: ''
-      }
+        status: 'inProgress'
+      },
+      liveOutput: ''
     }
   }]
 })
@@ -2904,9 +2904,9 @@ const fallbackMcpToolMessage = (itemId: string): ChatMessage => ({
         result: null,
         error: null,
         status: 'inProgress',
-        durationMs: null,
-        progressMessages: []
-      }
+        durationMs: null
+      },
+      progressMessages: []
     }
   }]
 })
@@ -3272,13 +3272,16 @@ const applySubagentNotification = (threadId: string, notification: CodexRpcNotif
         const baseItem: FileChangeItem = itemData.kind === 'file_change'
           ? itemData.item
           : fallbackItem.item
+        const liveOutput = itemData.kind === 'file_change'
+          ? itemData.liveOutput
+          : fallbackItem.liveOutput
         return {
           kind: 'file_change',
           item: {
             ...baseItem,
-            liveOutput: `${baseItem.liveOutput ?? ''}${params.delta}`,
             status: 'inProgress'
-          }
+          },
+          liveOutput: `${liveOutput ?? ''}${params.delta}`
         }
       })
       return
@@ -3290,13 +3293,16 @@ const applySubagentNotification = (threadId: string, notification: CodexRpcNotif
         const baseItem: McpToolCallItem = itemData.kind === 'mcp_tool_call'
           ? itemData.item
           : fallbackItem.item
+        const progressMessages = itemData.kind === 'mcp_tool_call'
+          ? itemData.progressMessages
+          : fallbackItem.progressMessages
         return {
           kind: 'mcp_tool_call',
           item: {
             ...baseItem,
-            progressMessages: [...(baseItem.progressMessages ?? []), params.message],
             status: 'inProgress'
-          }
+          },
+          progressMessages: [...(progressMessages ?? []), params.message]
         }
       })
       return
@@ -3563,13 +3569,16 @@ const applyNotification = (notification: CodexRpcNotification) => {
         const baseItem: FileChangeItem = itemData.kind === 'file_change'
           ? itemData.item
           : fallbackItem.item
+        const liveOutput = itemData.kind === 'file_change'
+          ? itemData.liveOutput
+          : fallbackItem.liveOutput
         return {
           kind: 'file_change',
           item: {
             ...baseItem,
-            liveOutput: `${baseItem.liveOutput ?? ''}${params.delta}`,
             status: 'inProgress'
-          }
+          },
+          liveOutput: `${liveOutput ?? ''}${params.delta}`
         }
       })
       status.value = 'streaming'
@@ -3582,13 +3591,16 @@ const applyNotification = (notification: CodexRpcNotification) => {
         const baseItem: McpToolCallItem = itemData.kind === 'mcp_tool_call'
           ? itemData.item
           : fallbackItem.item
+        const progressMessages = itemData.kind === 'mcp_tool_call'
+          ? itemData.progressMessages
+          : fallbackItem.progressMessages
         return {
           kind: 'mcp_tool_call',
           item: {
             ...baseItem,
-            progressMessages: [...(baseItem.progressMessages ?? []), params.message],
             status: 'inProgress'
-          }
+          },
+          progressMessages: [...(progressMessages ?? []), params.message]
         }
       })
       status.value = 'streaming'

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -55,7 +55,8 @@ import {
   type ChatPart,
   type FileChangeItem,
   type ItemData,
-  type McpToolCallItem
+  type McpToolCallItem,
+  type WebSearchStatus
 } from '~~/shared/codex-chat'
 import { buildTurnStartInput, type PersistedProjectAttachment } from '~~/shared/chat-attachments'
 import {
@@ -2746,7 +2747,9 @@ const ensureThread = async () => {
 }
 
 const seedStreamingMessage = (item: ThreadItem) => {
-  const [seed] = itemToMessages(item)
+  const [seed] = itemToMessages(item, {
+    webSearchStatus: item.type === 'webSearch' ? 'inProgress' : undefined
+  })
   if (!seed) {
     return
   }
@@ -3036,7 +3039,9 @@ const pushSubagentEventMessage = (threadId: string, kind: 'turn.failed' | 'strea
 }
 
 const seedSubagentStreamingMessage = (threadId: string, item: ThreadItem) => {
-  const [seed] = itemToMessages(item)
+  const [seed] = itemToMessages(item, {
+    webSearchStatus: item.type === 'webSearch' ? 'inProgress' : undefined
+  })
   if (!seed) {
     return
   }
@@ -3048,6 +3053,38 @@ const seedSubagentStreamingMessage = (threadId: string, item: ThreadItem) => {
     })
   )
 }
+
+const updateWebSearchMessageStatus = (
+  chatMessages: ChatMessage[],
+  status: WebSearchStatus
+) => chatMessages.map((message) => {
+  const partIndex = message.parts.findIndex(isItemPart)
+  if (partIndex === -1) {
+    return message
+  }
+
+  const itemPart = message.parts[partIndex] as Extract<ChatPart, { type: typeof ITEM_PART }>
+  if (itemPart.data.kind !== 'web_search') {
+    return message
+  }
+  if (!message.pending && itemPart.data.status !== 'inProgress') {
+    return message
+  }
+
+  const nextPart: Extract<ChatPart, { type: typeof ITEM_PART }> = {
+    ...itemPart,
+    data: {
+      ...itemPart.data,
+      status
+    }
+  }
+
+  return {
+    ...message,
+    pending: status === 'inProgress',
+    parts: message.parts.map((part, index) => index === partIndex ? nextPart : part)
+  }
+})
 
 const bootstrapSubagentPanel = async (threadId: string) => {
   if (!threadId) {
@@ -3322,6 +3359,9 @@ const applySubagentNotification = (threadId: string, notification: CodexRpcNotif
       const params = notification.params as { error?: { message?: string } }
       const messageText = params.error?.message ?? 'The turn failed.'
       pushSubagentEventMessage(threadId, 'turn.failed', messageText)
+      updateSubagentPanelMessages(threadId, (panelMessages) =>
+        updateWebSearchMessageStatus(panelMessages, 'failed')
+      )
       upsertSubagentPanel(threadId, (existingPanel) => ({
         ...(existingPanel ?? createSubagentPanelState(threadId)),
         status: 'errored',
@@ -3669,6 +3709,9 @@ const applyNotification = (notification: CodexRpcNotification) => {
       return
     }
     case 'turn/completed': {
+      if (notificationTurnStatus(notification) === 'failed') {
+        messages.value = updateWebSearchMessageStatus(messages.value, 'failed')
+      }
       maybeQueuePlanImplementationPrompt({
         threadId: notificationThreadId(notification) ?? liveStream?.threadId ?? activeThreadId.value,
         turnId: notificationTurnId(notification) ?? liveStream?.turnId ?? null,

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -68,6 +68,10 @@ import {
   type CollaborationModeMask
 } from '~~/shared/collaboration-mode'
 import type { ReviewStartResponse } from '~~/shared/generated/codex-app-server/v2/ReviewStartResponse'
+import type { ReviewStartParams } from '~~/shared/generated/codex-app-server/v2/ReviewStartParams'
+import type { ReviewTarget } from '~~/shared/generated/codex-app-server/v2/ReviewTarget'
+import type { ConfigReadResponse } from '~~/shared/generated/codex-app-server/v2/ConfigReadResponse'
+import type { ModelListResponse } from '~~/shared/generated/codex-app-server/v2/ModelListResponse'
 import type { Thread } from '~~/shared/generated/codex-app-server/v2/Thread'
 import type { ThreadReadResponse } from '~~/shared/generated/codex-app-server/v2/ThreadReadResponse'
 import type { ThreadItem } from '~~/shared/generated/codex-app-server/v2/ThreadItem'
@@ -75,17 +79,13 @@ import type { ThreadResumeResponse } from '~~/shared/generated/codex-app-server/
 import type { ThreadStartResponse } from '~~/shared/generated/codex-app-server/v2/ThreadStartResponse'
 import type { TurnStartResponse } from '~~/shared/generated/codex-app-server/v2/TurnStartResponse'
 import {
-  type ConfigReadResponse,
   notificationRequestId,
   notificationTurnStatus,
-  type ModelListResponse,
   notificationThreadName,
   notificationThreadId,
   notificationThreadUpdatedAt,
   notificationTurnId,
   type CodexRpcNotification,
-  type ReviewStartParams,
-  type ReviewTarget,
 } from '~~/shared/codex-rpc'
 import {
   buildTurnOverrides,

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -78,6 +78,7 @@ import type { ThreadItem } from '~~/shared/generated/codex-app-server/v2/ThreadI
 import type { ThreadResumeResponse } from '~~/shared/generated/codex-app-server/v2/ThreadResumeResponse'
 import type { ThreadStartResponse } from '~~/shared/generated/codex-app-server/v2/ThreadStartResponse'
 import type { TurnStartResponse } from '~~/shared/generated/codex-app-server/v2/TurnStartResponse'
+import type { ReasoningEffort } from '~~/shared/generated/codex-app-server/ReasoningEffort'
 import {
   notificationRequestId,
   notificationTurnStatus,
@@ -100,8 +101,7 @@ import {
   resolveContextWindowState,
   resolveEffortOptions,
   shouldShowContextWindowIndicator,
-  visibleModelOptions,
-  type ReasoningEffort
+  visibleModelOptions
 } from '~~/shared/chat-prompt-controls'
 import { shouldQueuePlanImplementationPrompt } from '~~/shared/plan-implementation-prompt'
 import {

--- a/packages/client/app/components/MessagePartRenderer.ts
+++ b/packages/client/app/components/MessagePartRenderer.ts
@@ -59,7 +59,8 @@ export default defineComponent({
           })
         case ITEM_PART:
           return h(MessagePartItem, {
-            part: props.part
+            part: props.part,
+            messagePending: props.message?.pending ?? false
           })
         default:
           return h('pre', {

--- a/packages/client/app/components/ThreadList.vue
+++ b/packages/client/app/components/ThreadList.vue
@@ -10,7 +10,7 @@ import {
   useThreadSummaries,
   type ThreadSummary
 } from '../composables/useThreadSummaries'
-import type { ThreadListResponse } from '~~/shared/codex-rpc'
+import type { ThreadListResponse } from '~~/shared/generated/codex-app-server/v2/ThreadListResponse'
 import { toProjectThreadRoute } from '~~/shared/codori'
 
 const props = defineProps<{

--- a/packages/client/app/components/message-item/DynamicToolCall.vue
+++ b/packages/client/app/components/message-item/DynamicToolCall.vue
@@ -5,6 +5,7 @@ import { useChatToolState } from './use-chat-tool-state'
 
 const props = defineProps<{
   item: DynamicToolCallItem
+  progressMessages?: string[]
 }>()
 
 const inputSummary = computed(() =>
@@ -95,6 +96,19 @@ const { open, isLoading, isStreaming } = useChatToolState(() => props.item.statu
         v-if="item.arguments != null"
         class="overflow-x-auto rounded-xl border border-default/70 bg-elevated/30 px-3 py-3 text-xs leading-6 text-toned"
       >{{ JSON.stringify(item.arguments, null, 2) }}</pre>
+
+      <ul
+        v-if="progressMessages?.length"
+        class="space-y-1 rounded-xl border border-default/70 bg-elevated/30 px-3 py-3"
+      >
+        <li
+          v-for="(message, index) in progressMessages"
+          :key="`${item.id}-progress-${index}`"
+          class="text-xs leading-6 text-toned"
+        >
+          {{ message }}
+        </li>
+      </ul>
 
       <p
         v-if="item.success !== null"

--- a/packages/client/app/components/message-item/FileChange.vue
+++ b/packages/client/app/components/message-item/FileChange.vue
@@ -6,6 +6,7 @@ import { useChatToolState } from './use-chat-tool-state'
 
 const props = defineProps<{
   item: FileChangeItem
+  liveOutput?: string | null
 }>()
 
 const changes = computed(() => props.item.changes ?? [])
@@ -86,9 +87,9 @@ const { open, isLoading, isStreaming } = useChatToolState(() => props.item.statu
   >
     <div class="space-y-3">
       <pre
-        v-if="item.liveOutput"
+        v-if="liveOutput"
         class="overflow-x-auto rounded-xl border border-default/70 bg-elevated/40 px-3 py-3 text-xs leading-6 text-toned"
-      >{{ item.liveOutput }}</pre>
+      >{{ liveOutput }}</pre>
 
       <ul class="space-y-3">
         <li

--- a/packages/client/app/components/message-item/FileChange.vue
+++ b/packages/client/app/components/message-item/FileChange.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { FileChangeItem } from '~~/shared/codex-chat'
+import type { PatchChangeKind } from '~~/shared/generated/codex-app-server/v2/PatchChangeKind'
 import { useChatToolState } from './use-chat-tool-state'
 
 const props = defineProps<{
@@ -26,7 +27,7 @@ const filePreview = computed(() => {
 
 const title = computed(() => {
   const hasChanges = changes.value.length > 0
-  const deletedOnly = hasChanges && changes.value.every(change => change.kind === 'delete')
+  const deletedOnly = hasChanges && changes.value.every(change => change.kind.type === 'delete')
 
   switch (props.item.status) {
     case 'inProgress':
@@ -42,8 +43,8 @@ const icon = computed(() =>
   props.item.status === 'failed' ? 'i-lucide-triangle-alert' : 'i-lucide-file-pen-line'
 )
 
-const changeKindIcon = (kind?: string) => {
-  switch (kind) {
+const changeKindIcon = (kind?: PatchChangeKind) => {
+  switch (kind?.type) {
     case 'add':
       return 'i-lucide-plus'
     case 'delete':
@@ -55,8 +56,8 @@ const changeKindIcon = (kind?: string) => {
   }
 }
 
-const changeKindClass = (kind?: string) => {
-  switch (kind) {
+const changeKindClass = (kind?: PatchChangeKind) => {
+  switch (kind?.type) {
     case 'add':
       return 'text-success'
     case 'delete':
@@ -97,9 +98,9 @@ const { open, isLoading, isStreaming } = useChatToolState(() => props.item.statu
         >
           <div class="flex items-center gap-2 text-xs font-medium text-muted">
             <UIcon
-              :name="changeKindIcon(change.kind as string | undefined)"
+              :name="changeKindIcon(change.kind)"
               class="size-3.5"
-              :class="changeKindClass(change.kind as string | undefined)"
+              :class="changeKindClass(change.kind)"
             />
             <span class="font-mono text-toned">{{ change.path }}</span>
           </div>

--- a/packages/client/app/components/message-item/FileChange.vue
+++ b/packages/client/app/components/message-item/FileChange.vue
@@ -28,7 +28,7 @@ const filePreview = computed(() => {
 
 const title = computed(() => {
   const hasChanges = changes.value.length > 0
-  const deletedOnly = hasChanges && changes.value.every(change => change.kind.type === 'delete')
+  const deletedOnly = hasChanges && changes.value.every(change => change.kind?.type === 'delete')
 
   switch (props.item.status) {
     case 'inProgress':

--- a/packages/client/app/components/message-item/McpToolCall.vue
+++ b/packages/client/app/components/message-item/McpToolCall.vue
@@ -5,6 +5,7 @@ import { useChatToolState } from './use-chat-tool-state'
 
 const props = defineProps<{
   item: McpToolCallItem
+  progressMessages?: string[]
 }>()
 
 const formatPrettyJson = (value: unknown) => {
@@ -47,7 +48,7 @@ const { open, isLoading, isStreaming } = useChatToolState(() => props.item.statu
       </div>
 
       <div
-        v-if="item.progressMessages?.length"
+        v-if="progressMessages?.length"
         class="rounded-xl border border-default/70 bg-elevated/30 px-3 py-3"
       >
         <p class="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted">
@@ -55,7 +56,7 @@ const { open, isLoading, isStreaming } = useChatToolState(() => props.item.statu
         </p>
         <ul class="space-y-1">
           <li
-            v-for="(message, index) in item.progressMessages"
+            v-for="(message, index) in progressMessages"
             :key="`${item.id}-progress-${index}`"
             class="text-xs leading-6 text-toned"
           >

--- a/packages/client/app/components/message-item/SubagentActivity.vue
+++ b/packages/client/app/components/message-item/SubagentActivity.vue
@@ -5,6 +5,7 @@ import { useChatToolState } from './use-chat-tool-state'
 
 const props = defineProps<{
   item: SubagentActivityItem
+  agentStates?: SubagentAgentState[]
 }>()
 
 const hiddenActions = new Set<SubagentActivityItem['tool']>([
@@ -13,7 +14,7 @@ const hiddenActions = new Set<SubagentActivityItem['tool']>([
 ])
 
 const isHidden = computed(() => hiddenActions.has(props.item.tool))
-const stateEntries = computed<SubagentAgentState[]>(() => props.item.agentsStates ?? [])
+const stateEntries = computed<SubagentAgentState[]>(() => props.agentStates ?? [])
 
 const shortThreadId = (value: string) => value.slice(0, 8)
 

--- a/packages/client/app/components/message-item/WebSearch.vue
+++ b/packages/client/app/components/message-item/WebSearch.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
-import type { CodexThreadItem } from '~~/shared/codex-rpc'
+import { computed } from 'vue'
+import type { ThreadItem } from '~~/shared/generated/codex-app-server/v2/ThreadItem'
 import { useChatToolState } from './use-chat-tool-state'
 
 const props = defineProps<{
-  item: Extract<CodexThreadItem, { type: 'webSearch' }>
+  item: Extract<ThreadItem, { type: 'webSearch' }>
+  pending?: boolean
 }>()
 
-const { open, isLoading, isStreaming } = useChatToolState(() => props.item.status, props.item.status === 'failed')
+const derivedStatus = computed(() => props.pending ? 'inProgress' : 'completed')
+const { open, isLoading, isStreaming } = useChatToolState(() => derivedStatus.value)
 </script>
 
 <template>
@@ -18,7 +21,6 @@ const { open, isLoading, isStreaming } = useChatToolState(() => props.item.statu
     :streaming="isStreaming"
     variant="inline"
     :open="open"
-    :default-open="item.status === 'failed'"
     @update:open="open = $event"
   />
 </template>

--- a/packages/client/app/components/message-item/WebSearch.vue
+++ b/packages/client/app/components/message-item/WebSearch.vue
@@ -1,26 +1,29 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import type { WebSearchStatus } from '~~/shared/codex-chat'
 import type { ThreadItem } from '~~/shared/generated/codex-app-server/v2/ThreadItem'
 import { useChatToolState } from './use-chat-tool-state'
 
 const props = defineProps<{
   item: Extract<ThreadItem, { type: 'webSearch' }>
-  pending?: boolean
+  status: WebSearchStatus
 }>()
 
-const derivedStatus = computed(() => props.pending ? 'inProgress' : 'completed')
-const { open, isLoading, isStreaming } = useChatToolState(() => derivedStatus.value)
+const title = computed(() => props.status === 'failed' ? 'Web search failed' : 'Web search')
+const icon = computed(() => props.status === 'failed' ? 'i-lucide-triangle-alert' : 'i-lucide-search')
+const { open, isLoading, isStreaming } = useChatToolState(() => props.status, props.status === 'failed')
 </script>
 
 <template>
   <UChatTool
-    text="Web search"
+    :text="title"
     :suffix="item.query"
-    icon="i-lucide-search"
+    :icon="icon"
     :loading="isLoading"
     :streaming="isStreaming"
     variant="inline"
     :open="open"
+    :default-open="status === 'failed'"
     @update:open="open = $event"
   />
 </template>

--- a/packages/client/app/components/message-part/Item.ts
+++ b/packages/client/app/components/message-part/Item.ts
@@ -35,13 +35,25 @@ export default defineComponent({
         case 'command_execution':
           return h(MessageItemCommandExecution, { item: itemData.item })
         case 'file_change':
-          return h(MessageItemFileChange, { item: itemData.item })
+          return h(MessageItemFileChange, {
+            item: itemData.item,
+            liveOutput: itemData.liveOutput
+          })
         case 'mcp_tool_call':
-          return h(MessageItemMcpToolCall, { item: itemData.item })
+          return h(MessageItemMcpToolCall, {
+            item: itemData.item,
+            progressMessages: itemData.progressMessages
+          })
         case 'dynamic_tool_call':
-          return h(MessageItemDynamicToolCall, { item: itemData.item })
+          return h(MessageItemDynamicToolCall, {
+            item: itemData.item,
+            progressMessages: itemData.progressMessages
+          })
         case 'subagent_activity':
-          return h(MessageItemSubagentActivity, { item: itemData.item })
+          return h(MessageItemSubagentActivity, {
+            item: itemData.item,
+            agentStates: itemData.agentStates
+          })
         case 'web_search':
           return h(MessageItemWebSearch, {
             item: itemData.item,

--- a/packages/client/app/components/message-part/Item.ts
+++ b/packages/client/app/components/message-part/Item.ts
@@ -57,7 +57,7 @@ export default defineComponent({
         case 'web_search':
           return h(MessageItemWebSearch, {
             item: itemData.item,
-            pending: props.messagePending
+            status: itemData.status
           })
         case 'context_compaction':
           return h(MessageItemContextCompaction)

--- a/packages/client/app/components/message-part/Item.ts
+++ b/packages/client/app/components/message-part/Item.ts
@@ -18,6 +18,10 @@ export default defineComponent({
     part: {
       type: Object as PropType<ChatPart | null>,
       default: null
+    },
+    messagePending: {
+      type: Boolean,
+      default: false
     }
   },
   setup(props) {
@@ -39,7 +43,10 @@ export default defineComponent({
         case 'subagent_activity':
           return h(MessageItemSubagentActivity, { item: itemData.item })
         case 'web_search':
-          return h(MessageItemWebSearch, { item: itemData.item })
+          return h(MessageItemWebSearch, {
+            item: itemData.item,
+            pending: props.messagePending
+          })
         case 'context_compaction':
           return h(MessageItemContextCompaction)
         default:

--- a/packages/client/app/composables/useChatSession.ts
+++ b/packages/client/app/composables/useChatSession.ts
@@ -1,12 +1,12 @@
 import { ref, type Ref } from 'vue'
 import type { ChatMessage, SubagentAgentStatus, VisualSubagentPanel } from '~~/shared/codex-chat'
 import type { CollaborationModeMask } from '~~/shared/collaboration-mode'
+import type { ReasoningEffort } from '~~/shared/generated/codex-app-server/ReasoningEffort'
 import type { CodexRpcNotification } from '~~/shared/codex-rpc'
 import type { ThreadPlanState } from '~~/shared/turn-plan'
 import {
   FALLBACK_MODELS,
   type ModelOption,
-  type ReasoningEffort,
   type TokenUsageSnapshot
 } from '~~/shared/chat-prompt-controls'
 

--- a/packages/client/app/composables/useChatSession.ts
+++ b/packages/client/app/composables/useChatSession.ts
@@ -1,7 +1,7 @@
 import { ref, type Ref } from 'vue'
 import type { ChatMessage, SubagentAgentStatus, VisualSubagentPanel } from '~~/shared/codex-chat'
-import type { CollaborationModeMask } from '~~/shared/collaboration-mode'
 import type { ReasoningEffort } from '~~/shared/generated/codex-app-server/ReasoningEffort'
+import type { CollaborationModeMask } from '~~/shared/generated/codex-app-server/v2/CollaborationModeMask'
 import type { CodexRpcNotification } from '~~/shared/codex-rpc'
 import type { ThreadPlanState } from '~~/shared/turn-plan'
 import {

--- a/packages/client/app/composables/useChatSession.ts
+++ b/packages/client/app/composables/useChatSession.ts
@@ -1,7 +1,7 @@
 import { ref, type Ref } from 'vue'
 import type { ChatMessage, SubagentAgentStatus, VisualSubagentPanel } from '~~/shared/codex-chat'
+import type { CollaborationModeMask } from '~~/shared/collaboration-mode'
 import type { ReasoningEffort } from '~~/shared/generated/codex-app-server/ReasoningEffort'
-import type { CollaborationModeMask } from '~~/shared/generated/codex-app-server/v2/CollaborationModeMask'
 import type { CodexRpcNotification } from '~~/shared/codex-rpc'
 import type { ThreadPlanState } from '~~/shared/turn-plan'
 import {

--- a/packages/client/app/composables/useChatSession.ts
+++ b/packages/client/app/composables/useChatSession.ts
@@ -72,38 +72,42 @@ export type ChatSession = {
 
 const sessions = new Map<string, ChatSession>()
 
-const createSession = (): ChatSession => ({
-  messages: ref<ChatMessage[]>([]),
-  subagentPanels: ref<SubagentPanelState[]>([]),
-  threadPlans: ref<Record<string, ThreadPlanState>>({}),
-  threadCollaborationModeMasks: ref<Record<string, CollaborationModeMask>>({}),
-  collaborationModeMasks: ref<CollaborationModeMask[]>([]),
-  collaborationModesLoaded: ref(false),
-  collaborationModesLoading: ref(false),
-  collaborationModesError: ref<string | null>(null),
-  status: ref<ChatStatus>('ready'),
-  error: ref<string | null>(null),
-  activeThreadId: ref<string | null>(null),
-  threadTitle: ref<string | null>(null),
-  pendingThreadId: ref<string | null>(null),
-  autoRedirectThreadId: ref<string | null>(null),
-  loadVersion: ref(0),
-  promptControlsLoaded: ref(false),
-  promptControlsLoading: ref(false),
-  availableModels: ref<ModelOption[]>(FALLBACK_MODELS),
-  selectedModel: ref(FALLBACK_MODELS[0]!.model),
-  selectedEffort: ref(FALLBACK_MODELS[0]!.defaultReasoningEffort),
-  modelContextWindow: ref<number | null>(null),
-  tokenUsage: ref<TokenUsageSnapshot | null>(null),
-  latestPlanTurnId: ref<string | null>(null),
-  queuedPlanImplementationPromptTurnId: ref<string | null>(null),
-  queuedPlanImplementationPromptThreadId: ref<string | null>(null),
-  planImplementationPromptTurnId: ref<string | null>(null),
-  planImplementationPromptThreadId: ref<string | null>(null),
-  shownPlanImplementationPromptTurnIds: new Set<string>(),
-  pendingLiveStream: null,
-  liveStream: null
-})
+const createSession = (): ChatSession => {
+  const session: ChatSession = {
+    messages: ref([]) as Ref<ChatMessage[]>,
+    subagentPanels: ref([]) as Ref<SubagentPanelState[]>,
+    threadPlans: ref({}) as Ref<Record<string, ThreadPlanState>>,
+    threadCollaborationModeMasks: ref({}) as Ref<Record<string, CollaborationModeMask>>,
+    collaborationModeMasks: ref([]) as Ref<CollaborationModeMask[]>,
+    collaborationModesLoaded: ref(false),
+    collaborationModesLoading: ref(false),
+    collaborationModesError: ref(null) as Ref<string | null>,
+    status: ref('ready') as Ref<ChatStatus>,
+    error: ref(null) as Ref<string | null>,
+    activeThreadId: ref(null) as Ref<string | null>,
+    threadTitle: ref(null) as Ref<string | null>,
+    pendingThreadId: ref(null) as Ref<string | null>,
+    autoRedirectThreadId: ref(null) as Ref<string | null>,
+    loadVersion: ref(0),
+    promptControlsLoaded: ref(false),
+    promptControlsLoading: ref(false),
+    availableModels: ref(FALLBACK_MODELS) as Ref<ModelOption[]>,
+    selectedModel: ref(FALLBACK_MODELS[0]!.model),
+    selectedEffort: ref(FALLBACK_MODELS[0]!.defaultReasoningEffort),
+    modelContextWindow: ref(null) as Ref<number | null>,
+    tokenUsage: ref(null) as Ref<TokenUsageSnapshot | null>,
+    latestPlanTurnId: ref(null) as Ref<string | null>,
+    queuedPlanImplementationPromptTurnId: ref(null) as Ref<string | null>,
+    queuedPlanImplementationPromptThreadId: ref(null) as Ref<string | null>,
+    planImplementationPromptTurnId: ref(null) as Ref<string | null>,
+    planImplementationPromptThreadId: ref(null) as Ref<string | null>,
+    shownPlanImplementationPromptTurnIds: new Set<string>(),
+    pendingLiveStream: null,
+    liveStream: null
+  }
+
+  return session
+}
 
 export const useChatSession = (projectId: string) => {
   const existing = sessions.get(projectId)

--- a/packages/client/app/composables/useThreadSummaries.ts
+++ b/packages/client/app/composables/useThreadSummaries.ts
@@ -1,5 +1,5 @@
 import { ref, type Ref } from 'vue'
-import type { CodexThread } from '~~/shared/codex-rpc'
+import type { Thread } from '~~/shared/generated/codex-app-server/v2/Thread'
 
 export type ThreadSummary = {
   id: string
@@ -17,7 +17,7 @@ type UseThreadSummariesResult = ThreadSummariesState & {
   setThreads: (nextThreads: ThreadSummary[]) => void
   setLoading: (nextLoading: boolean) => void
   setError: (nextError: string | null) => void
-  syncThreadSummary: (thread: Pick<CodexThread, 'id' | 'name' | 'preview' | 'updatedAt'>) => void
+  syncThreadSummary: (thread: Pick<Thread, 'id' | 'name' | 'preview' | 'updatedAt'>) => void
   updateThreadSummaryTitle: (threadId: string, title: string, updatedAt?: number) => void
 }
 
@@ -49,7 +49,7 @@ export const normalizeThreadTitleCandidate = (value: string | null | undefined) 
   return stripped
 }
 
-export const resolveThreadSummaryTitle = (thread: Pick<CodexThread, 'id' | 'name' | 'preview'>) => {
+export const resolveThreadSummaryTitle = (thread: Pick<Thread, 'id' | 'name' | 'preview'>) => {
   const nextTitle = normalizeThreadTitleCandidate(thread.name) || normalizeThreadTitleCandidate(thread.preview)
   return nextTitle || `Thread ${thread.id}`
 }
@@ -97,7 +97,7 @@ const createApi = (state: ThreadSummariesState): UseThreadSummariesResult => ({
   setError: (nextError: string | null) => {
     state.error.value = nextError
   },
-  syncThreadSummary: (thread: Pick<CodexThread, 'id' | 'name' | 'preview' | 'updatedAt'>) => {
+  syncThreadSummary: (thread: Pick<Thread, 'id' | 'name' | 'preview' | 'updatedAt'>) => {
     state.threads.value = mergeThreadSummary(state.threads.value, {
       id: thread.id,
       title: resolveThreadSummaryTitle(thread),

--- a/packages/client/shared/chat-attachments.ts
+++ b/packages/client/shared/chat-attachments.ts
@@ -1,4 +1,4 @@
-import type { CodexUserInput } from './codex-rpc'
+import type { UserInput } from './generated/codex-app-server/v2/UserInput'
 import { encodeProjectIdSegment } from './codori'
 import { resolveApiUrl, shouldUseServerProxy } from './network'
 
@@ -79,9 +79,9 @@ export const validateAttachmentSelection = <T extends FileLike>(
 export const buildTurnStartInput = (
   text: string,
   attachments: Array<{ path: string }>,
-  additionalInput: CodexUserInput[] = []
-): CodexUserInput[] => {
-  const input: CodexUserInput[] = []
+  additionalInput: UserInput[] = []
+): UserInput[] => {
+  const input: UserInput[] = []
   const trimmedText = text.trim()
 
   if (trimmedText) {

--- a/packages/client/shared/chat-prompt-controls.ts
+++ b/packages/client/shared/chat-prompt-controls.ts
@@ -1,3 +1,5 @@
+import type { ReasoningEffort } from './generated/codex-app-server/ReasoningEffort'
+
 export const FALLBACK_REASONING_EFFORTS = [
   'none',
   'minimal',
@@ -5,9 +7,7 @@ export const FALLBACK_REASONING_EFFORTS = [
   'medium',
   'high',
   'xhigh'
-] as const
-
-export type ReasoningEffort = typeof FALLBACK_REASONING_EFFORTS[number]
+] as const satisfies readonly ReasoningEffort[]
 
 export type ModelOption = {
   id: string

--- a/packages/client/shared/codex-chat.ts
+++ b/packages/client/shared/codex-chat.ts
@@ -1,12 +1,9 @@
 import type { MessagePhase } from './generated/codex-app-server/MessagePhase'
-import type { UserInput as GeneratedUserInput } from './generated/codex-app-server/v2/UserInput'
 import type { MemoryCitation } from './generated/codex-app-server/v2/MemoryCitation'
 import type { Thread } from './generated/codex-app-server/v2/Thread'
 import type { ThreadItem } from './generated/codex-app-server/v2/ThreadItem'
 import type { Turn } from './generated/codex-app-server/v2/Turn'
-
-export type CodexUserInput = GeneratedUserInput
-export type CodexThreadItem = ThreadItem
+import type { UserInput } from './generated/codex-app-server/v2/UserInput'
 
 export const EVENT_PART = 'data-thread-event' as const
 export const ITEM_PART = 'data-thread-item' as const
@@ -34,13 +31,13 @@ export type ThreadEventData =
       message: string
     }
 
-export type CommandExecutionItem = Extract<CodexThreadItem, { type: 'commandExecution' }>
+export type CommandExecutionItem = Extract<ThreadItem, { type: 'commandExecution' }>
 
-export type FileChangeItem = Extract<CodexThreadItem, { type: 'fileChange' }>
-export type McpToolCallItem = Extract<CodexThreadItem, { type: 'mcpToolCall' }>
-export type DynamicToolCallItem = Extract<CodexThreadItem, { type: 'dynamicToolCall' }>
+export type FileChangeItem = Extract<ThreadItem, { type: 'fileChange' }>
+export type McpToolCallItem = Extract<ThreadItem, { type: 'mcpToolCall' }>
+export type DynamicToolCallItem = Extract<ThreadItem, { type: 'dynamicToolCall' }>
 
-export type SubagentTool = Extract<CodexThreadItem, { type: 'collabAgentToolCall' }>['tool']
+export type SubagentTool = Extract<ThreadItem, { type: 'collabAgentToolCall' }>['tool']
 export type SubagentToolStatus = 'inProgress' | 'completed' | 'failed'
 export type SubagentAgentStatus =
   | 'pendingInit'
@@ -58,7 +55,7 @@ export type SubagentAgentState = {
   message: string | null
 }
 
-export type SubagentActivityItem = Extract<CodexThreadItem, { type: 'collabAgentToolCall' }>
+export type SubagentActivityItem = Extract<ThreadItem, { type: 'collabAgentToolCall' }>
 
 export type VisualSubagentPanel = {
   threadId: string
@@ -97,11 +94,11 @@ export type ItemData =
     }
   | {
       kind: 'web_search'
-      item: Extract<CodexThreadItem, { type: 'webSearch' }>
+      item: Extract<ThreadItem, { type: 'webSearch' }>
     }
   | {
       kind: 'context_compaction'
-      item: Extract<CodexThreadItem, { type: 'contextCompaction' }>
+      item: Extract<ThreadItem, { type: 'contextCompaction' }>
     }
 
 export type ChatPart =
@@ -152,7 +149,7 @@ export const asAgentMessageItem = (input: {
   text: string
   phase?: MessagePhase | null
   memoryCitation?: MemoryCitation | null
-}): Extract<CodexThreadItem, { type: 'agentMessage' }> => ({
+}): Extract<ThreadItem, { type: 'agentMessage' }> => ({
   type: 'agentMessage',
   id: input.id,
   text: input.text,
@@ -184,7 +181,7 @@ const attachmentMediaTypeFromUrl = (url: string) => {
   return match?.[1] || 'image/*'
 }
 
-const userInputToParts = (input: CodexUserInput): ChatPart[] => {
+const userInputToParts = (input: UserInput): ChatPart[] => {
   if (input.type === 'text') {
     if (!input.text.trim()) {
       return []
@@ -224,18 +221,18 @@ const userInputToParts = (input: CodexUserInput): ChatPart[] => {
   }]
 }
 
-const getUserMessageText = (item: Extract<CodexThreadItem, { type: 'userMessage' }>) =>
+const getUserMessageText = (item: Extract<ThreadItem, { type: 'userMessage' }>) =>
   item.content
-    .filter((input): input is Extract<CodexUserInput, { type: 'text' }> => input.type === 'text')
+    .filter((input): input is Extract<UserInput, { type: 'text' }> => input.type === 'text')
     .map(input => input.text.trim())
     .filter(Boolean)
     .join('\n')
 
 const shouldHideReviewBootstrapUserMessage = (
-  item: Extract<CodexThreadItem, { type: 'userMessage' }>,
+  item: Extract<ThreadItem, { type: 'userMessage' }>,
   turn: Turn
 ) => {
-  const reviewLifecycle = turn.items.find((candidate): candidate is Extract<CodexThreadItem, { type: 'enteredReviewMode' | 'exitedReviewMode' }> =>
+  const reviewLifecycle = turn.items.find((candidate): candidate is Extract<ThreadItem, { type: 'enteredReviewMode' | 'exitedReviewMode' }> =>
     (candidate.type === 'enteredReviewMode' || candidate.type === 'exitedReviewMode')
     && candidate.id === item.id
   )
@@ -247,7 +244,7 @@ const shouldHideReviewBootstrapUserMessage = (
   return getUserMessageText(item) === reviewLifecycle.review.trim()
 }
 
-export const itemToMessages = (item: CodexThreadItem): ChatMessage[] => {
+export const itemToMessages = (item: ThreadItem): ChatMessage[] => {
   switch (item.type) {
     case 'userMessage':
       return [{

--- a/packages/client/shared/codex-chat.ts
+++ b/packages/client/shared/codex-chat.ts
@@ -1,4 +1,11 @@
-import type { CodexThread, CodexThreadItem, CodexTurn, CodexUserInput } from './codex-rpc'
+import type { MessagePhase } from './generated/codex-app-server/MessagePhase'
+import type { UserInput as GeneratedUserInput } from './generated/codex-app-server/v2/UserInput'
+import type { MemoryCitation } from './generated/codex-app-server/v2/MemoryCitation'
+import type { ThreadItem } from './generated/codex-app-server/v2/ThreadItem'
+import type { CodexThread, CodexTurn } from './codex-rpc'
+
+export type CodexUserInput = GeneratedUserInput
+export type CodexThreadItem = ThreadItem
 
 export const EVENT_PART = 'data-thread-event' as const
 export const ITEM_PART = 'data-thread-item' as const
@@ -144,6 +151,19 @@ export type ChatMessage = {
   pending?: boolean
   parts: ChatPart[]
 }
+
+export const asAgentMessageItem = (input: {
+  id: string
+  text: string
+  phase?: MessagePhase | null
+  memoryCitation?: MemoryCitation | null
+}): Extract<CodexThreadItem, { type: 'agentMessage' }> => ({
+  type: 'agentMessage',
+  id: input.id,
+  text: input.text,
+  phase: input.phase ?? null,
+  memoryCitation: input.memoryCitation ?? null
+})
 
 export const isSubagentActiveStatus = (status: SubagentAgentStatus) =>
   status === null || status === 'pendingInit' || status === 'running'
@@ -339,7 +359,6 @@ export const itemToMessages = (item: CodexThreadItem): ChatMessage[] => {
       return [{
         id: item.id,
         role: 'system',
-        pending: item.status === 'inProgress',
         parts: [{
           type: ITEM_PART,
           data: {

--- a/packages/client/shared/codex-chat.ts
+++ b/packages/client/shared/codex-chat.ts
@@ -67,6 +67,8 @@ export type VisualSubagentPanel = {
   lastSeenAt: number
 }
 
+export type WebSearchStatus = 'inProgress' | 'completed' | 'failed'
+
 export type ItemData =
   | {
       kind: 'command_execution'
@@ -95,6 +97,7 @@ export type ItemData =
   | {
       kind: 'web_search'
       item: Extract<ThreadItem, { type: 'webSearch' }>
+      status: WebSearchStatus
     }
   | {
       kind: 'context_compaction'
@@ -244,7 +247,13 @@ const shouldHideReviewBootstrapUserMessage = (
   return getUserMessageText(item) === reviewLifecycle.review.trim()
 }
 
-export const itemToMessages = (item: ThreadItem): ChatMessage[] => {
+export const itemToMessages = (
+  item: ThreadItem,
+  options: {
+    webSearchPending?: boolean
+    webSearchStatus?: WebSearchStatus
+  } = {}
+): ChatMessage[] => {
   switch (item.type) {
     case 'userMessage':
       return [{
@@ -353,11 +362,13 @@ export const itemToMessages = (item: ThreadItem): ChatMessage[] => {
       return [{
         id: item.id,
         role: 'system',
+        pending: options.webSearchPending,
         parts: [{
           type: ITEM_PART,
           data: {
             kind: 'web_search',
-            item
+            item,
+            status: options.webSearchStatus ?? 'completed'
           }
         }]
       }]
@@ -417,7 +428,16 @@ export const threadToMessages = (thread: Thread) =>
         return []
       }
 
-      return itemToMessages(item)
+      return itemToMessages(item, {
+        webSearchPending: item.type === 'webSearch' && turn.status === 'inProgress',
+        webSearchStatus: item.type === 'webSearch'
+          ? (turn.status === 'failed'
+            ? 'failed'
+            : turn.status === 'inProgress'
+              ? 'inProgress'
+              : 'completed')
+          : undefined
+      })
     })
   )
 

--- a/packages/client/shared/codex-chat.ts
+++ b/packages/client/shared/codex-chat.ts
@@ -1,8 +1,9 @@
 import type { MessagePhase } from './generated/codex-app-server/MessagePhase'
 import type { UserInput as GeneratedUserInput } from './generated/codex-app-server/v2/UserInput'
 import type { MemoryCitation } from './generated/codex-app-server/v2/MemoryCitation'
+import type { Thread } from './generated/codex-app-server/v2/Thread'
 import type { ThreadItem } from './generated/codex-app-server/v2/ThreadItem'
-import type { CodexThread, CodexTurn } from './codex-rpc'
+import type { Turn } from './generated/codex-app-server/v2/Turn'
 
 export type CodexUserInput = GeneratedUserInput
 export type CodexThreadItem = ThreadItem
@@ -227,7 +228,7 @@ const getUserMessageText = (item: Extract<CodexThreadItem, { type: 'userMessage'
 
 const shouldHideReviewBootstrapUserMessage = (
   item: Extract<CodexThreadItem, { type: 'userMessage' }>,
-  turn: CodexTurn
+  turn: Turn
 ) => {
   const reviewLifecycle = turn.items.find((candidate): candidate is Extract<CodexThreadItem, { type: 'enteredReviewMode' | 'exitedReviewMode' }> =>
     (candidate.type === 'enteredReviewMode' || candidate.type === 'exitedReviewMode')
@@ -416,7 +417,7 @@ export const itemToMessages = (item: CodexThreadItem): ChatMessage[] => {
   }
 }
 
-export const threadToMessages = (thread: CodexThread) =>
+export const threadToMessages = (thread: Thread) =>
   thread.turns.flatMap((turn) =>
     turn.items.flatMap((item) => {
       if (item.type === 'userMessage' && shouldHideReviewBootstrapUserMessage(item, turn)) {
@@ -427,7 +428,7 @@ export const threadToMessages = (thread: CodexThread) =>
     })
   )
 
-export const findLatestPlanTurnId = (turns: CodexTurn[]) => {
+export const findLatestPlanTurnId = (turns: Turn[]) => {
   for (let index = turns.length - 1; index >= 0; index -= 1) {
     const turn = turns[index]
     if (turn && turn.items.some(item => item.type === 'plan')) {
@@ -438,7 +439,7 @@ export const findLatestPlanTurnId = (turns: CodexTurn[]) => {
   return null
 }
 
-export const findLatestCompletedPlanTurnId = (turns: CodexTurn[]) => {
+export const findLatestCompletedPlanTurnId = (turns: Turn[]) => {
   for (let index = turns.length - 1; index >= 0; index -= 1) {
     const turn = turns[index]
     if (turn && turn.status === 'completed' && turn.items.some(item => item.type === 'plan')) {

--- a/packages/client/shared/codex-chat.ts
+++ b/packages/client/shared/codex-chat.ts
@@ -36,17 +36,9 @@ export type ThreadEventData =
 
 export type CommandExecutionItem = Extract<CodexThreadItem, { type: 'commandExecution' }>
 
-export type FileChangeItem = Extract<CodexThreadItem, { type: 'fileChange' }> & {
-  liveOutput?: string | null
-}
-
-export type McpToolCallItem = Extract<CodexThreadItem, { type: 'mcpToolCall' }> & {
-  progressMessages?: string[]
-}
-
-export type DynamicToolCallItem = Extract<CodexThreadItem, { type: 'dynamicToolCall' }> & {
-  progressMessages?: string[]
-}
+export type FileChangeItem = Extract<CodexThreadItem, { type: 'fileChange' }>
+export type McpToolCallItem = Extract<CodexThreadItem, { type: 'mcpToolCall' }>
+export type DynamicToolCallItem = Extract<CodexThreadItem, { type: 'dynamicToolCall' }>
 
 export type SubagentTool = Extract<CodexThreadItem, { type: 'collabAgentToolCall' }>['tool']
 export type SubagentToolStatus = 'inProgress' | 'completed' | 'failed'
@@ -66,9 +58,7 @@ export type SubagentAgentState = {
   message: string | null
 }
 
-export type SubagentActivityItem = Omit<Extract<CodexThreadItem, { type: 'collabAgentToolCall' }>, 'agentsStates'> & {
-  agentsStates: SubagentAgentState[]
-}
+export type SubagentActivityItem = Extract<CodexThreadItem, { type: 'collabAgentToolCall' }>
 
 export type VisualSubagentPanel = {
   threadId: string
@@ -88,18 +78,22 @@ export type ItemData =
   | {
       kind: 'file_change'
       item: FileChangeItem
+      liveOutput?: string | null
     }
   | {
       kind: 'mcp_tool_call'
       item: McpToolCallItem
+      progressMessages?: string[]
     }
   | {
       kind: 'dynamic_tool_call'
       item: DynamicToolCallItem
+      progressMessages?: string[]
     }
   | {
       kind: 'subagent_activity'
       item: SubagentActivityItem
+      agentStates: SubagentAgentState[]
     }
   | {
       kind: 'web_search'
@@ -168,6 +162,17 @@ export const asAgentMessageItem = (input: {
 
 export const isSubagentActiveStatus = (status: SubagentAgentStatus) =>
   status === null || status === 'pendingInit' || status === 'running'
+
+const flattenSubagentAgentStates = (
+  item: SubagentActivityItem
+): SubagentAgentState[] => [
+  ...item.receiverThreadIds,
+  ...Object.keys(item.agentsStates).filter(threadId => !item.receiverThreadIds.includes(threadId))
+].map((threadId) => ({
+  threadId,
+  status: item.agentsStates[threadId]?.status ?? null,
+  message: item.agentsStates[threadId]?.message ?? null
+}))
 
 const streamingState = (pending?: boolean) => pending ? 'streaming' : 'done'
 
@@ -342,17 +347,8 @@ export const itemToMessages = (item: CodexThreadItem): ChatMessage[] => {
           type: ITEM_PART,
           data: {
             kind: 'subagent_activity',
-            item: {
-              ...item,
-              agentsStates: [
-                ...item.receiverThreadIds,
-                ...Object.keys(item.agentsStates).filter(threadId => !item.receiverThreadIds.includes(threadId))
-              ].map((threadId) => ({
-                threadId,
-                status: item.agentsStates[threadId]?.status ?? null,
-                message: item.agentsStates[threadId]?.message ?? null
-              }))
-            }
+            item,
+            agentStates: flattenSubagentAgentStates(item)
           }
         }]
       }]

--- a/packages/client/shared/codex-rpc.ts
+++ b/packages/client/shared/codex-rpc.ts
@@ -8,6 +8,7 @@ import type { ItemCompletedNotification as GeneratedItemCompletedNotification } 
 import type { ItemStartedNotification as GeneratedItemStartedNotification } from './generated/codex-app-server/v2/ItemStartedNotification'
 import type { PlanDeltaNotification as GeneratedPlanDeltaNotification } from './generated/codex-app-server/v2/PlanDeltaNotification'
 import type { ServerRequestResolvedNotification as GeneratedServerRequestResolvedNotification } from './generated/codex-app-server/v2/ServerRequestResolvedNotification'
+import type { ThreadItem as GeneratedThreadItem } from './generated/codex-app-server/v2/ThreadItem'
 import type { TurnCompletedNotification as GeneratedTurnCompletedNotification } from './generated/codex-app-server/v2/TurnCompletedNotification'
 import type { TurnPlanUpdatedNotification as GeneratedTurnPlanUpdatedNotification } from './generated/codex-app-server/v2/TurnPlanUpdatedNotification'
 import type { TurnStatus as GeneratedTurnStatus } from './generated/codex-app-server/v2/TurnStatus'
@@ -47,105 +48,7 @@ export type CodexRpcServerRequestHandler = (request: CodexRpcServerRequest) => P
 
 export type CodexUserInput = GeneratedUserInput
 
-export type CodexThreadItem =
-  | {
-      type: 'userMessage'
-      id: string
-      content: CodexUserInput[]
-    }
-  | {
-      type: 'agentMessage'
-      id: string
-      text: string
-    }
-  | {
-      type: 'plan'
-      id: string
-      text: string
-    }
-  | {
-      type: 'reasoning'
-      id: string
-      summary: string[]
-      content: string[]
-    }
-  | {
-      type: 'commandExecution'
-      id: string
-      command: string
-      aggregatedOutput: string | null
-      exitCode: number | null
-      status: string
-    }
-  | {
-      type: 'fileChange'
-      id: string
-      changes: Array<{
-        path: string
-        kind?: unknown
-        diff?: string | null
-      }>
-      status: string
-    }
-  | {
-      type: 'mcpToolCall'
-      id: string
-      server: string
-      tool: string
-      arguments: unknown
-      result: {
-        content?: unknown[]
-        structuredContent?: unknown
-      } | null
-      error: {
-        message: string
-      } | null
-      status: string
-    }
-  | {
-      type: 'dynamicToolCall'
-      id: string
-      tool: string
-      arguments: unknown
-      status: string
-      contentItems: Array<{ type: 'inputText', text: string } | { type: 'inputImage', imageUrl: string }> | null
-      success: boolean | null
-    }
-  | {
-      type: 'collabAgentToolCall'
-      id: string
-      tool: 'spawnAgent' | 'sendInput' | 'resumeAgent' | 'wait' | 'closeAgent'
-      status: string
-      senderThreadId: string
-      receiverThreadIds: string[]
-      prompt: string | null
-      model: string | null
-      reasoningEffort: string | null
-      agentsStates: Record<string, {
-        status: 'pendingInit' | 'running' | 'interrupted' | 'completed' | 'errored' | 'shutdown' | 'notFound' | null
-        message: string | null
-      } | undefined>
-    }
-  | {
-      type: 'webSearch'
-      id: string
-      query: string
-      status?: string
-    }
-  | {
-      type: 'contextCompaction'
-      id: string
-    }
-  | {
-      type: 'enteredReviewMode'
-      id: string
-      review: string
-    }
-  | {
-      type: 'exitedReviewMode'
-      id: string
-      review: string
-    }
+export type CodexThreadItem = GeneratedThreadItem
 
 export type CodexTurn = {
   id: string

--- a/packages/client/shared/codex-rpc.ts
+++ b/packages/client/shared/codex-rpc.ts
@@ -4,17 +4,14 @@ type JsonRpcError = {
   data?: unknown
 }
 
+import type { InitializeResponse } from './generated/codex-app-server/InitializeResponse'
 import type { ItemCompletedNotification as GeneratedItemCompletedNotification } from './generated/codex-app-server/v2/ItemCompletedNotification'
 import type { ItemStartedNotification as GeneratedItemStartedNotification } from './generated/codex-app-server/v2/ItemStartedNotification'
 import type { PlanDeltaNotification as GeneratedPlanDeltaNotification } from './generated/codex-app-server/v2/PlanDeltaNotification'
 import type { ServerRequestResolvedNotification as GeneratedServerRequestResolvedNotification } from './generated/codex-app-server/v2/ServerRequestResolvedNotification'
-import type { ThreadItem as GeneratedThreadItem } from './generated/codex-app-server/v2/ThreadItem'
 import type { TurnCompletedNotification as GeneratedTurnCompletedNotification } from './generated/codex-app-server/v2/TurnCompletedNotification'
 import type { TurnPlanUpdatedNotification as GeneratedTurnPlanUpdatedNotification } from './generated/codex-app-server/v2/TurnPlanUpdatedNotification'
 import type { TurnStatus as GeneratedTurnStatus } from './generated/codex-app-server/v2/TurnStatus'
-import type { UserInput as GeneratedUserInput } from './generated/codex-app-server/v2/UserInput'
-export type { ReasoningEffort } from './chat-prompt-controls'
-import type { ReasoningEffort } from './chat-prompt-controls'
 
 type JsonRpcId = string | number
 
@@ -45,110 +42,6 @@ type PendingRequest = {
 }
 
 export type CodexRpcServerRequestHandler = (request: CodexRpcServerRequest) => Promise<unknown> | unknown
-
-export type CodexUserInput = GeneratedUserInput
-
-export type CodexThreadItem = GeneratedThreadItem
-
-export type CodexTurn = {
-  id: string
-  items: CodexThreadItem[]
-  status: GeneratedTurnStatus
-  error: {
-    message: string
-  } | null
-  startedAt?: number | null
-  completedAt?: number | null
-  durationMs?: number | null
-}
-
-export type CodexThread = {
-  id: string
-  preview: string
-  cwd: string
-  createdAt: number
-  updatedAt: number
-  name: string | null
-  agentNickname?: string | null
-  agentRole?: string | null
-  turns: CodexTurn[]
-}
-
-export type InitializeResponse = {
-  userAgent: string
-  platformFamily: string
-  platformOs: string
-}
-
-export type ThreadListResponse = {
-  data: CodexThread[]
-  nextCursor: string | null
-}
-
-export type ThreadStartResponse = {
-  thread: CodexThread
-  model?: string | null
-  reasoningEffort?: ReasoningEffort | null
-}
-
-export type ThreadResumeResponse = {
-  thread: CodexThread
-  model?: string | null
-  reasoningEffort?: ReasoningEffort | null
-}
-
-export type ThreadReadResponse = {
-  thread: CodexThread
-}
-
-export type TurnStartResponse = {
-  turn: {
-    id: string
-  }
-}
-
-export type ReviewTarget =
-  | {
-      type: 'uncommittedChanges'
-    }
-  | {
-      type: 'baseBranch'
-      branch: string
-    }
-  | {
-      type: 'commit'
-      sha: string
-      title?: string | null
-    }
-  | {
-      type: 'custom'
-      instructions: string
-    }
-
-export type ReviewDelivery = 'inline' | 'detached'
-
-export type ReviewStartParams = {
-  threadId: string
-  delivery?: ReviewDelivery
-  target: ReviewTarget
-}
-
-export type ReviewStartResponse = {
-  reviewThreadId: string
-  turn: CodexTurn
-}
-
-export type ModelListResponse = {
-  data?: unknown[]
-}
-
-export type ConfigReadResponse = {
-  config?: {
-    model?: string | null
-    model_context_window?: number | string | null
-    model_reasoning_effort?: ReasoningEffort | null
-  } | null
-}
 
 export type CodexRpcNotification = {
   method: string

--- a/packages/client/shared/codex-rpc.ts
+++ b/packages/client/shared/codex-rpc.ts
@@ -5,6 +5,7 @@ type JsonRpcError = {
 }
 
 import type { InitializeResponse } from './generated/codex-app-server/InitializeResponse'
+import type { ServerNotification } from './generated/codex-app-server/ServerNotification'
 import type { ItemCompletedNotification as GeneratedItemCompletedNotification } from './generated/codex-app-server/v2/ItemCompletedNotification'
 import type { ItemStartedNotification as GeneratedItemStartedNotification } from './generated/codex-app-server/v2/ItemStartedNotification'
 import type { PlanDeltaNotification as GeneratedPlanDeltaNotification } from './generated/codex-app-server/v2/PlanDeltaNotification'
@@ -43,10 +44,17 @@ type PendingRequest = {
 
 export type CodexRpcServerRequestHandler = (request: CodexRpcServerRequest) => Promise<unknown> | unknown
 
-export type CodexRpcNotification = {
-  method: string
-  params?: unknown
-}
+type LegacyCodexRpcNotification =
+  | {
+      method: 'turn/failed'
+      params?: unknown
+    }
+  | {
+      method: 'stream/error'
+      params?: unknown
+    }
+
+export type CodexRpcNotification = ServerNotification | LegacyCodexRpcNotification
 
 const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -64,6 +72,9 @@ const asNotificationParams = <T>(
   notification.method === method && isObjectRecord(notification.params)
     ? notification.params as Partial<T>
     : null
+
+const notificationParams = (notification: CodexRpcNotification) =>
+  isObjectRecord(notification.params) ? notification.params : null
 
 const asError = (value: unknown) =>
   value instanceof Error ? value : new Error(typeof value === 'string' ? value : 'Unknown RPC error.')
@@ -138,7 +149,7 @@ export const notificationThreadId = (notification: CodexRpcNotification) => {
     return turnCompleted.threadId
   }
 
-  const params = isObjectRecord(notification.params) ? notification.params : null
+  const params = notificationParams(notification)
   const directThreadId = params?.threadId
   if (typeof directThreadId === 'string') {
     return directThreadId
@@ -178,7 +189,7 @@ export const notificationTurnId = (notification: CodexRpcNotification) => {
     return turnCompleted.turn.id
   }
 
-  const params = isObjectRecord(notification.params) ? notification.params : null
+  const params = notificationParams(notification)
 
   const directTurnId = params?.turnId
   if (typeof directTurnId === 'string') {
@@ -194,7 +205,7 @@ export const notificationTurnId = (notification: CodexRpcNotification) => {
 }
 
 export const notificationThreadName = (notification: CodexRpcNotification) => {
-  const params = isObjectRecord(notification.params) ? notification.params : null
+  const params = notificationParams(notification)
   const thread = isObjectRecord(params?.thread) ? params.thread : null
   const directName = thread?.name ?? params?.name ?? params?.title
 
@@ -202,7 +213,7 @@ export const notificationThreadName = (notification: CodexRpcNotification) => {
 }
 
 export const notificationThreadUpdatedAt = (notification: CodexRpcNotification) => {
-  const params = isObjectRecord(notification.params) ? notification.params : null
+  const params = notificationParams(notification)
   const thread = isObjectRecord(params?.thread) ? params.thread : null
   const directUpdatedAt = thread?.updatedAt ?? params?.updatedAt
 
@@ -215,7 +226,7 @@ export const notificationRequestId = (notification: CodexRpcNotification) => {
     return resolvedRequest.requestId
   }
 
-  const params = isObjectRecord(notification.params) ? notification.params : null
+  const params = notificationParams(notification)
   const directRequestId = params?.requestId
 
   return isJsonRpcId(directRequestId) ? directRequestId : null
@@ -227,7 +238,7 @@ export const notificationTurnStatus = (notification: CodexRpcNotification): Gene
     return turnCompleted.turn.status
   }
 
-  const params = isObjectRecord(notification.params) ? notification.params : null
+  const params = notificationParams(notification)
   const directStatus = params?.status
   if (isGeneratedTurnStatus(directStatus)) {
     return directStatus
@@ -395,7 +406,7 @@ export class CodexRpcClient {
     }
   }
 
-  private async parsePayload(raw: unknown): Promise<JsonRpcResponse | JsonRpcNotification | JsonRpcServerRequest | null> {
+  private async parsePayload(raw: unknown): Promise<JsonRpcResponse | CodexRpcNotification | JsonRpcServerRequest | null> {
     const text = typeof raw === 'string'
       ? raw
       : raw instanceof ArrayBuffer
@@ -422,7 +433,7 @@ export class CodexRpcClient {
       }
 
       if (typeof parsed.method === 'string') {
-        return parsed as JsonRpcNotification
+        return parsed as CodexRpcNotification
       }
 
       return null

--- a/packages/client/shared/codex-rpc.ts
+++ b/packages/client/shared/codex-rpc.ts
@@ -5,6 +5,7 @@ type JsonRpcError = {
 }
 
 import type { InitializeResponse } from './generated/codex-app-server/InitializeResponse'
+import type { ServerRequest } from './generated/codex-app-server/ServerRequest'
 import type { ServerNotification } from './generated/codex-app-server/ServerNotification'
 import type { ItemCompletedNotification as GeneratedItemCompletedNotification } from './generated/codex-app-server/v2/ItemCompletedNotification'
 import type { ItemStartedNotification as GeneratedItemStartedNotification } from './generated/codex-app-server/v2/ItemStartedNotification'
@@ -33,7 +34,24 @@ type JsonRpcNotification = {
   params?: unknown
 }
 
-export type CodexRpcServerRequest = JsonRpcRequest
+type LegacyCodexRpcServerRequest =
+  | {
+      id: JsonRpcId
+      method: 'item/tool/requestUserInput'
+      params: {
+        questions: Array<Record<string, unknown>>
+        threadId?: string
+        turnId?: string
+        itemId?: string
+      }
+    }
+  | {
+      id: JsonRpcId
+      method: 'mcpServer/elicitation/request'
+      params: Record<string, unknown>
+    }
+
+export type CodexRpcServerRequest = ServerRequest | LegacyCodexRpcServerRequest
 
 type JsonRpcServerRequest = CodexRpcServerRequest
 

--- a/packages/client/shared/collaboration-mode.ts
+++ b/packages/client/shared/collaboration-mode.ts
@@ -1,6 +1,6 @@
 import type { ReasoningEffort } from './generated/codex-app-server/ReasoningEffort'
-import type { CollaborationModeListResponse } from './generated/codex-app-server/v2/CollaborationModeListResponse'
-import type { CollaborationModeMask } from './generated/codex-app-server/v2/CollaborationModeMask'
+import type { CollaborationModeListResponse as GeneratedCollaborationModeListResponse } from './generated/codex-app-server/v2/CollaborationModeListResponse'
+import type { CollaborationModeMask as GeneratedCollaborationModeMask } from './generated/codex-app-server/v2/CollaborationModeMask'
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -35,7 +35,14 @@ const asReasoningEffort = (value: unknown): ReasoningEffort | null | undefined =
   }
 }
 
-export type CollaborationModeKind = NonNullable<CollaborationModeMask['mode']>
+export type CollaborationModeKind = NonNullable<GeneratedCollaborationModeMask['mode']>
+
+export type CollaborationModeMask = {
+  name: string
+  mode: CollaborationModeKind | null
+  model: string | null
+  reasoning_effort?: ReasoningEffort | null
+}
 
 export type CollaborationModeSettings = {
   model: string
@@ -73,11 +80,11 @@ const normalizeCollaborationModeMask = (value: unknown): CollaborationModeMask |
     name,
     mode: asModeKind(value.mode),
     model: asTrimmedString(value.model),
-    reasoning_effort: asReasoningEffort(reasoningSource) ?? null
+    reasoning_effort: asReasoningEffort(reasoningSource)
   }
 }
 
-export const normalizeCollaborationModeListResponse = (value: CollaborationModeListResponse | unknown): CollaborationModeMask[] => {
+export const normalizeCollaborationModeListResponse = (value: GeneratedCollaborationModeListResponse | unknown): CollaborationModeMask[] => {
   if (!isRecord(value) || !Array.isArray(value.data)) {
     return []
   }
@@ -108,7 +115,9 @@ export const buildCollaborationModeFromMask = (
     mode: mask.mode,
     settings: {
       model: mask.model ?? base.model,
-      reasoning_effort: mask.reasoning_effort ?? base.reasoning_effort,
+      reasoning_effort: mask.reasoning_effort === undefined
+        ? base.reasoning_effort
+        : mask.reasoning_effort,
       developer_instructions: null
     }
   }

--- a/packages/client/shared/collaboration-mode.ts
+++ b/packages/client/shared/collaboration-mode.ts
@@ -1,4 +1,4 @@
-import type { ReasoningEffort } from './chat-prompt-controls'
+import type { ReasoningEffort } from './generated/codex-app-server/ReasoningEffort'
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)

--- a/packages/client/shared/collaboration-mode.ts
+++ b/packages/client/shared/collaboration-mode.ts
@@ -1,4 +1,6 @@
 import type { ReasoningEffort } from './generated/codex-app-server/ReasoningEffort'
+import type { CollaborationModeListResponse } from './generated/codex-app-server/v2/CollaborationModeListResponse'
+import type { CollaborationModeMask } from './generated/codex-app-server/v2/CollaborationModeMask'
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -33,7 +35,7 @@ const asReasoningEffort = (value: unknown): ReasoningEffort | null | undefined =
   }
 }
 
-export type CollaborationModeKind = 'plan' | 'default'
+export type CollaborationModeKind = NonNullable<CollaborationModeMask['mode']>
 
 export type CollaborationModeSettings = {
   model: string
@@ -44,17 +46,6 @@ export type CollaborationModeSettings = {
 export type CollaborationMode = {
   mode: CollaborationModeKind
   settings: CollaborationModeSettings
-}
-
-export type CollaborationModeMask = {
-  name: string
-  mode: CollaborationModeKind | null
-  model: string | null
-  reasoning_effort?: ReasoningEffort | null
-}
-
-export type CollaborationModeListResponse = {
-  data: CollaborationModeMask[]
 }
 
 export const DRAFT_COLLABORATION_MODE_KEY = '__draft__'
@@ -82,11 +73,11 @@ const normalizeCollaborationModeMask = (value: unknown): CollaborationModeMask |
     name,
     mode: asModeKind(value.mode),
     model: asTrimmedString(value.model),
-    reasoning_effort: asReasoningEffort(reasoningSource)
+    reasoning_effort: asReasoningEffort(reasoningSource) ?? null
   }
 }
 
-export const normalizeCollaborationModeListResponse = (value: unknown): CollaborationModeMask[] => {
+export const normalizeCollaborationModeListResponse = (value: CollaborationModeListResponse | unknown): CollaborationModeMask[] => {
   if (!isRecord(value) || !Array.isArray(value.data)) {
     return []
   }
@@ -117,9 +108,7 @@ export const buildCollaborationModeFromMask = (
     mode: mask.mode,
     settings: {
       model: mask.model ?? base.model,
-      reasoning_effort: mask.reasoning_effort === undefined
-        ? base.reasoning_effort
-        : mask.reasoning_effort,
+      reasoning_effort: mask.reasoning_effort ?? base.reasoning_effort,
       developer_instructions: null
     }
   }

--- a/packages/client/shared/mention-autocomplete.ts
+++ b/packages/client/shared/mention-autocomplete.ts
@@ -1,5 +1,5 @@
 import type { SubagentAgentStatus } from './codex-chat'
-import type { CodexUserInput } from './codex-rpc'
+import type { UserInput } from './generated/codex-app-server/v2/UserInput'
 import { encodeProjectIdSegment } from './codori'
 import { resolveApiUrl, shouldUseServerProxy } from './network'
 
@@ -54,7 +54,7 @@ export type PluginMentionAutocompleteEntry = {
 }
 
 export type MentionAutocompleteSubmission = {
-  pluginInput: Extract<CodexUserInput, { type: 'mention' }>[]
+  pluginInput: Extract<UserInput, { type: 'mention' }>[]
   agentThreadIds: string[]
 }
 

--- a/packages/client/shared/pending-user-request.ts
+++ b/packages/client/shared/pending-user-request.ts
@@ -275,11 +275,11 @@ const parseElicitationField = (
 }
 
 export const parsePendingUserRequest = (request: CodexRpcServerRequest): PendingUserRequest | null => {
-  const params = isObjectRecord(request.params) ? request.params : null
-
   switch (request.method) {
     case 'item/tool/requestUserInput': {
-      const typedParams = params as Partial<ToolRequestUserInputParams> | null
+      const typedParams = isObjectRecord(request.params)
+        ? request.params as Partial<ToolRequestUserInputParams>
+        : null
       const questions = Array.isArray(typedParams?.questions)
         ? typedParams.questions
           .map(parseRequestUserInputQuestion)
@@ -299,6 +299,9 @@ export const parsePendingUserRequest = (request: CodexRpcServerRequest): Pending
       }
     }
     case 'mcpServer/elicitation/request': {
+      const params = isObjectRecord(request.params)
+        ? request.params as Record<string, unknown>
+        : null
       const mode = asTrimmedString(params?.mode)
       if (mode === 'url') {
         const url = asTrimmedString(params?.url)

--- a/packages/client/shared/turn-plan.ts
+++ b/packages/client/shared/turn-plan.ts
@@ -1,14 +1,10 @@
+import type { TurnPlanStep } from './generated/codex-app-server/v2/TurnPlanStep'
+import type { TurnPlanStepStatus } from './generated/codex-app-server/v2/TurnPlanStepStatus'
+
 type ObjectRecord = Record<string, unknown>
 
 const isObjectRecord = (value: unknown): value is ObjectRecord =>
   typeof value === 'object' && value !== null
-
-export type TurnPlanStepStatus = 'pending' | 'inProgress' | 'completed'
-
-export type TurnPlanStep = {
-  step: string
-  status: TurnPlanStepStatus
-}
 
 export type TurnPlanUpdate = {
   threadId: string | null

--- a/packages/client/test/chat-transcript.test.ts
+++ b/packages/client/test/chat-transcript.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { Thread } from '../shared/generated/codex-app-server/v2/Thread'
 import type { Turn } from '../shared/generated/codex-app-server/v2/Turn'
 import {
+  ITEM_PART,
   asAgentMessageItem,
   findLatestCompletedPlanTurnId,
   findLatestPlanTurnId,
@@ -408,6 +409,72 @@ describe('chat transcript stability', () => {
         type: 'text',
         text: 'Full review instructions',
         state: 'done'
+      }]
+    }])
+  })
+
+  it('keeps hydrated web-search items pending for in-progress turns', () => {
+    expect(threadToMessages(makeThread({
+      id: 'thread-1',
+      preview: '',
+      cwd: '/tmp',
+      createdAt: 0,
+      updatedAt: 0,
+      name: null,
+      turns: [makeTurn({
+        id: 'turn-1',
+        status: 'inProgress',
+        error: null,
+        items: [{
+          type: 'webSearch',
+          id: 'search-1',
+          query: 'codori',
+          action: null
+        }]
+      }), makeTurn({
+        id: 'turn-2',
+        status: 'completed',
+        error: null,
+        items: [{
+          type: 'webSearch',
+          id: 'search-2',
+          query: 'codex app server',
+          action: null
+        }]
+      })]
+    }))).toEqual<ChatMessage[]>([{
+      id: 'search-1',
+      role: 'system',
+      pending: true,
+      parts: [{
+        type: ITEM_PART,
+        data: {
+          kind: 'web_search',
+          item: {
+            type: 'webSearch',
+            id: 'search-1',
+            query: 'codori',
+            action: null
+          },
+          status: 'inProgress'
+        }
+      }]
+    }, {
+      id: 'search-2',
+      role: 'system',
+      pending: false,
+      parts: [{
+        type: ITEM_PART,
+        data: {
+          kind: 'web_search',
+          item: {
+            type: 'webSearch',
+            id: 'search-2',
+            query: 'codex app server',
+            action: null
+          },
+          status: 'completed'
+        }
       }]
     }])
   })

--- a/packages/client/test/chat-transcript.test.ts
+++ b/packages/client/test/chat-transcript.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest'
+import type { Thread } from '../shared/generated/codex-app-server/v2/Thread'
+import type { Turn } from '../shared/generated/codex-app-server/v2/Turn'
 import {
   asAgentMessageItem,
   findLatestCompletedPlanTurnId,
@@ -11,6 +13,36 @@ import {
 } from '../shared/codex-chat'
 import { mergeThreadSummary, renameThreadSummary } from '../app/composables/useThreadSummaries'
 import { resolveChatMessagesStatus } from '../app/utils/chat-messages-status'
+
+const makeTurn = (input: Pick<Turn, 'id' | 'items' | 'status' | 'error'> & Partial<Pick<Turn, 'startedAt' | 'completedAt' | 'durationMs'>>): Turn => ({
+  id: input.id,
+  items: input.items,
+  status: input.status,
+  error: input.error,
+  startedAt: input.startedAt ?? null,
+  completedAt: input.completedAt ?? null,
+  durationMs: input.durationMs ?? null
+})
+
+const makeThread = (input: Pick<Thread, 'id' | 'preview' | 'cwd' | 'createdAt' | 'updatedAt' | 'name' | 'turns'>): Thread => ({
+  id: input.id,
+  forkedFromId: null,
+  preview: input.preview,
+  ephemeral: false,
+  modelProvider: 'openai',
+  createdAt: input.createdAt,
+  updatedAt: input.updatedAt,
+  status: { type: 'idle' },
+  path: null,
+  cwd: input.cwd,
+  cliVersion: '0.0.0-test',
+  source: 'appServer',
+  agentNickname: null,
+  agentRole: null,
+  gitInfo: null,
+  name: input.name,
+  turns: input.turns
+})
 
 describe('chat transcript stability', () => {
   it('replaces a streamed text message with the completed server payload', () => {
@@ -135,7 +167,7 @@ describe('chat transcript stability', () => {
   })
 
   it('tracks the latest turn that contains a plan item', () => {
-    expect(findLatestPlanTurnId([{
+    expect(findLatestPlanTurnId([makeTurn({
       id: 'turn-1',
       status: 'completed',
       error: null,
@@ -143,7 +175,7 @@ describe('chat transcript stability', () => {
         id: 'agent-1',
         text: 'hello'
       })]
-    }, {
+    }), makeTurn({
       id: 'turn-2',
       status: 'completed',
       error: null,
@@ -152,7 +184,7 @@ describe('chat transcript stability', () => {
         id: 'plan-1',
         text: 'first plan'
       }]
-    }, {
+    }), makeTurn({
       id: 'turn-3',
       status: 'completed',
       error: null,
@@ -164,9 +196,9 @@ describe('chat transcript stability', () => {
         id: 'plan-2',
         text: 'latest plan'
       }]
-    }])).toBe('turn-3')
+    })])).toBe('turn-3')
 
-    expect(findLatestPlanTurnId([{
+    expect(findLatestPlanTurnId([makeTurn({
       id: 'turn-1',
       status: 'completed',
       error: null,
@@ -174,11 +206,11 @@ describe('chat transcript stability', () => {
         id: 'agent-1',
         text: 'hello'
       })]
-    }])).toBeNull()
+    })])).toBeNull()
   })
 
   it('tracks the latest completed turn that contains a plan item', () => {
-    expect(findLatestCompletedPlanTurnId([{
+    expect(findLatestCompletedPlanTurnId([makeTurn({
       id: 'turn-1',
       status: 'completed',
       error: null,
@@ -187,7 +219,7 @@ describe('chat transcript stability', () => {
         id: 'plan-1',
         text: 'first plan'
       }]
-    }, {
+    }), makeTurn({
       id: 'turn-2',
       status: 'inProgress',
       error: null,
@@ -196,9 +228,9 @@ describe('chat transcript stability', () => {
         id: 'plan-2',
         text: 'still streaming'
       }]
-    }])).toBe('turn-1')
+    })])).toBe('turn-1')
 
-    expect(findLatestCompletedPlanTurnId([{
+    expect(findLatestCompletedPlanTurnId([makeTurn({
       id: 'turn-1',
       status: 'inProgress',
       error: null,
@@ -207,7 +239,7 @@ describe('chat transcript stability', () => {
         id: 'plan-1',
         text: 'not done'
       }]
-    }])).toBeNull()
+    })])).toBeNull()
   })
 
   it('keeps chat loading state in submitted mode until real assistant output appears', () => {
@@ -326,14 +358,14 @@ describe('chat transcript stability', () => {
   })
 
   it('hides the synthetic review bootstrap user message when hydrating a thread', () => {
-    expect(threadToMessages({
+    expect(threadToMessages(makeThread({
       id: 'thread-1',
       preview: '',
       cwd: '/tmp',
       createdAt: 0,
       updatedAt: 0,
       name: null,
-      turns: [{
+      turns: [makeTurn({
         id: 'turn-1',
         status: 'completed',
         error: null,
@@ -358,8 +390,8 @@ describe('chat transcript stability', () => {
             text_elements: []
           }]
         }]
-      }]
-    })).toEqual<ChatMessage[]>([{
+      })]
+    }))).toEqual<ChatMessage[]>([{
       id: 'turn-1-review-started',
       role: 'system',
       parts: [{

--- a/packages/client/test/chat-transcript.test.ts
+++ b/packages/client/test/chat-transcript.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  asAgentMessageItem,
   findLatestCompletedPlanTurnId,
   findLatestPlanTurnId,
   itemToMessages,
@@ -138,11 +139,10 @@ describe('chat transcript stability', () => {
       id: 'turn-1',
       status: 'completed',
       error: null,
-      items: [{
-        type: 'agentMessage',
+      items: [asAgentMessageItem({
         id: 'agent-1',
         text: 'hello'
-      }]
+      })]
     }, {
       id: 'turn-2',
       status: 'completed',
@@ -156,11 +156,10 @@ describe('chat transcript stability', () => {
       id: 'turn-3',
       status: 'completed',
       error: null,
-      items: [{
-        type: 'agentMessage',
+      items: [asAgentMessageItem({
         id: 'agent-2',
         text: 'follow-up'
-      }, {
+      }), {
         type: 'plan',
         id: 'plan-2',
         text: 'latest plan'
@@ -171,11 +170,10 @@ describe('chat transcript stability', () => {
       id: 'turn-1',
       status: 'completed',
       error: null,
-      items: [{
-        type: 'agentMessage',
+      items: [asAgentMessageItem({
         id: 'agent-1',
         text: 'hello'
-      }]
+      })]
     }])).toBeNull()
   })
 

--- a/packages/client/test/collaboration-mode.test.ts
+++ b/packages/client/test/collaboration-mode.test.ts
@@ -28,7 +28,7 @@ describe('collaboration mode helpers', () => {
       name: 'Default',
       mode: 'default',
       model: null,
-      reasoning_effort: undefined
+      reasoning_effort: null
     }])
   })
 

--- a/packages/client/test/collaboration-mode.test.ts
+++ b/packages/client/test/collaboration-mode.test.ts
@@ -28,8 +28,29 @@ describe('collaboration mode helpers', () => {
       name: 'Default',
       mode: 'default',
       model: null,
-      reasoning_effort: null
+      reasoning_effort: undefined
     }])
+  })
+
+  it('preserves explicit null reasoning effort overrides', () => {
+    const defaultMask = findCollaborationModeMask([{
+      name: 'Default',
+      mode: 'default',
+      model: null,
+      reasoning_effort: null
+    }], 'default')
+
+    expect(buildCollaborationModeFromMask(defaultMask, {
+      model: 'gpt-5.4',
+      reasoning_effort: 'high'
+    })).toEqual({
+      mode: 'default',
+      settings: {
+        model: 'gpt-5.4',
+        reasoning_effort: null,
+        developer_instructions: null
+      }
+    })
   })
 
   it('builds a concrete collaboration mode from a mask and base prompt settings', () => {

--- a/packages/client/test/pending-user-request-shared.test.ts
+++ b/packages/client/test/pending-user-request-shared.test.ts
@@ -1,23 +1,76 @@
 import { nextTick, ref } from 'vue'
 import { describe, expect, it } from 'vitest'
 import { usePendingUserRequest } from '../app/composables/usePendingUserRequest'
-import { toServerRequestResponse } from '../shared/codex-rpc'
+import { toServerRequestResponse, type CodexRpcServerRequest } from '../shared/codex-rpc'
 import {
   buildMcpElicitationResponse,
   buildRequestUserInputResponse,
   parsePendingUserRequest
 } from '../shared/pending-user-request'
 
+const makeRequestUserInputRequest = (input: {
+  id: string | number
+  threadId?: string | null
+  turnId?: string | null
+  itemId?: string | null
+  questions: Array<Record<string, unknown>>
+}): CodexRpcServerRequest => ({
+  id: input.id,
+  method: 'item/tool/requestUserInput',
+  params: {
+    ...(input.threadId != null ? { threadId: input.threadId } : {}),
+    ...(input.turnId != null ? { turnId: input.turnId } : {}),
+    ...(input.itemId != null ? { itemId: input.itemId } : {}),
+    questions: input.questions
+  }
+})
+
+const makeMcpElicitationRequest = (input: {
+  id: string | number
+  mode: 'form' | 'url'
+  threadId?: string | null
+  turnId?: string | null
+  serverName?: string
+  message: string
+  requestedSchema?: Record<string, unknown>
+  url?: string
+  elicitationId?: string
+}): CodexRpcServerRequest => ({
+  id: input.id,
+  method: 'mcpServer/elicitation/request',
+  params: input.mode === 'form'
+    ? {
+        mode: 'form',
+        ...(input.threadId != null ? { threadId: input.threadId } : {}),
+        ...(input.turnId !== undefined ? { turnId: input.turnId } : {}),
+        serverName: input.serverName ?? 'test-server',
+        _meta: null,
+        message: input.message,
+        requestedSchema: input.requestedSchema ?? {
+          type: 'object',
+          properties: {}
+        }
+      }
+    : {
+        mode: 'url',
+        ...(input.threadId != null ? { threadId: input.threadId } : {}),
+        ...(input.turnId !== undefined ? { turnId: input.turnId } : {}),
+        serverName: input.serverName ?? 'test-server',
+        _meta: null,
+        message: input.message,
+        url: input.url ?? 'https://example.com/auth',
+        elicitationId: input.elicitationId ?? 'elic-1'
+      }
+})
+
 describe('pending user request shared helpers', () => {
   it('parses request-user-input questions and builds answers payloads', () => {
-    const parsed = parsePendingUserRequest({
+    const parsed = parsePendingUserRequest(makeRequestUserInputRequest({
       id: 7,
-      method: 'item/tool/requestUserInput',
-      params: {
-        threadId: 'thread-1',
-        turnId: 'turn-1',
-        itemId: 'item-1',
-        questions: [{
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      itemId: 'item-1',
+      questions: [{
           header: 'Scope',
           id: 'scope',
           question: 'What should Codex focus on?',
@@ -28,8 +81,7 @@ describe('pending user request shared helpers', () => {
           isOther: true,
           isSecret: false
         }]
-      }
-    })
+    }))
 
     expect(parsed).toEqual({
       kind: 'requestUserInput',
@@ -62,13 +114,11 @@ describe('pending user request shared helpers', () => {
   })
 
   it('parses MCP elicitation form and url requests', () => {
-    expect(parsePendingUserRequest({
+    expect(parsePendingUserRequest(makeMcpElicitationRequest({
       id: 9,
-      method: 'mcpServer/elicitation/request',
-      params: {
-        mode: 'form',
-        message: 'Need confirmation',
-        requestedSchema: {
+      mode: 'form',
+      message: 'Need confirmation',
+      requestedSchema: {
           type: 'object',
           properties: {
             email: {
@@ -83,8 +133,7 @@ describe('pending user request shared helpers', () => {
           },
           required: ['email']
         }
-      }
-    })).toEqual({
+    }))).toEqual({
       kind: 'mcpElicitationForm',
       requestId: 9,
       threadId: null,
@@ -109,16 +158,11 @@ describe('pending user request shared helpers', () => {
       }]
     })
 
-    expect(parsePendingUserRequest({
+    expect(parsePendingUserRequest(makeMcpElicitationRequest({
       id: 10,
-      method: 'mcpServer/elicitation/request',
-      params: {
-        mode: 'url',
-        message: 'Open the auth flow',
-        url: 'https://example.com/auth',
-        elicitationId: 'elic-1'
-      }
-    })).toEqual({
+      mode: 'url',
+      message: 'Open the auth flow'
+    }))).toEqual({
       kind: 'mcpElicitationUrl',
       requestId: 10,
       threadId: null,
@@ -140,16 +184,13 @@ describe('pending user request shared helpers', () => {
   })
 
   it('delegates interactive server requests to the UI handler before falling back', async () => {
-    await expect(toServerRequestResponse({
+    await expect(toServerRequestResponse(makeRequestUserInputRequest({
       id: 12,
-      method: 'item/tool/requestUserInput',
-      params: {
-        questions: [{
+      questions: [{
           id: 'choice',
           question: 'Pick one'
         }]
-      }
-    }, {
+    }), {
       handler: async () => ({
         answers: {
           choice: {
@@ -165,14 +206,11 @@ describe('pending user request shared helpers', () => {
       }
     })
 
-    await expect(toServerRequestResponse({
+    await expect(toServerRequestResponse(makeMcpElicitationRequest({
       id: 13,
-      method: 'mcpServer/elicitation/request',
-      params: {
-        mode: 'url',
-        url: 'https://example.com/auth'
-      }
-    }, {
+      mode: 'url',
+      message: 'Open the auth flow'
+    }), {
       handler: async () => null
     })).resolves.toEqual({
       action: 'decline',
@@ -183,17 +221,14 @@ describe('pending user request shared helpers', () => {
 
   it('holds an incoming request until the UI resolves it', async () => {
     const manager = usePendingUserRequest(`project-${Date.now()}`, ref('thread-1'))
-    const responsePromise = manager.handleServerRequest({
+    const responsePromise = manager.handleServerRequest(makeRequestUserInputRequest({
       id: 11,
-      method: 'item/tool/requestUserInput',
-      params: {
-        questions: [{
+      questions: [{
           id: 'choice',
           question: 'Pick one',
           options: [{ label: 'Ship', description: 'Proceed' }]
         }]
-      }
-    })
+    }))
 
     expect(manager.pendingRequest.value?.kind).toBe('requestUserInput')
 
@@ -220,18 +255,15 @@ describe('pending user request shared helpers', () => {
   it('only exposes requests for the active thread session', async () => {
     const activeThreadId = ref('thread-a')
     const manager = usePendingUserRequest(`project-${Date.now()}`, activeThreadId)
-    const responsePromise = manager.handleServerRequest({
+    const responsePromise = manager.handleServerRequest(makeRequestUserInputRequest({
       id: 14,
-      method: 'item/tool/requestUserInput',
-      params: {
-        threadId: 'thread-a',
-        questions: [{
+      threadId: 'thread-a',
+      questions: [{
           id: 'choice',
           question: 'Pick one',
           options: [{ label: 'Ship' }]
         }]
-      }
-    })
+    }))
 
     expect(manager.pendingRequest.value?.threadId).toBe('thread-a')
 
@@ -262,17 +294,14 @@ describe('pending user request shared helpers', () => {
   it('promotes draft-scoped live requests when a new thread starts', async () => {
     const activeThreadId = ref<string | null>(null)
     const manager = usePendingUserRequest(`project-${Date.now()}`, activeThreadId)
-    const responsePromise = manager.handleServerRequest({
+    const responsePromise = manager.handleServerRequest(makeRequestUserInputRequest({
       id: 17,
-      method: 'item/tool/requestUserInput',
-      params: {
-        questions: [{
+      questions: [{
           id: 'scope',
           question: 'Pick a scope',
           options: [{ label: 'ChatWorkspace' }]
         }]
-      }
-    })
+    }))
 
     expect(manager.pendingRequest.value?.kind).toBe('requestUserInput')
     expect(manager.pendingRequest.value?.threadId).toBeNull()
@@ -307,17 +336,14 @@ describe('pending user request shared helpers', () => {
     const currentThreadId = ref<string | null>('thread-route')
     const activeThreadId = ref<string | null>(null)
     const manager = usePendingUserRequest(projectId, currentThreadId, activeThreadId)
-    const responsePromise = manager.handleServerRequest({
+    const responsePromise = manager.handleServerRequest(makeRequestUserInputRequest({
       id: 18,
-      method: 'item/tool/requestUserInput',
-      params: {
-        questions: [{
+      questions: [{
           id: 'scope',
           question: 'Pick a scope',
           options: [{ label: 'Route thread' }]
         }]
-      }
-    })
+    }))
 
     expect(manager.pendingRequest.value?.kind).toBe('requestUserInput')
     expect(manager.pendingRequest.value?.threadId).toBeNull()
@@ -345,18 +371,15 @@ describe('pending user request shared helpers', () => {
     const projectId = `project-${Date.now()}`
     const currentThreadId = ref<string | null>('thread-route')
     const firstManager = usePendingUserRequest(projectId, currentThreadId)
-    const responsePromise = firstManager.handleServerRequest({
+    const responsePromise = firstManager.handleServerRequest(makeRequestUserInputRequest({
       id: 19,
-      method: 'item/tool/requestUserInput',
-      params: {
-        threadId: 'thread-route',
-        questions: [{
+      threadId: 'thread-route',
+      questions: [{
           id: 'scope',
           question: 'Pick a scope',
           options: [{ label: 'Preserved' }]
         }]
-      }
-    })
+    }))
 
     const secondManager = usePendingUserRequest(projectId, currentThreadId)
     expect(secondManager.pendingRequest.value?.kind).toBe('requestUserInput')
@@ -384,18 +407,15 @@ describe('pending user request shared helpers', () => {
     const projectId = `project-${Date.now()}`
     const currentThreadId = ref<string | null>('thread-a')
     const manager = usePendingUserRequest(projectId, currentThreadId)
-    const responsePromise = manager.handleServerRequest({
+    const responsePromise = manager.handleServerRequest(makeRequestUserInputRequest({
       id: 191,
-      method: 'item/tool/requestUserInput',
-      params: {
-        threadId: 'thread-a',
-        questions: [{
+      threadId: 'thread-a',
+      questions: [{
           id: 'scope',
           question: 'Pick a scope',
           options: [{ label: 'Chat surface' }]
         }]
-      }
-    })
+    }))
 
     currentThreadId.value = 'thread-b'
     expect(manager.pendingRequest.value).toBeNull()
@@ -422,18 +442,15 @@ describe('pending user request shared helpers', () => {
     const projectId = `project-${Date.now()}`
     const currentThreadId = ref<string | null>('thread-a')
     const manager = usePendingUserRequest(projectId, currentThreadId)
-    const responsePromise = manager.handleServerRequest({
+    const responsePromise = manager.handleServerRequest(makeRequestUserInputRequest({
       id: 192,
-      method: 'item/tool/requestUserInput',
-      params: {
-        threadId: 'thread-a',
-        questions: [{
+      threadId: 'thread-a',
+      questions: [{
           id: 'scope',
           question: 'Pick a scope',
           options: [{ label: 'Chat surface' }]
         }]
-      }
-    })
+    }))
 
     currentThreadId.value = 'thread-b'
     expect(manager.pendingRequest.value).toBeNull()
@@ -459,30 +476,24 @@ describe('pending user request shared helpers', () => {
   it('ignores stale responses after the queue advances to the next request', async () => {
     const activeThreadId = ref('thread-stale')
     const manager = usePendingUserRequest(`project-${Date.now()}`, activeThreadId)
-    const firstResponse = manager.handleServerRequest({
+    const firstResponse = manager.handleServerRequest(makeRequestUserInputRequest({
       id: 20,
-      method: 'item/tool/requestUserInput',
-      params: {
-        threadId: 'thread-stale',
-        questions: [{
+      threadId: 'thread-stale',
+      questions: [{
           id: 'first',
           question: 'First choice',
           options: [{ label: 'One' }]
         }]
-      }
-    })
-    const secondResponse = manager.handleServerRequest({
+    }))
+    const secondResponse = manager.handleServerRequest(makeRequestUserInputRequest({
       id: 21,
-      method: 'item/tool/requestUserInput',
-      params: {
-        threadId: 'thread-stale',
-        questions: [{
+      threadId: 'thread-stale',
+      questions: [{
           id: 'second',
           question: 'Second choice',
           options: [{ label: 'Two' }]
         }]
-      }
-    })
+    }))
 
     expect(manager.resolveRequest(20, {
       answers: {
@@ -532,24 +543,20 @@ describe('pending user request shared helpers', () => {
     const activeThreadId = ref('thread-a')
     const manager = usePendingUserRequest(projectId, activeThreadId)
 
-    const userInputPromise = manager.handleServerRequest({
+    const userInputPromise = manager.handleServerRequest(makeRequestUserInputRequest({
       id: 15,
-      method: 'item/tool/requestUserInput',
-      params: {
-        threadId: 'thread-a',
-        questions: [{
+      threadId: 'thread-a',
+      questions: [{
           id: 'choice',
           question: 'Pick one'
         }]
-      }
-    })
-    const mcpPromise = manager.handleServerRequest({
+    }))
+    const mcpPromise = manager.handleServerRequest(makeMcpElicitationRequest({
       id: 16,
-      method: 'mcpServer/elicitation/request',
-      params: {
-        threadId: 'thread-b',
-        mode: 'form',
-        requestedSchema: {
+      threadId: 'thread-b',
+      mode: 'form',
+      message: 'Need confirmation',
+      requestedSchema: {
           type: 'object',
           properties: {
             email: {
@@ -558,8 +565,7 @@ describe('pending user request shared helpers', () => {
             }
           }
         }
-      }
-    })
+    }))
 
     manager.cancelAllPendingRequests()
 

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -440,12 +440,18 @@ describe('client package', () => {
             prompt: 'Inspect the API surface.',
             model: 'gpt-5.4-mini',
             reasoningEffort: 'medium',
-            agentsStates: [{
-              threadId: 'child-thread',
-              status: 'running',
-              message: 'Scanning files'
-            }]
-          }
+            agentsStates: {
+              'child-thread': {
+                status: 'running',
+                message: 'Scanning files'
+              }
+            }
+          },
+          agentStates: [{
+            threadId: 'child-thread',
+            status: 'running',
+            message: 'Scanning files'
+          }]
         }
       }]
     }])

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -15,6 +15,7 @@ import {
 import { resolveChatMessagesStatus, shouldAwaitAssistantOutput } from '../app/utils/chat-messages-status'
 import {
   ITEM_PART,
+  asAgentMessageItem,
   isSubagentActiveStatus,
   itemToMessages,
   type VisualSubagentPanel
@@ -145,9 +146,10 @@ describe('client package', () => {
 
   it('maps agent thread items into chat messages', () => {
     expect(itemToMessages({
-      type: 'agentMessage',
-      id: 'agent-1',
-      text: 'Working on it'
+      ...asAgentMessageItem({
+        id: 'agent-1',
+        text: 'Working on it'
+      })
     })).toEqual([{
       id: 'agent-1',
       role: 'assistant',
@@ -377,7 +379,8 @@ describe('client package', () => {
       arguments: { path: '/tmp/demo.txt' },
       result: null,
       error: null,
-      status: 'inProgress'
+      status: 'inProgress',
+      durationMs: null
     })).toEqual([{
       id: 'tool-1',
       role: 'system',
@@ -394,7 +397,8 @@ describe('client package', () => {
             arguments: { path: '/tmp/demo.txt' },
             result: null,
             error: null,
-            status: 'inProgress'
+            status: 'inProgress',
+            durationMs: null
           }
         }
       }]


### PR DESCRIPTION
## Summary
- replace hand-written client-side Codex RPC, thread, turn, item, reasoning-effort, plan-step, and collaboration-mode request/notification types with generated `codex app-server` types at the API boundary
- keep UI-only transcript metadata such as `liveOutput`, `progressMessages`, and render-layer web-search status in message adapters instead of mutating generated `ThreadItem` shapes
- preserve collaboration-mode `reasoning_effort` semantics by distinguishing an omitted field from an explicit `null` override while continuing to consume generated response types
- address PR feedback by guarding `FileChange` delete-only detection and restoring pending/failed web-search UI state during hydration and failure transitions

## Validation
- `pnpm --filter @codori/client test`
- `pnpm --filter @codori/client typecheck`
- `pnpm --filter @codori/client lint` (existing 3 warnings only)

## Why
This reduces drift between Codori and the upstream app-server contract, makes generated schema mismatches fail closer to the boundary, keeps render-specific state out of raw transport models, and preserves the existing tool-state UX while the generated schema still lacks native web-search status fields.