### PR TITLE
Refactor ChatWorkspace workflow controllers

### DIFF
--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -2175,7 +2175,7 @@ const scheduleScrollToBottom = async (behavior: ScrollBehavior = 'auto') => {
   })
 }
 
-const ensureProjectRuntime = async () => {
+async function ensureProjectRuntime() {
   if (!loaded.value) {
     await refreshProjects()
   }

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -30,6 +30,7 @@ import {
 } from '../utils/chat-turn-engagement'
 import { isFocusWithinContainer } from '../utils/slash-prompt-focus'
 import { useChatAttachments, type DraftAttachment } from '../composables/useChatAttachments'
+import { useChatReviewWorkflow } from '../composables/useChatReviewWorkflow'
 import { usePendingUserRequest } from '../composables/usePendingUserRequest'
 import { useChatSession, type LiveStream, type SubagentPanelState } from '../composables/useChatSession'
 import { useProjects } from '../composables/useProjects'
@@ -105,11 +106,7 @@ import {
   visibleModelOptions
 } from '~~/shared/chat-prompt-controls'
 import { shouldQueuePlanImplementationPrompt } from '~~/shared/plan-implementation-prompt'
-import {
-  resolveProjectGitBranchesUrl,
-  toProjectThreadRoute,
-  type ProjectGitBranchesResponse
-} from '~~/shared/codori'
+import { toProjectThreadRoute } from '~~/shared/codori'
 import {
   filterSlashCommands,
   findActiveSlashCommand,
@@ -309,7 +306,6 @@ const submitError = computed(() => composerError.value ? new Error(composerError
 const interruptRequested = ref(false)
 const awaitingAssistantOutput = ref(false)
 const sendMessageLocked = ref(false)
-const reviewStartPending = ref(false)
 const promptSelectionStart = ref(0)
 const promptSelectionEnd = ref(0)
 const isPromptFocused = ref(false)
@@ -335,20 +331,12 @@ const insertedSkillMentions = ref<SkillAutocompleteSelection[]>([])
 const fileAutocompleteLoading = ref(false)
 const fileAutocompleteError = ref<string | null>(null)
 const fileAutocompleteResults = ref<NormalizedFuzzyFileSearchMatch[]>([])
-const reviewDrawerOpen = ref(false)
-const reviewDrawerMode = ref<'target' | 'branch'>('target')
-const reviewDrawerCommandText = ref('/review')
 const usageStatusModalOpen = ref(false)
-const reviewBranches = ref<string[]>([])
-const reviewCurrentBranch = ref<string | null>(null)
-const reviewBranchesLoading = ref(false)
-const reviewBranchesError = ref<string | null>(null)
 let planImplementationPromptFlushToken = 0
-const isBusy = computed(() =>
+const isWorkflowBusy = computed(() =>
   status.value === 'submitted'
   || status.value === 'streaming'
   || isUploading.value
-  || reviewStartPending.value
 )
 const hasDraftContent = computed(() =>
   input.value.trim().length > 0
@@ -696,10 +684,6 @@ const slashDropdownOpen = computed(() =>
 
 const highlightedSlashCommand = computed(() =>
   filteredSlashCommands.value[slashHighlightIndex.value] ?? filteredSlashCommands.value[0] ?? null
-)
-
-const reviewBaseBranches = computed(() =>
-  reviewBranches.value.filter(branch => branch !== reviewCurrentBranch.value)
 )
 
 const starterPrompts = computed(() => {
@@ -1323,26 +1307,6 @@ const setComposerError = (messageText: string) => {
   status.value = 'error'
 }
 
-const resetReviewDrawerState = () => {
-  reviewDrawerMode.value = 'target'
-  reviewDrawerCommandText.value = '/review'
-  reviewBranchesLoading.value = false
-  reviewBranchesError.value = null
-}
-
-const closeReviewDrawer = () => {
-  reviewDrawerOpen.value = false
-  resetReviewDrawerState()
-}
-
-const openReviewDrawer = (commandText = '/review') => {
-  dismissedSlashMatchKey.value = null
-  reviewDrawerCommandText.value = commandText
-  reviewDrawerMode.value = 'target'
-  reviewBranchesError.value = null
-  reviewDrawerOpen.value = true
-}
-
 const clearSlashCommandDraft = () => {
   // Successful slash commands consume the draft immediately. Leaving `/usage`
   // or `/review` in the prompt after opening the modal/drawer makes the next
@@ -1817,98 +1781,6 @@ const ensureSkillAutocompleteCatalogCurrent = async () => {
   })
 }
 
-const fetchProjectGitBranches = async () => {
-  reviewBranchesLoading.value = true
-  reviewBranchesError.value = null
-
-  try {
-    const response = await fetch(resolveProjectGitBranchesUrl({
-      projectId: props.projectId,
-      configuredBase: String(runtimeConfig.public.serverBase ?? '')
-    }))
-
-    const body = await response.json() as ProjectGitBranchesResponse | { error?: { message?: string } }
-    if (!response.ok) {
-      throw new Error(body && typeof body === 'object' && 'error' in body
-        ? body.error?.message ?? 'Failed to load local branches.'
-        : 'Failed to load local branches.')
-    }
-
-    const result = body as ProjectGitBranchesResponse
-    reviewCurrentBranch.value = result.currentBranch
-    reviewBranches.value = result.branches
-  } finally {
-    reviewBranchesLoading.value = false
-  }
-}
-
-const openBaseBranchPicker = async () => {
-  reviewDrawerMode.value = 'branch'
-
-  try {
-    await fetchProjectGitBranches()
-    if (!reviewBaseBranches.value.length) {
-      reviewBranchesError.value = 'No local base branches are available to compare against.'
-    }
-  } catch (caughtError) {
-    reviewBranchesError.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
-  }
-}
-
-const startReview = async (target: ReviewTarget) => {
-  if (reviewStartPending.value) {
-    return
-  }
-
-  if (hasPendingRequest.value || isBusy.value) {
-    setComposerError('Review can only start when the current thread is idle.')
-    return
-  }
-
-  reviewStartPending.value = true
-  const draftText = reviewDrawerCommandText.value
-  const submittedAttachments = attachments.value.slice()
-  input.value = ''
-  clearAttachments({ revoke: false })
-
-  try {
-    const client = getClient(props.projectId)
-    const liveStream = await ensurePendingLiveStream()
-    error.value = null
-    status.value = 'submitted'
-    tokenUsage.value = null
-    markAwaitingAssistantOutput(true)
-
-    const response = await client.request<ReviewStartResponse>('review/start', {
-      threadId: liveStream.threadId,
-      delivery: 'inline',
-      target
-    } satisfies ReviewStartParams)
-
-    for (const item of response.turn.items) {
-      if (item.type === 'userMessage') {
-        continue
-      }
-
-      for (const nextMessage of itemToMessages(item)) {
-        messages.value = upsertStreamingMessage(messages.value, {
-          ...nextMessage,
-          pending: false
-        })
-      }
-    }
-
-    lockLiveStreamTurnId(liveStream, response.turn.id)
-    replayBufferedNotifications(liveStream)
-    closeReviewDrawer()
-  } catch (caughtError) {
-    restoreDraftIfPristine(draftText, submittedAttachments)
-    setComposerError(caughtError instanceof Error ? caughtError.message : String(caughtError))
-  } finally {
-    reviewStartPending.value = false
-  }
-}
-
 const updateThreadPlanState = (threadId: string, params: unknown) => {
   const nextPlanUpdate = normalizeTurnPlanUpdate(params)
   if (!nextPlanUpdate) {
@@ -2238,15 +2110,6 @@ const activateSlashCommand = async (
   await handleSlashCommandSubmission(`/${command.name}`, attachments.value.slice())
 }
 
-const handleReviewDrawerOpenChange = (open: boolean) => {
-  if (open) {
-    reviewDrawerOpen.value = true
-    return
-  }
-
-  closeReviewDrawer()
-}
-
 const handleUsageStatusOpenChange = (open: boolean) => {
   usageStatusModalOpen.value = open
 }
@@ -2266,11 +2129,6 @@ watch(isPlanImplementationPromptOpen, (open) => {
     session.shownPlanImplementationPromptTurnIds.add(planImplementationPromptTurnId.value)
   }
 })
-
-const handleReviewDrawerBack = () => {
-  reviewDrawerMode.value = 'target'
-  reviewBranchesError.value = null
-}
 
 const removeOptimisticMessage = (messageId: string) => {
   messages.value = removeChatMessage(messages.value, messageId)
@@ -2301,6 +2159,52 @@ const restoreDraftIfPristine = (
     replaceAttachments(submittedAttachments)
   }
 }
+
+const reviewWorkflow = useChatReviewWorkflow({
+  projectId: props.projectId,
+  serverBase: String(runtimeConfig.public.serverBase ?? ''),
+  input,
+  attachments,
+  hasPendingRequest,
+  isWorkflowBusy,
+  error,
+  status,
+  tokenUsage,
+  messages,
+  setComposerError,
+  markAwaitingAssistantOutput,
+  clearAttachments,
+  restoreDraftIfPristine: (text, submittedAttachments) =>
+    restoreDraftIfPristine(text, submittedAttachments),
+  ensurePendingLiveStream,
+  getClient,
+  lockLiveStreamTurnId,
+  replayBufferedNotifications,
+  clearDismissedSlashMatch: () => {
+    dismissedSlashMatchKey.value = null
+  }
+})
+
+const {
+  reviewDrawerOpen,
+  reviewDrawerMode,
+  reviewBaseBranches,
+  reviewCurrentBranch,
+  reviewBranchesLoading,
+  reviewBranchesError,
+  reviewStartPending,
+  openReviewDrawer,
+  closeReviewDrawer,
+  openBaseBranchPicker,
+  startReview,
+  handleReviewDrawerOpenChange,
+  handleReviewDrawerBack
+} = reviewWorkflow
+
+const isBusy = computed(() =>
+  isWorkflowBusy.value
+  || reviewStartPending.value
+)
 
 const untrackPendingUserMessage = (messageId: string) => {
   const liveStream = currentLiveStream()

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -32,6 +32,7 @@ import { isFocusWithinContainer } from '../utils/slash-prompt-focus'
 import { useChatAttachments, type DraftAttachment } from '../composables/useChatAttachments'
 import { useChatPlanWorkflow } from '../composables/useChatPlanWorkflow'
 import { useChatReviewWorkflow } from '../composables/useChatReviewWorkflow'
+import { useSubagentPanelsController } from '../composables/useSubagentPanelsController'
 import { usePendingUserRequest } from '../composables/usePendingUserRequest'
 import { useChatSession, type LiveStream, type SubagentPanelState } from '../composables/useChatSession'
 import { useProjects } from '../composables/useProjects'
@@ -848,7 +849,6 @@ const loadPromptControls = async () => {
   return await promptControlsPromise
 }
 
-const subagentBootstrapPromises = new Map<string, Promise<void>>()
 const optimisticAttachmentSnapshots = new Map<string, DraftAttachment[]>()
 let promptControlsPromise: Promise<void> | null = null
 let pendingThreadHydration: Promise<void> | null = null
@@ -1964,6 +1964,26 @@ const {
   maybeQueuePlanImplementationPrompt
 } = planWorkflow
 
+const subagentPanelsController = useSubagentPanelsController({
+  projectId: props.projectId,
+  subagentPanels,
+  ensureProjectRuntime: async () => await ensureProjectRuntime(),
+  getClient,
+  isActiveTurnStatus,
+  currentLiveStream
+})
+
+const {
+  getSubagentPanel,
+  createSubagentPanelState,
+  upsertSubagentPanel,
+  rememberObservedSubagentThread,
+  bootstrapSubagentPanel,
+  applySubagentActivityItem,
+  rebuildSubagentPanelsFromThread,
+  applySubagentNotification
+} = subagentPanelsController
+
 const isBusy = computed(() =>
   isWorkflowBusy.value
   || reviewStartPending.value
@@ -2102,62 +2122,6 @@ const sendMentionedAgentMessage = async (input: {
     bootstrapped: panel?.bootstrapped ?? true,
     lastSeenAt: Date.now()
   }))
-}
-
-const shortThreadId = (value: string) => value.slice(0, 8)
-
-const resolveSubagentName = (
-  threadId: string,
-  thread?: Pick<Thread, 'agentNickname' | 'name' | 'preview'> | null
-) => {
-  const candidate = thread?.agentNickname?.trim()
-    || thread?.name?.trim()
-    || thread?.preview?.trim()
-
-  if (candidate) {
-    return candidate
-  }
-
-  return `Agent ${shortThreadId(threadId)}`
-}
-
-const getSubagentPanel = (threadId: string) =>
-  subagentPanels.value.find(panel => panel.threadId === threadId)
-
-const createSubagentPanelState = (threadId: string): SubagentPanelState => ({
-  threadId,
-  name: resolveSubagentName(threadId),
-  role: null,
-  status: null,
-  messages: [],
-  firstSeenAt: Date.now(),
-  lastSeenAt: Date.now(),
-  turnId: null,
-  bootstrapped: false,
-  bufferedNotifications: []
-})
-
-const upsertSubagentPanel = (
-  threadId: string,
-  updater: (panel: SubagentPanelState | undefined) => SubagentPanelState
-) => {
-  const current = getSubagentPanel(threadId)
-  const nextPanel = updater(current)
-  const index = subagentPanels.value.findIndex(panel => panel.threadId === threadId)
-
-  if (index === -1) {
-    subagentPanels.value = [...subagentPanels.value, nextPanel]
-    return nextPanel
-  }
-
-  subagentPanels.value = subagentPanels.value.map((panel, panelIndex) =>
-    panelIndex === index ? nextPanel : panel
-  )
-  return nextPanel
-}
-
-const rememberObservedSubagentThread = (threadId: string) => {
-  session.liveStream?.observedSubagentThreadIds.add(threadId)
 }
 
 const isTextPart = (part: ChatPart): part is Extract<ChatPart, { type: 'text' }> =>
@@ -2607,120 +2571,6 @@ const pushEventMessage = (kind: 'turn.failed' | 'stream.error', messageText: str
   )
 }
 
-const updateSubagentPanelMessages = (
-  threadId: string,
-  updater: (panelMessages: ChatMessage[]) => ChatMessage[]
-) => {
-  upsertSubagentPanel(threadId, (panel) => {
-    const basePanel = panel ?? createSubagentPanelState(threadId)
-    return {
-      ...basePanel,
-      messages: updater(basePanel.messages),
-      lastSeenAt: Date.now()
-    }
-  })
-}
-
-const updateSubagentMessage = (
-  threadId: string,
-  messageId: string,
-  fallbackMessage: ChatMessage,
-  transform: (message: ChatMessage) => ChatMessage
-) => {
-  updateSubagentPanelMessages(threadId, (panelMessages) => {
-    const existing = panelMessages.find(message => message.id === messageId)
-    return upsertStreamingMessage(panelMessages, transform(existing ?? fallbackMessage))
-  })
-}
-
-const appendSubagentTextPartDelta = (
-  threadId: string,
-  messageId: string,
-  delta: string,
-  fallbackMessage: ChatMessage
-) => {
-  updateSubagentMessage(threadId, messageId, fallbackMessage, (message) => {
-    const partIndex = message.parts.findIndex(isTextPart)
-    const existingTextPart = partIndex === -1 ? null : message.parts[partIndex] as Extract<ChatPart, { type: 'text' }>
-    const nextText = existingTextPart ? `${existingTextPart.text}${delta}` : delta
-    const nextTextPart: Extract<ChatPart, { type: 'text' }> = {
-      type: 'text',
-      text: nextText,
-      state: 'streaming'
-    }
-    const nextParts = partIndex === -1
-      ? [...message.parts, nextTextPart]
-      : message.parts.map((part, index) => index === partIndex ? nextTextPart : part)
-
-    return {
-      ...message,
-      pending: true,
-      parts: nextParts
-    }
-  })
-}
-
-const updateSubagentItemPart = (
-  threadId: string,
-  messageId: string,
-  fallbackMessage: ChatMessage,
-  transform: (itemData: ItemData) => ItemData
-) => {
-  updateSubagentMessage(threadId, messageId, fallbackMessage, (message) => {
-    const partIndex = message.parts.findIndex(isItemPart)
-    const existingData = partIndex === -1 ? null : (message.parts[partIndex] as Extract<ChatPart, { type: typeof ITEM_PART }>).data
-    const nextData = transform(existingData ?? getFallbackItemData(fallbackMessage))
-    const nextPart: Extract<ChatPart, { type: typeof ITEM_PART }> = {
-      type: ITEM_PART,
-      data: nextData
-    }
-    const nextParts = partIndex === -1
-      ? [...message.parts, nextPart]
-      : message.parts.map((part, index) => index === partIndex ? nextPart : part)
-
-    return {
-      ...message,
-      pending: true,
-      parts: nextParts
-    }
-  })
-}
-
-const pushSubagentEventMessage = (threadId: string, kind: 'turn.failed' | 'stream.error', messageText: string) => {
-  updateSubagentPanelMessages(threadId, (panelMessages) =>
-    upsertStreamingMessage(
-      panelMessages,
-      eventToMessage(`subagent-event-${threadId}-${kind}-${Date.now()}`, kind === 'turn.failed'
-        ? {
-            kind,
-            error: {
-              message: messageText
-            }
-          }
-        : {
-            kind,
-            message: messageText
-          })
-    )
-  )
-}
-
-const seedSubagentStreamingMessage = (threadId: string, item: ThreadItem) => {
-  const [seed] = itemToMessages(item, {
-    webSearchStatus: item.type === 'webSearch' ? 'inProgress' : undefined
-  })
-  if (!seed) {
-    return
-  }
-
-  updateSubagentPanelMessages(threadId, (panelMessages) =>
-    upsertStreamingMessage(panelMessages, {
-      ...seed,
-      pending: true
-    })
-  )
-}
-
 const updateWebSearchMessageStatus = (
   chatMessages: ChatMessage[],
   status: WebSearchStatus
@@ -2752,308 +2602,6 @@ const updateWebSearchMessageStatus = (
     parts: message.parts.map((part, index) => index === partIndex ? nextPart : part)
   }
 })
-
-const bootstrapSubagentPanel = async (threadId: string) => {
-  if (!threadId) {
-    return
-  }
-
-  const existingPromise = subagentBootstrapPromises.get(threadId)
-  if (existingPromise) {
-    await existingPromise
-    return
-  }
-
-  const bootstrapPromise = (async () => {
-    try {
-      await ensureProjectRuntime()
-      const client = getClient(props.projectId)
-      const response = await client.request<ThreadReadResponse>('thread/read', {
-        threadId,
-        includeTurns: true
-      })
-      const activeTurn = [...response.thread.turns].reverse().find(turn => isActiveTurnStatus(turn.status))
-      const pendingNotifications = getSubagentPanel(threadId)?.bufferedNotifications.slice() ?? []
-
-      upsertSubagentPanel(threadId, (panel) => {
-        const basePanel = panel ?? createSubagentPanelState(threadId)
-        return {
-          ...basePanel,
-          name: resolveSubagentName(threadId, response.thread),
-          role: response.thread.agentRole ?? basePanel.role ?? null,
-          messages: threadToMessages(response.thread),
-          turnId: activeTurn?.id ?? null,
-          bootstrapped: true,
-          bufferedNotifications: [],
-          status: panel?.status
-            ?? (activeTurn ? 'running' : basePanel.status)
-            ?? null,
-          lastSeenAt: Date.now()
-        }
-      })
-
-      for (const notification of pendingNotifications) {
-        applySubagentNotification(threadId, notification)
-      }
-    } catch {
-      upsertSubagentPanel(threadId, (panel) => ({
-        ...(panel ?? createSubagentPanelState(threadId)),
-        lastSeenAt: Date.now()
-      }))
-    } finally {
-      subagentBootstrapPromises.delete(threadId)
-    }
-  })()
-
-  subagentBootstrapPromises.set(threadId, bootstrapPromise)
-  await bootstrapPromise
-}
-
-const applySubagentActivityItem = (item: Extract<ThreadItem, { type: 'collabAgentToolCall' }>) => {
-  const orderedThreadIds = [
-    ...item.receiverThreadIds,
-    ...Object.keys(item.agentsStates).filter(threadId => !item.receiverThreadIds.includes(threadId))
-  ]
-
-  for (const threadId of orderedThreadIds) {
-    const agentState = item.agentsStates[threadId]
-    rememberObservedSubagentThread(threadId)
-    upsertSubagentPanel(threadId, (panel) => {
-      const basePanel = panel ?? createSubagentPanelState(threadId)
-      return {
-        ...basePanel,
-        status: agentState?.status ?? basePanel.status,
-        lastSeenAt: Date.now()
-      }
-    })
-  }
-
-  for (const threadId of orderedThreadIds) {
-    void bootstrapSubagentPanel(threadId)
-  }
-}
-
-const rebuildSubagentPanelsFromThread = (thread: Thread) => {
-  subagentPanels.value = []
-  for (const turn of thread.turns) {
-    for (const item of turn.items) {
-      if (item.type === 'collabAgentToolCall') {
-        applySubagentActivityItem(item)
-      }
-    }
-  }
-}
-
-const applySubagentNotification = (threadId: string, notification: CodexRpcNotification) => {
-  const panel = getSubagentPanel(threadId)
-  if (!panel) {
-    return
-  }
-
-  if (!panel.bootstrapped) {
-    upsertSubagentPanel(threadId, (existingPanel) => ({
-      ...(existingPanel ?? createSubagentPanelState(threadId)),
-      bufferedNotifications: [...(existingPanel?.bufferedNotifications ?? []), notification],
-      lastSeenAt: Date.now()
-    }))
-    return
-  }
-
-  const turnId = notificationTurnId(notification)
-  if (panel.turnId && turnId && turnId !== panel.turnId && notification.method !== 'turn/started') {
-    return
-  }
-
-  switch (notification.method) {
-    case 'turn/started': {
-      upsertSubagentPanel(threadId, (existingPanel) => ({
-        ...(existingPanel ?? createSubagentPanelState(threadId)),
-        turnId: notificationTurnId(notification),
-        status: existingPanel?.status === 'completed' ? existingPanel.status : 'running',
-        lastSeenAt: Date.now()
-      }))
-      return
-    }
-    case 'item/started': {
-      const params = notification.params as { item: ThreadItem }
-      if (params.item.type === 'collabAgentToolCall') {
-        applySubagentActivityItem(params.item)
-      }
-      seedSubagentStreamingMessage(threadId, params.item)
-      return
-    }
-    case 'item/completed': {
-      const params = notification.params as { item: ThreadItem }
-      if (params.item.type === 'collabAgentToolCall') {
-        applySubagentActivityItem(params.item)
-      }
-      for (const nextMessage of itemToMessages(params.item)) {
-        updateSubagentPanelMessages(threadId, (panelMessages) =>
-          replaceStreamingMessage(panelMessages, {
-            ...nextMessage,
-            pending: false
-          })
-        )
-      }
-      return
-    }
-    case 'item/agentMessage/delta':
-    case 'item/plan/delta': {
-      const params = notification.params as { itemId: string, delta: string }
-      appendSubagentTextPartDelta(threadId, params.itemId, params.delta, {
-        id: params.itemId,
-        role: 'assistant',
-        pending: true,
-        parts: [{
-          type: 'text',
-          text: '',
-          state: 'streaming'
-        }]
-      })
-      return
-    }
-    case 'item/reasoning/textDelta':
-    case 'item/reasoning/summaryTextDelta': {
-      const params = notification.params as { itemId: string, delta: string }
-      updateSubagentMessage(threadId, params.itemId, {
-        id: params.itemId,
-        role: 'assistant',
-        pending: true,
-        parts: [{
-          type: 'reasoning',
-          summary: [],
-          content: [],
-          state: 'streaming'
-        }]
-      }, (message) => {
-        const partIndex = message.parts.findIndex(part => part.type === 'reasoning')
-        const existingPart = partIndex === -1
-          ? {
-              type: 'reasoning' as const,
-              summary: [],
-              content: []
-            }
-          : message.parts[partIndex] as Extract<ChatPart, { type: 'reasoning' }>
-        const nextPart: Extract<ChatPart, { type: 'reasoning' }> = {
-          type: 'reasoning',
-          summary: notification.method === 'item/reasoning/summaryTextDelta'
-            ? [...existingPart.summary, params.delta]
-            : existingPart.summary,
-          content: notification.method === 'item/reasoning/textDelta'
-            ? [...existingPart.content, params.delta]
-            : existingPart.content,
-          state: 'streaming'
-        }
-        const nextParts = partIndex === -1
-          ? [...message.parts, nextPart]
-          : message.parts.map((part, index) => index === partIndex ? nextPart : part)
-
-        return {
-          ...message,
-          pending: true,
-          parts: nextParts
-        }
-      })
-      return
-    }
-    case 'item/commandExecution/outputDelta': {
-      const params = notification.params as { itemId: string, delta: string }
-      const fallbackItem = fallbackCommandItemData(params.itemId)
-      updateSubagentItemPart(threadId, params.itemId, fallbackCommandMessage(params.itemId), (itemData) => ({
-        kind: 'command_execution',
-        item: {
-          ...(itemData.kind === 'command_execution' ? itemData.item : fallbackItem.item),
-          aggregatedOutput: `${(itemData.kind === 'command_execution' ? itemData.item.aggregatedOutput : '') ?? ''}${params.delta}`,
-          status: 'inProgress'
-        }
-      }))
-      return
-    }
-    case 'item/fileChange/outputDelta': {
-      const params = notification.params as { itemId: string, delta: string }
-      const fallbackItem = fallbackFileChangeItemData(params.itemId)
-      updateSubagentItemPart(threadId, params.itemId, fallbackFileChangeMessage(params.itemId), (itemData) => {
-        const baseItem: FileChangeItem = itemData.kind === 'file_change'
-          ? itemData.item
-          : fallbackItem.item
-        const liveOutput = itemData.kind === 'file_change'
-          ? itemData.liveOutput
-          : fallbackItem.liveOutput
-        return {
-          kind: 'file_change',
-          item: {
-            ...baseItem,
-            status: 'inProgress'
-          },
-          liveOutput: `${liveOutput ?? ''}${params.delta}`
-        }
-      })
-      return
-    }
-    case 'item/mcpToolCall/progress': {
-      const params = notification.params as { itemId: string, message: string }
-      const fallbackItem = fallbackMcpToolItemData(params.itemId)
-      updateSubagentItemPart(threadId, params.itemId, fallbackMcpToolMessage(params.itemId), (itemData) => {
-        const baseItem: McpToolCallItem = itemData.kind === 'mcp_tool_call'
-          ? itemData.item
-          : fallbackItem.item
-        const progressMessages = itemData.kind === 'mcp_tool_call'
-          ? itemData.progressMessages
-          : fallbackItem.progressMessages
-        return {
-          kind: 'mcp_tool_call',
-          item: {
-            ...baseItem,
-            status: 'inProgress'
-          },
-          progressMessages: [...(progressMessages ?? []), params.message]
-        }
-      })
-      return
-    }
-    case 'turn/completed': {
-      upsertSubagentPanel(threadId, (existingPanel) => ({
-        ...(existingPanel ?? createSubagentPanelState(threadId)),
-        turnId: null,
-        status: isSubagentActiveStatus(existingPanel?.status ?? null)
-          ? 'completed'
-          : existingPanel?.status ?? null,
-        lastSeenAt: Date.now()
-      }))
-      return
-    }
-    case 'turn/failed': {
-      const params = notification.params as { error?: { message?: string } }
-      const messageText = params.error?.message ?? 'The turn failed.'
-      pushSubagentEventMessage(threadId, 'turn.failed', messageText)
-      updateSubagentPanelMessages(threadId, (panelMessages) =>
-        updateWebSearchMessageStatus(panelMessages, 'failed')
-      )
-      upsertSubagentPanel(threadId, (existingPanel) => ({
-        ...(existingPanel ?? createSubagentPanelState(threadId)),
-        status: 'errored',
-        turnId: null,
-        lastSeenAt: Date.now()
-      }))
-      return
-    }
-    case 'stream/error': {
-      const params = notification.params as { message?: string }
-      const messageText = params.message ?? 'The stream failed.'
-      pushSubagentEventMessage(threadId, 'stream.error', messageText)
-      upsertSubagentPanel(threadId, (existingPanel) => ({
-        ...(existingPanel ?? createSubagentPanelState(threadId)),
-        status: 'errored',
-        turnId: null,
-        lastSeenAt: Date.now()
-      }))
-      return
-    }
-    default:
-      return
-  }
-}
-
 const applyNotification = (notification: CodexRpcNotification) => {
   const liveStream = currentLiveStream()
   if (liveStream?.interruptAcknowledged && shouldIgnoreNotificationAfterInterrupt(notification.method)) {

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -34,7 +34,7 @@ import { useChatPlanWorkflow } from '../composables/useChatPlanWorkflow'
 import { useChatReviewWorkflow } from '../composables/useChatReviewWorkflow'
 import { useSubagentPanelsController } from '../composables/useSubagentPanelsController'
 import { usePendingUserRequest } from '../composables/usePendingUserRequest'
-import { useChatSession, type LiveStream, type SubagentPanelState } from '../composables/useChatSession'
+import { useChatSession, type LiveStream } from '../composables/useChatSession'
 import { useProjects } from '../composables/useProjects'
 import { useRpc } from '../composables/useRpc'
 import { useChatSubmitGuard } from '../composables/useChatSubmitGuard'
@@ -65,13 +65,8 @@ import { buildTurnStartInput, type PersistedProjectAttachment } from '~~/shared/
 import {
   type CollaborationMode
 } from '~~/shared/collaboration-mode'
-import type { ReviewStartResponse } from '~~/shared/generated/codex-app-server/v2/ReviewStartResponse'
-import type { ReviewStartParams } from '~~/shared/generated/codex-app-server/v2/ReviewStartParams'
-import type { ReviewTarget } from '~~/shared/generated/codex-app-server/v2/ReviewTarget'
-import type { CollaborationModeListResponse } from '~~/shared/generated/codex-app-server/v2/CollaborationModeListResponse'
 import type { ConfigReadResponse } from '~~/shared/generated/codex-app-server/v2/ConfigReadResponse'
 import type { ModelListResponse } from '~~/shared/generated/codex-app-server/v2/ModelListResponse'
-import type { Thread } from '~~/shared/generated/codex-app-server/v2/Thread'
 import type { ThreadReadResponse } from '~~/shared/generated/codex-app-server/v2/ThreadReadResponse'
 import type { ThreadItem } from '~~/shared/generated/codex-app-server/v2/ThreadItem'
 import type { ThreadResumeResponse } from '~~/shared/generated/codex-app-server/v2/ThreadResumeResponse'
@@ -1912,7 +1907,6 @@ const {
   reviewBranchesError,
   reviewStartPending,
   openReviewDrawer,
-  closeReviewDrawer,
   openBaseBranchPicker,
   startReview,
   handleReviewDrawerOpenChange,
@@ -1940,7 +1934,7 @@ const planWorkflow = useChatPlanWorkflow({
   planImplementationPromptTurnId,
   planImplementationPromptThreadId,
   shownPlanImplementationPromptTurnIds: session.shownPlanImplementationPromptTurnIds,
-  ensureProjectRuntime: async () => await ensureProjectRuntime(),
+  ensureProjectRuntime,
   getClient
 })
 
@@ -1967,7 +1961,7 @@ const {
 const subagentPanelsController = useSubagentPanelsController({
   projectId: props.projectId,
   subagentPanels,
-  ensureProjectRuntime: async () => await ensureProjectRuntime(),
+  ensureProjectRuntime,
   getClient,
   isActiveTurnStatus,
   currentLiveStream

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -30,6 +30,7 @@ import {
 } from '../utils/chat-turn-engagement'
 import { isFocusWithinContainer } from '../utils/slash-prompt-focus'
 import { useChatAttachments, type DraftAttachment } from '../composables/useChatAttachments'
+import { useChatPlanWorkflow } from '../composables/useChatPlanWorkflow'
 import { useChatReviewWorkflow } from '../composables/useChatReviewWorkflow'
 import { usePendingUserRequest } from '../composables/usePendingUserRequest'
 import { useChatSession, type LiveStream, type SubagentPanelState } from '../composables/useChatSession'
@@ -61,12 +62,7 @@ import {
 } from '~~/shared/codex-chat'
 import { buildTurnStartInput, type PersistedProjectAttachment } from '~~/shared/chat-attachments'
 import {
-  buildCollaborationModeFromMask,
-  findCollaborationModeMask,
-  normalizeCollaborationModeListResponse,
-  resolveThreadCollaborationModeKey,
-  type CollaborationMode,
-  type CollaborationModeMask
+  type CollaborationMode
 } from '~~/shared/collaboration-mode'
 import type { ReviewStartResponse } from '~~/shared/generated/codex-app-server/v2/ReviewStartResponse'
 import type { ReviewStartParams } from '~~/shared/generated/codex-app-server/v2/ReviewStartParams'
@@ -105,7 +101,6 @@ import {
   shouldShowContextWindowIndicator,
   visibleModelOptions
 } from '~~/shared/chat-prompt-controls'
-import { shouldQueuePlanImplementationPrompt } from '~~/shared/plan-implementation-prompt'
 import { toProjectThreadRoute } from '~~/shared/codori'
 import {
   filterSlashCommands,
@@ -157,12 +152,6 @@ import {
   resolveSubagentAccent,
   toSubagentAvatarText
 } from '~~/shared/subagent-panels'
-import {
-  applyTurnPlanUpdate,
-  normalizeTurnPlanUpdate,
-  shouldResetThreadPlanState
-} from '~~/shared/turn-plan'
-
 const props = defineProps<{
   projectId: string
   threadId?: string | null
@@ -332,7 +321,6 @@ const fileAutocompleteLoading = ref(false)
 const fileAutocompleteError = ref<string | null>(null)
 const fileAutocompleteResults = ref<NormalizedFuzzyFileSearchMatch[]>([])
 const usageStatusModalOpen = ref(false)
-let planImplementationPromptFlushToken = 0
 const isWorkflowBusy = computed(() =>
   status.value === 'submitted'
   || status.value === 'streaming'
@@ -355,29 +343,6 @@ const promptSubmitStatus = computed(() =>
   })
 )
 const projectTitle = computed(() => selectedProject.value?.projectId ?? props.projectId)
-const currentThreadCollaborationModeKey = computed(() =>
-  resolveThreadCollaborationModeKey(activeThreadId.value ?? routeThreadId.value)
-)
-const currentPlanPromptThreadId = computed(() =>
-  activeThreadId.value ?? routeThreadId.value
-)
-const isPlanImplementationPromptOpen = computed(() =>
-  Boolean(planImplementationPromptTurnId.value && planImplementationPromptThreadId.value === currentPlanPromptThreadId.value)
-)
-const currentThreadCollaborationModeMask = computed(() =>
-  threadCollaborationModeMasks.value[currentThreadCollaborationModeKey.value] ?? null
-)
-const planCollaborationModeMask = computed(() =>
-  findCollaborationModeMask(collaborationModeMasks.value, 'plan')
-)
-const currentCollaborationModeLabel = computed(() =>
-  currentThreadCollaborationModeMask.value?.mode === 'plan'
-    ? currentThreadCollaborationModeMask.value.name
-    : null
-)
-const isPlanModeActive = computed(() =>
-  currentThreadCollaborationModeMask.value?.mode === 'plan'
-)
 const composerPlaceholder = computed(() =>
   hasPendingRequest.value
     ? 'Respond to the pending request below to let Codex continue'
@@ -488,15 +453,6 @@ const activeAgentMentionEntries = computed(() =>
       status: panel.status
     } satisfies AgentMentionAutocompleteEntry))
 )
-
-const currentThreadPlan = computed(() => {
-  const threadId = activeThreadId.value ?? routeThreadId.value
-  if (!threadId) {
-    return null
-  }
-
-  return threadPlans.value[threadId] ?? null
-})
 
 const agentMentionAccentIndexByThreadId = computed(() => {
   const entries = new Map<string, number>()
@@ -1781,228 +1737,6 @@ const ensureSkillAutocompleteCatalogCurrent = async () => {
   })
 }
 
-const updateThreadPlanState = (threadId: string, params: unknown) => {
-  const nextPlanUpdate = normalizeTurnPlanUpdate(params)
-  if (!nextPlanUpdate) {
-    return
-  }
-
-  const nextPlanState = applyTurnPlanUpdate(threadPlans.value[threadId], {
-    ...nextPlanUpdate,
-    threadId
-  })
-  if (!nextPlanState) {
-    const nextThreadPlans = { ...threadPlans.value }
-    delete nextThreadPlans[threadId]
-    threadPlans.value = nextThreadPlans
-    return
-  }
-
-  threadPlans.value = {
-    ...threadPlans.value,
-    [threadId]: nextPlanState
-  }
-}
-
-const setThreadPlanPanelOpen = (open: boolean) => {
-  if (!currentThreadPlan.value?.threadId) {
-    return
-  }
-
-  threadPlans.value = {
-    ...threadPlans.value,
-    [currentThreadPlan.value.threadId]: {
-      ...currentThreadPlan.value,
-      panelOpen: open
-    }
-  }
-}
-
-const clearThreadPlanState = (threadId: string) => {
-  if (!(threadId in threadPlans.value)) {
-    return
-  }
-
-  const nextThreadPlans = { ...threadPlans.value }
-  delete nextThreadPlans[threadId]
-  threadPlans.value = nextThreadPlans
-}
-
-const setThreadCollaborationModeMask = (
-  threadId: string | null | undefined,
-  mask: CollaborationModeMask | null
-) => {
-  const key = resolveThreadCollaborationModeKey(threadId)
-  const nextThreadModes = { ...threadCollaborationModeMasks.value }
-
-  if (mask) {
-    nextThreadModes[key] = mask
-  } else {
-    delete nextThreadModes[key]
-  }
-
-  threadCollaborationModeMasks.value = nextThreadModes
-}
-
-const moveDraftCollaborationModeToThread = (threadId: string) => {
-  const draftKey = resolveThreadCollaborationModeKey(null)
-  const draftMode = threadCollaborationModeMasks.value[draftKey]
-  if (!draftMode) {
-    return
-  }
-
-  const nextThreadModes = { ...threadCollaborationModeMasks.value }
-  nextThreadModes[threadId] = draftMode
-  delete nextThreadModes[draftKey]
-  threadCollaborationModeMasks.value = nextThreadModes
-}
-
-const buildCurrentTurnCollaborationMode = () =>
-  buildCollaborationModeFromMask(currentThreadCollaborationModeMask.value, {
-    model: selectedModel.value,
-    reasoning_effort: selectedEffort.value
-  })
-
-let pendingCollaborationModesLoad: Promise<void> | null = null
-
-const loadCollaborationModes = async (options?: { force?: boolean }) => {
-  if (collaborationModesLoaded.value && !options?.force) {
-    return
-  }
-
-  if (pendingCollaborationModesLoad) {
-    await pendingCollaborationModesLoad
-    return
-  }
-
-  const loadPromise = (async () => {
-    collaborationModesLoading.value = true
-    collaborationModesError.value = null
-
-    try {
-      await ensureProjectRuntime()
-      const response = await getClient(props.projectId).request<CollaborationModeListResponse>('collaborationMode/list', {})
-      collaborationModeMasks.value = normalizeCollaborationModeListResponse(response)
-    } catch (caughtError) {
-      collaborationModeMasks.value = []
-      collaborationModesError.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
-    } finally {
-      collaborationModesLoaded.value = true
-      collaborationModesLoading.value = false
-    }
-  })()
-
-  pendingCollaborationModesLoad = loadPromise
-
-  try {
-    await loadPromise
-  } finally {
-    if (pendingCollaborationModesLoad === loadPromise) {
-      pendingCollaborationModesLoad = null
-    }
-  }
-}
-
-const ensurePlanModeAvailable = async () => {
-  if (!collaborationModesLoaded.value || (collaborationModesLoading.value && !planCollaborationModeMask.value)) {
-    await loadCollaborationModes()
-  }
-
-  if (!planCollaborationModeMask.value && collaborationModesError.value) {
-    await loadCollaborationModes({ force: true })
-  }
-
-  if (planCollaborationModeMask.value) {
-    return planCollaborationModeMask.value
-  }
-
-  throw new Error(collaborationModesError.value ?? 'Plan mode is unavailable in the current runtime.')
-}
-
-const setCurrentThreadCollaborationMode = async (mode: 'plan' | 'default') => {
-  if (isBusy.value) {
-    throw new Error('Cannot switch collaboration mode while a turn is running.')
-  }
-
-  await loadCollaborationModes()
-  if (collaborationModesError.value && !findCollaborationModeMask(collaborationModeMasks.value, mode)) {
-    await loadCollaborationModes({ force: true })
-  }
-  const mask = findCollaborationModeMask(collaborationModeMasks.value, mode)
-  if (!mask) {
-    throw new Error(
-      mode === 'plan'
-        ? collaborationModesError.value ?? 'Plan mode is unavailable in the current runtime.'
-        : collaborationModesError.value ?? 'Default collaboration mode is unavailable in the current runtime.'
-    )
-  }
-
-  setThreadCollaborationModeMask(activeThreadId.value ?? routeThreadId.value, mask)
-}
-
-const closePlanImplementationPrompt = () => {
-  planImplementationPromptFlushToken += 1
-  queuedPlanImplementationPromptTurnId.value = null
-  queuedPlanImplementationPromptThreadId.value = null
-  planImplementationPromptTurnId.value = null
-  planImplementationPromptThreadId.value = null
-}
-
-const flushPlanImplementationPrompt = async () => {
-  if (
-    !queuedPlanImplementationPromptTurnId.value
-    || !queuedPlanImplementationPromptThreadId.value
-    || hasPendingRequest.value
-  ) {
-    return
-  }
-
-  const turnId = queuedPlanImplementationPromptTurnId.value
-  const threadId = queuedPlanImplementationPromptThreadId.value
-  if (session.shownPlanImplementationPromptTurnIds.has(turnId)) {
-    queuedPlanImplementationPromptTurnId.value = null
-    queuedPlanImplementationPromptThreadId.value = null
-    return
-  }
-
-  if (currentPlanPromptThreadId.value !== threadId) {
-    return
-  }
-
-  const flushToken = ++planImplementationPromptFlushToken
-  await nextTick()
-  if (
-    flushToken !== planImplementationPromptFlushToken
-    || hasPendingRequest.value
-    || queuedPlanImplementationPromptTurnId.value !== turnId
-    || queuedPlanImplementationPromptThreadId.value !== threadId
-    || currentPlanPromptThreadId.value !== threadId
-  ) {
-    return
-  }
-
-  planImplementationPromptTurnId.value = turnId
-  planImplementationPromptThreadId.value = threadId
-}
-
-const maybeQueuePlanImplementationPrompt = (input: {
-  threadId: string | null
-  turnId: string | null
-  turnStatus: string | null | undefined
-}) => {
-  if (!shouldQueuePlanImplementationPrompt({
-    turnId: input.turnId,
-    latestPlanTurnId: latestPlanTurnId.value,
-    turnStatus: input.turnStatus
-  })) {
-    return
-  }
-
-  queuedPlanImplementationPromptThreadId.value = input.threadId
-  queuedPlanImplementationPromptTurnId.value = input.turnId
-  flushPlanImplementationPrompt()
-}
-
 type SlashCommandSubmissionResult = {
   consumed: boolean
   replacementText?: string
@@ -2114,22 +1848,6 @@ const handleUsageStatusOpenChange = (open: boolean) => {
   usageStatusModalOpen.value = open
 }
 
-watch(hasPendingRequest, (nextValue) => {
-  if (!nextValue) {
-    flushPlanImplementationPrompt()
-  }
-})
-
-watch(currentPlanPromptThreadId, () => {
-  void flushPlanImplementationPrompt()
-})
-
-watch(isPlanImplementationPromptOpen, (open) => {
-  if (open && planImplementationPromptTurnId.value) {
-    session.shownPlanImplementationPromptTurnIds.add(planImplementationPromptTurnId.value)
-  }
-})
-
 const removeOptimisticMessage = (messageId: string) => {
   messages.value = removeChatMessage(messages.value, messageId)
   optimisticAttachmentSnapshots.delete(messageId)
@@ -2200,6 +1918,51 @@ const {
   handleReviewDrawerOpenChange,
   handleReviewDrawerBack
 } = reviewWorkflow
+
+const planWorkflow = useChatPlanWorkflow({
+  projectId: props.projectId,
+  routeThreadId,
+  activeThreadId,
+  hasPendingRequest,
+  isBusy: computed(() => isWorkflowBusy.value || reviewStartPending.value),
+  selectedProjectStatus: computed(() => selectedProject.value?.status ?? null),
+  selectedModel,
+  selectedEffort,
+  threadPlans,
+  threadCollaborationModeMasks,
+  collaborationModeMasks,
+  collaborationModesLoaded,
+  collaborationModesLoading,
+  collaborationModesError,
+  latestPlanTurnId,
+  queuedPlanImplementationPromptTurnId,
+  queuedPlanImplementationPromptThreadId,
+  planImplementationPromptTurnId,
+  planImplementationPromptThreadId,
+  shownPlanImplementationPromptTurnIds: session.shownPlanImplementationPromptTurnIds,
+  ensureProjectRuntime: async () => await ensureProjectRuntime(),
+  getClient
+})
+
+const {
+  currentThreadCollaborationModeMask,
+  planCollaborationModeMask,
+  currentCollaborationModeLabel,
+  isPlanModeActive,
+  currentThreadPlan,
+  isPlanImplementationPromptOpen,
+  setThreadPlanPanelOpen,
+  clearThreadPlanState,
+  updateThreadPlanState,
+  shouldResetThreadPlanForTurn,
+  setThreadCollaborationModeMask,
+  moveDraftCollaborationModeToThread,
+  buildCurrentTurnCollaborationMode,
+  ensurePlanModeAvailable,
+  setCurrentThreadCollaborationMode,
+  closePlanImplementationPrompt,
+  maybeQueuePlanImplementationPrompt
+} = planWorkflow
 
 const isBusy = computed(() =>
   isWorkflowBusy.value
@@ -3345,7 +3108,7 @@ const applyNotification = (notification: CodexRpcNotification) => {
         return
       }
 
-      if (threadId && shouldResetThreadPlanState(threadPlans.value[threadId], nextTurnId)) {
+      if (threadId && shouldResetThreadPlanForTurn(threadId, nextTurnId)) {
         clearThreadPlanState(threadId)
       }
 
@@ -4400,22 +4163,6 @@ watch(
     }
   },
   { flush: 'post' }
-)
-
-watch(
-  () => selectedProject.value?.status ?? null,
-  (projectStatus) => {
-    if (
-      projectStatus !== 'running'
-      || collaborationModesLoaded.value
-      || collaborationModesLoading.value
-    ) {
-      return
-    }
-
-    void loadCollaborationModes()
-  },
-  { immediate: true }
 )
 
 watch(

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -2602,6 +2602,125 @@ const updateWebSearchMessageStatus = (
     parts: message.parts.map((part, index) => index === partIndex ? nextPart : part)
   }
 })
+
+const applyTurnStartedNotification = (
+  notification: CodexRpcNotification,
+  liveStream: LiveStream | null
+) => {
+  const threadId = notificationThreadId(notification) ?? currentLiveStream()?.threadId ?? activeThreadId.value
+  const nextTurnId = notificationTurnId(notification)
+  if (liveStream && !shouldAdvanceLiveStreamTurn({
+    lockedTurnId: liveStream.lockedTurnId,
+    nextTurnId
+  })) {
+    return
+  }
+
+  if (threadId && shouldResetThreadPlanForTurn(threadId, nextTurnId)) {
+    clearThreadPlanState(threadId)
+  }
+
+  if (nextTurnId) {
+    latestPlanTurnId.value = null
+  }
+  closePlanImplementationPrompt()
+
+  if (liveStream) {
+    setLiveStreamTurnId(liveStream, nextTurnId)
+    setLiveStreamInterruptRequested(liveStream, false)
+  }
+  messages.value = upsertStreamingMessage(
+    messages.value,
+    eventToMessage(`event-turn-started-${nextTurnId ?? Date.now()}`, {
+      kind: 'turn.started'
+    })
+  )
+  status.value = 'streaming'
+}
+
+const applyItemStartedNotification = (notification: CodexRpcNotification) => {
+  const params = notification.params as { item: ThreadItem }
+  if (params.item.type === 'collabAgentToolCall') {
+    applySubagentActivityItem(params.item)
+  }
+  if (params.item.type === 'plan') {
+    latestPlanTurnId.value = notificationTurnId(notification) ?? currentLiveStream()?.turnId ?? null
+  }
+  if (params.item.type === 'userMessage') {
+    for (const nextMessage of itemToMessages(params.item)) {
+      reconcilePendingUserMessage({
+        ...nextMessage,
+        pending: false
+      })
+    }
+    status.value = 'streaming'
+    return
+  }
+  markAssistantOutputStartedForItem(params.item)
+  seedStreamingMessage(params.item)
+  status.value = 'streaming'
+}
+
+const applyItemCompletedNotification = (notification: CodexRpcNotification) => {
+  const params = notification.params as { item: ThreadItem }
+  if (params.item.type === 'collabAgentToolCall') {
+    applySubagentActivityItem(params.item)
+  }
+  if (params.item.type === 'plan') {
+    latestPlanTurnId.value = notificationTurnId(notification) ?? currentLiveStream()?.turnId ?? null
+  }
+  markAssistantOutputStartedForItem(params.item)
+  for (const nextMessage of itemToMessages(params.item)) {
+    const confirmedMessage = {
+      ...nextMessage,
+      pending: false
+    }
+    if (params.item.type === 'userMessage') {
+      reconcilePendingUserMessage(confirmedMessage)
+      continue
+    }
+
+    messages.value = replaceStreamingMessage(messages.value, confirmedMessage)
+  }
+}
+
+const applyTerminalNotification = (
+  kind: 'turn.failed' | 'stream.error',
+  messageText: string,
+  liveStream: LiveStream | null
+) => {
+  markAwaitingAssistantOutput(false)
+  pushEventMessage(kind, messageText)
+  clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
+  if (liveStream) {
+    liveStream.lockedTurnId = null
+  }
+  clearLiveStream(new Error(messageText))
+  error.value = messageText
+  status.value = 'error'
+}
+
+const applyTurnCompletedNotification = (
+  notification: CodexRpcNotification,
+  liveStream: LiveStream | null
+) => {
+  if (notificationTurnStatus(notification) === 'failed') {
+    messages.value = updateWebSearchMessageStatus(messages.value, 'failed')
+  }
+  maybeQueuePlanImplementationPrompt({
+    threadId: notificationThreadId(notification) ?? liveStream?.threadId ?? activeThreadId.value,
+    turnId: notificationTurnId(notification) ?? liveStream?.turnId ?? null,
+    turnStatus: notificationTurnStatus(notification)
+  })
+  markAwaitingAssistantOutput(false)
+  clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
+  if (liveStream) {
+    liveStream.lockedTurnId = null
+  }
+  error.value = null
+  status.value = 'ready'
+  clearLiveStream()
+}
 const applyNotification = (notification: CodexRpcNotification) => {
   const liveStream = currentLiveStream()
   if (liveStream?.interruptAcknowledged && shouldIgnoreNotificationAfterInterrupt(notification.method)) {
@@ -2647,81 +2766,15 @@ const applyNotification = (notification: CodexRpcNotification) => {
       return
     }
     case 'turn/started': {
-      const threadId = notificationThreadId(notification) ?? currentLiveStream()?.threadId ?? activeThreadId.value
-      const nextTurnId = notificationTurnId(notification)
-      if (liveStream && !shouldAdvanceLiveStreamTurn({
-        lockedTurnId: liveStream.lockedTurnId,
-        nextTurnId
-      })) {
-        return
-      }
-
-      if (threadId && shouldResetThreadPlanForTurn(threadId, nextTurnId)) {
-        clearThreadPlanState(threadId)
-      }
-
-      if (nextTurnId) {
-        latestPlanTurnId.value = null
-      }
-      closePlanImplementationPrompt()
-
-      if (liveStream) {
-        setLiveStreamTurnId(liveStream, nextTurnId)
-        setLiveStreamInterruptRequested(liveStream, false)
-      }
-      messages.value = upsertStreamingMessage(
-        messages.value,
-        eventToMessage(`event-turn-started-${nextTurnId ?? Date.now()}`, {
-          kind: 'turn.started'
-        })
-      )
-      status.value = 'streaming'
+      applyTurnStartedNotification(notification, liveStream)
       return
     }
     case 'item/started': {
-      const params = notification.params as { item: ThreadItem }
-      if (params.item.type === 'collabAgentToolCall') {
-        applySubagentActivityItem(params.item)
-      }
-      if (params.item.type === 'plan') {
-        latestPlanTurnId.value = notificationTurnId(notification) ?? currentLiveStream()?.turnId ?? null
-      }
-      if (params.item.type === 'userMessage') {
-        for (const nextMessage of itemToMessages(params.item)) {
-          reconcilePendingUserMessage({
-            ...nextMessage,
-            pending: false
-          })
-        }
-        status.value = 'streaming'
-        return
-      }
-      markAssistantOutputStartedForItem(params.item)
-      seedStreamingMessage(params.item)
-      status.value = 'streaming'
+      applyItemStartedNotification(notification)
       return
     }
     case 'item/completed': {
-      const params = notification.params as { item: ThreadItem }
-      if (params.item.type === 'collabAgentToolCall') {
-        applySubagentActivityItem(params.item)
-      }
-      if (params.item.type === 'plan') {
-        latestPlanTurnId.value = notificationTurnId(notification) ?? currentLiveStream()?.turnId ?? null
-      }
-      markAssistantOutputStartedForItem(params.item)
-      for (const nextMessage of itemToMessages(params.item)) {
-        const confirmedMessage = {
-          ...nextMessage,
-          pending: false
-        }
-        if (params.item.type === 'userMessage') {
-          reconcilePendingUserMessage(confirmedMessage)
-          continue
-        }
-
-        messages.value = replaceStreamingMessage(messages.value, confirmedMessage)
-      }
+      applyItemCompletedNotification(notification)
       return
     }
     case 'item/agentMessage/delta': {
@@ -2883,63 +2936,21 @@ const applyNotification = (notification: CodexRpcNotification) => {
     }
     case 'error': {
       const params = notification.params as { error?: { message?: string } }
-      const messageText = params.error?.message ?? 'The stream failed.'
-      markAwaitingAssistantOutput(false)
-      pushEventMessage('stream.error', messageText)
-      clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
-      if (liveStream) {
-        liveStream.lockedTurnId = null
-      }
-      clearLiveStream(new Error(messageText))
-      error.value = messageText
-      status.value = 'error'
+      applyTerminalNotification('stream.error', params.error?.message ?? 'The stream failed.', liveStream)
       return
     }
     case 'turn/failed': {
       const params = notification.params as { error?: { message?: string } }
-      const messageText = params.error?.message ?? 'The turn failed.'
-      markAwaitingAssistantOutput(false)
-      pushEventMessage('turn.failed', messageText)
-      clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
-      if (liveStream) {
-        liveStream.lockedTurnId = null
-      }
-      clearLiveStream(new Error(messageText))
-      error.value = messageText
-      status.value = 'error'
+      applyTerminalNotification('turn.failed', params.error?.message ?? 'The turn failed.', liveStream)
       return
     }
     case 'stream/error': {
       const params = notification.params as { message?: string }
-      const messageText = params.message ?? 'The stream failed.'
-      markAwaitingAssistantOutput(false)
-      pushEventMessage('stream.error', messageText)
-      clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
-      if (liveStream) {
-        liveStream.lockedTurnId = null
-      }
-      clearLiveStream(new Error(messageText))
-      error.value = messageText
-      status.value = 'error'
+      applyTerminalNotification('stream.error', params.message ?? 'The stream failed.', liveStream)
       return
     }
     case 'turn/completed': {
-      if (notificationTurnStatus(notification) === 'failed') {
-        messages.value = updateWebSearchMessageStatus(messages.value, 'failed')
-      }
-      maybeQueuePlanImplementationPrompt({
-        threadId: notificationThreadId(notification) ?? liveStream?.threadId ?? activeThreadId.value,
-        turnId: notificationTurnId(notification) ?? liveStream?.turnId ?? null,
-        turnStatus: notificationTurnStatus(notification)
-      })
-      markAwaitingAssistantOutput(false)
-      clearPendingOptimisticMessages(liveStream, { discardSnapshots: true })
-      if (liveStream) {
-        liveStream.lockedTurnId = null
-      }
-      error.value = null
-      status.value = 'ready'
-      clearLiveStream()
+      applyTurnCompletedNotification(notification, liveStream)
       return
     }
     default:

--- a/packages/client/app/composables/useChatPlanWorkflow.ts
+++ b/packages/client/app/composables/useChatPlanWorkflow.ts
@@ -1,0 +1,365 @@
+import { computed, nextTick, watch, type ComputedRef, type Ref } from 'vue'
+import type { ReasoningEffort } from '~~/shared/chat-prompt-controls'
+import {
+  buildCollaborationModeFromMask,
+  findCollaborationModeMask,
+  normalizeCollaborationModeListResponse,
+  resolveThreadCollaborationModeKey,
+  type CollaborationMode,
+  type CollaborationModeListResponse,
+  type CollaborationModeMask
+} from '~~/shared/collaboration-mode'
+import { shouldQueuePlanImplementationPrompt } from '~~/shared/plan-implementation-prompt'
+import {
+  applyTurnPlanUpdate,
+  normalizeTurnPlanUpdate,
+  shouldResetThreadPlanState,
+  type ThreadPlanState
+} from '~~/shared/turn-plan'
+
+type CollaborationModeClient = {
+  request<T>(method: 'collaborationMode/list', params: Record<string, never>): Promise<T>
+}
+
+type UseChatPlanWorkflowOptions = {
+  projectId: string
+  routeThreadId: Ref<string | null>
+  activeThreadId: Ref<string | null>
+  hasPendingRequest: Ref<boolean>
+  isBusy: ComputedRef<boolean>
+  selectedProjectStatus: ComputedRef<string | null>
+  selectedModel: Ref<string>
+  selectedEffort: Ref<ReasoningEffort>
+  threadPlans: Ref<Record<string, ThreadPlanState>>
+  threadCollaborationModeMasks: Ref<Record<string, CollaborationModeMask>>
+  collaborationModeMasks: Ref<CollaborationModeMask[]>
+  collaborationModesLoaded: Ref<boolean>
+  collaborationModesLoading: Ref<boolean>
+  collaborationModesError: Ref<string | null>
+  latestPlanTurnId: Ref<string | null>
+  queuedPlanImplementationPromptTurnId: Ref<string | null>
+  queuedPlanImplementationPromptThreadId: Ref<string | null>
+  planImplementationPromptTurnId: Ref<string | null>
+  planImplementationPromptThreadId: Ref<string | null>
+  shownPlanImplementationPromptTurnIds: Set<string>
+  ensureProjectRuntime: () => Promise<void>
+  getClient: (projectId: string) => CollaborationModeClient
+}
+
+export const useChatPlanWorkflow = (options: UseChatPlanWorkflowOptions) => {
+  const currentThreadCollaborationModeKey = computed(() =>
+    resolveThreadCollaborationModeKey(options.activeThreadId.value ?? options.routeThreadId.value)
+  )
+  const currentPlanPromptThreadId = computed(() =>
+    options.activeThreadId.value ?? options.routeThreadId.value
+  )
+  const isPlanImplementationPromptOpen = computed(() =>
+    Boolean(
+      options.planImplementationPromptTurnId.value
+      && options.planImplementationPromptThreadId.value === currentPlanPromptThreadId.value
+    )
+  )
+  const currentThreadCollaborationModeMask = computed(() =>
+    options.threadCollaborationModeMasks.value[currentThreadCollaborationModeKey.value] ?? null
+  )
+  const planCollaborationModeMask = computed(() =>
+    findCollaborationModeMask(options.collaborationModeMasks.value, 'plan')
+  )
+  const currentCollaborationModeLabel = computed(() =>
+    currentThreadCollaborationModeMask.value?.mode === 'plan'
+      ? currentThreadCollaborationModeMask.value.name
+      : null
+  )
+  const isPlanModeActive = computed(() =>
+    currentThreadCollaborationModeMask.value?.mode === 'plan'
+  )
+  const currentThreadPlan = computed(() => {
+    const threadId = options.activeThreadId.value ?? options.routeThreadId.value
+    if (!threadId) {
+      return null
+    }
+
+    return options.threadPlans.value[threadId] ?? null
+  })
+
+  const setThreadPlanPanelOpen = (open: boolean) => {
+    if (!currentThreadPlan.value?.threadId) {
+      return
+    }
+
+    options.threadPlans.value = {
+      ...options.threadPlans.value,
+      [currentThreadPlan.value.threadId]: {
+        ...currentThreadPlan.value,
+        panelOpen: open
+      }
+    }
+  }
+
+  const clearThreadPlanState = (threadId: string) => {
+    if (!(threadId in options.threadPlans.value)) {
+      return
+    }
+
+    const nextThreadPlans = { ...options.threadPlans.value }
+    delete nextThreadPlans[threadId]
+    options.threadPlans.value = nextThreadPlans
+  }
+
+  const updateThreadPlanState = (threadId: string, params: unknown) => {
+    const nextPlanUpdate = normalizeTurnPlanUpdate(params)
+    if (!nextPlanUpdate) {
+      return
+    }
+
+    const nextPlanState = applyTurnPlanUpdate(options.threadPlans.value[threadId], {
+      ...nextPlanUpdate,
+      threadId
+    })
+    if (!nextPlanState) {
+      clearThreadPlanState(threadId)
+      return
+    }
+
+    options.threadPlans.value = {
+      ...options.threadPlans.value,
+      [threadId]: nextPlanState
+    }
+  }
+
+  const shouldResetThreadPlanForTurn = (threadId: string, nextTurnId: string | null) =>
+    shouldResetThreadPlanState(options.threadPlans.value[threadId], nextTurnId)
+
+  const setThreadCollaborationModeMask = (
+    threadId: string | null | undefined,
+    mask: CollaborationModeMask | null
+  ) => {
+    const key = resolveThreadCollaborationModeKey(threadId)
+    const nextThreadModes = { ...options.threadCollaborationModeMasks.value }
+
+    if (mask) {
+      nextThreadModes[key] = mask
+    } else {
+      delete nextThreadModes[key]
+    }
+
+    options.threadCollaborationModeMasks.value = nextThreadModes
+  }
+
+  const moveDraftCollaborationModeToThread = (threadId: string) => {
+    const draftKey = resolveThreadCollaborationModeKey(null)
+    const draftMode = options.threadCollaborationModeMasks.value[draftKey]
+    if (!draftMode) {
+      return
+    }
+
+    const nextThreadModes = { ...options.threadCollaborationModeMasks.value }
+    nextThreadModes[threadId] = draftMode
+    delete nextThreadModes[draftKey]
+    options.threadCollaborationModeMasks.value = nextThreadModes
+  }
+
+  const buildCurrentTurnCollaborationMode = (): CollaborationMode | null =>
+    buildCollaborationModeFromMask(currentThreadCollaborationModeMask.value, {
+      model: options.selectedModel.value,
+      reasoning_effort: options.selectedEffort.value
+    })
+
+  let pendingCollaborationModesLoad: Promise<void> | null = null
+
+  const loadCollaborationModes = async (loadOptions?: { force?: boolean }) => {
+    if (options.collaborationModesLoaded.value && !loadOptions?.force) {
+      return
+    }
+
+    if (pendingCollaborationModesLoad) {
+      await pendingCollaborationModesLoad
+      return
+    }
+
+    const loadPromise = (async () => {
+      options.collaborationModesLoading.value = true
+      options.collaborationModesError.value = null
+
+      try {
+        await options.ensureProjectRuntime()
+        const response = await options.getClient(options.projectId).request<CollaborationModeListResponse>('collaborationMode/list', {})
+        options.collaborationModeMasks.value = normalizeCollaborationModeListResponse(response)
+      } catch (caughtError) {
+        options.collaborationModeMasks.value = []
+        options.collaborationModesError.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
+      } finally {
+        options.collaborationModesLoaded.value = true
+        options.collaborationModesLoading.value = false
+      }
+    })()
+
+    pendingCollaborationModesLoad = loadPromise
+
+    try {
+      await loadPromise
+    } finally {
+      if (pendingCollaborationModesLoad === loadPromise) {
+        pendingCollaborationModesLoad = null
+      }
+    }
+  }
+
+  const ensurePlanModeAvailable = async () => {
+    if (
+      !options.collaborationModesLoaded.value
+      || (options.collaborationModesLoading.value && !planCollaborationModeMask.value)
+    ) {
+      await loadCollaborationModes()
+    }
+
+    if (!planCollaborationModeMask.value && options.collaborationModesError.value) {
+      await loadCollaborationModes({ force: true })
+    }
+
+    if (planCollaborationModeMask.value) {
+      return planCollaborationModeMask.value
+    }
+
+    throw new Error(options.collaborationModesError.value ?? 'Plan mode is unavailable in the current runtime.')
+  }
+
+  const setCurrentThreadCollaborationMode = async (mode: 'plan' | 'default') => {
+    if (options.isBusy.value) {
+      throw new Error('Cannot switch collaboration mode while a turn is running.')
+    }
+
+    await loadCollaborationModes()
+    if (options.collaborationModesError.value && !findCollaborationModeMask(options.collaborationModeMasks.value, mode)) {
+      await loadCollaborationModes({ force: true })
+    }
+    const mask = findCollaborationModeMask(options.collaborationModeMasks.value, mode)
+    if (!mask) {
+      throw new Error(
+        mode === 'plan'
+          ? options.collaborationModesError.value ?? 'Plan mode is unavailable in the current runtime.'
+          : options.collaborationModesError.value ?? 'Default collaboration mode is unavailable in the current runtime.'
+      )
+    }
+
+    setThreadCollaborationModeMask(options.activeThreadId.value ?? options.routeThreadId.value, mask)
+  }
+
+  let planImplementationPromptFlushToken = 0
+
+  const closePlanImplementationPrompt = () => {
+    planImplementationPromptFlushToken += 1
+    options.queuedPlanImplementationPromptTurnId.value = null
+    options.queuedPlanImplementationPromptThreadId.value = null
+    options.planImplementationPromptTurnId.value = null
+    options.planImplementationPromptThreadId.value = null
+  }
+
+  const flushPlanImplementationPrompt = async () => {
+    if (
+      !options.queuedPlanImplementationPromptTurnId.value
+      || !options.queuedPlanImplementationPromptThreadId.value
+      || options.hasPendingRequest.value
+    ) {
+      return
+    }
+
+    const turnId = options.queuedPlanImplementationPromptTurnId.value
+    const threadId = options.queuedPlanImplementationPromptThreadId.value
+    if (options.shownPlanImplementationPromptTurnIds.has(turnId)) {
+      options.queuedPlanImplementationPromptTurnId.value = null
+      options.queuedPlanImplementationPromptThreadId.value = null
+      return
+    }
+
+    if (currentPlanPromptThreadId.value !== threadId) {
+      return
+    }
+
+    const flushToken = ++planImplementationPromptFlushToken
+    await nextTick()
+    if (
+      flushToken !== planImplementationPromptFlushToken
+      || options.hasPendingRequest.value
+      || options.queuedPlanImplementationPromptTurnId.value !== turnId
+      || options.queuedPlanImplementationPromptThreadId.value !== threadId
+      || currentPlanPromptThreadId.value !== threadId
+    ) {
+      return
+    }
+
+    options.planImplementationPromptTurnId.value = turnId
+    options.planImplementationPromptThreadId.value = threadId
+  }
+
+  const maybeQueuePlanImplementationPrompt = (input: {
+    threadId: string | null
+    turnId: string | null
+    turnStatus: string | null | undefined
+  }) => {
+    if (!shouldQueuePlanImplementationPrompt({
+      turnId: input.turnId,
+      latestPlanTurnId: options.latestPlanTurnId.value,
+      turnStatus: input.turnStatus
+    })) {
+      return
+    }
+
+    options.queuedPlanImplementationPromptThreadId.value = input.threadId
+    options.queuedPlanImplementationPromptTurnId.value = input.turnId
+    void flushPlanImplementationPrompt()
+  }
+
+  watch(options.hasPendingRequest, (nextValue) => {
+    if (!nextValue) {
+      void flushPlanImplementationPrompt()
+    }
+  })
+
+  watch(currentPlanPromptThreadId, () => {
+    void flushPlanImplementationPrompt()
+  })
+
+  watch(isPlanImplementationPromptOpen, (open) => {
+    if (open && options.planImplementationPromptTurnId.value) {
+      options.shownPlanImplementationPromptTurnIds.add(options.planImplementationPromptTurnId.value)
+    }
+  })
+
+  watch(
+    options.selectedProjectStatus,
+    (projectStatus) => {
+      if (
+        projectStatus !== 'running'
+        || options.collaborationModesLoaded.value
+        || options.collaborationModesLoading.value
+      ) {
+        return
+      }
+
+      void loadCollaborationModes()
+    },
+    { immediate: true }
+  )
+
+  return {
+    currentThreadCollaborationModeMask,
+    planCollaborationModeMask,
+    currentCollaborationModeLabel,
+    isPlanModeActive,
+    currentThreadPlan,
+    isPlanImplementationPromptOpen,
+    setThreadPlanPanelOpen,
+    clearThreadPlanState,
+    updateThreadPlanState,
+    shouldResetThreadPlanForTurn,
+    setThreadCollaborationModeMask,
+    moveDraftCollaborationModeToThread,
+    buildCurrentTurnCollaborationMode,
+    loadCollaborationModes,
+    ensurePlanModeAvailable,
+    setCurrentThreadCollaborationMode,
+    closePlanImplementationPrompt,
+    maybeQueuePlanImplementationPrompt
+  }
+}

--- a/packages/client/app/composables/useChatPlanWorkflow.ts
+++ b/packages/client/app/composables/useChatPlanWorkflow.ts
@@ -1,14 +1,14 @@
 import { computed, nextTick, watch, type ComputedRef, type Ref } from 'vue'
-import type { ReasoningEffort } from '~~/shared/chat-prompt-controls'
+import type { ReasoningEffort } from '~~/shared/generated/codex-app-server/ReasoningEffort'
 import {
   buildCollaborationModeFromMask,
   findCollaborationModeMask,
   normalizeCollaborationModeListResponse,
   resolveThreadCollaborationModeKey,
   type CollaborationMode,
-  type CollaborationModeListResponse,
   type CollaborationModeMask
 } from '~~/shared/collaboration-mode'
+import type { CollaborationModeListResponse } from '~~/shared/generated/codex-app-server/v2/CollaborationModeListResponse'
 import { shouldQueuePlanImplementationPrompt } from '~~/shared/plan-implementation-prompt'
 import {
   applyTurnPlanUpdate,

--- a/packages/client/app/composables/useChatReviewWorkflow.ts
+++ b/packages/client/app/composables/useChatReviewWorkflow.ts
@@ -2,11 +2,6 @@ import { computed, ref, type ComputedRef, type Ref } from 'vue'
 import type { DraftAttachment } from './useChatAttachments'
 import type { ChatStatus, LiveStream } from './useChatSession'
 import {
-  type ReviewStartParams,
-  type ReviewStartResponse,
-  type ReviewTarget
-} from '~~/shared/codex-rpc'
-import {
   itemToMessages,
   upsertStreamingMessage,
   type ChatMessage
@@ -15,6 +10,9 @@ import {
   resolveProjectGitBranchesUrl,
   type ProjectGitBranchesResponse
 } from '~~/shared/codori'
+import type { ReviewStartParams } from '~~/shared/generated/codex-app-server/v2/ReviewStartParams'
+import type { ReviewStartResponse } from '~~/shared/generated/codex-app-server/v2/ReviewStartResponse'
+import type { ReviewTarget } from '~~/shared/generated/codex-app-server/v2/ReviewTarget'
 import type { TokenUsageSnapshot } from '~~/shared/chat-prompt-controls'
 
 type ReviewRpcClient = {

--- a/packages/client/app/composables/useChatReviewWorkflow.ts
+++ b/packages/client/app/composables/useChatReviewWorkflow.ts
@@ -1,0 +1,203 @@
+import { computed, ref, type ComputedRef, type Ref } from 'vue'
+import type { DraftAttachment } from './useChatAttachments'
+import type { ChatStatus, LiveStream } from './useChatSession'
+import {
+  type ReviewStartParams,
+  type ReviewStartResponse,
+  type ReviewTarget
+} from '~~/shared/codex-rpc'
+import {
+  itemToMessages,
+  upsertStreamingMessage,
+  type ChatMessage
+} from '~~/shared/codex-chat'
+import {
+  resolveProjectGitBranchesUrl,
+  type ProjectGitBranchesResponse
+} from '~~/shared/codori'
+import type { TokenUsageSnapshot } from '~~/shared/chat-prompt-controls'
+
+type ReviewRpcClient = {
+  request<T>(method: 'review/start', params: ReviewStartParams): Promise<T>
+}
+
+type UseChatReviewWorkflowOptions = {
+  projectId: string
+  serverBase: string
+  input: Ref<string>
+  attachments: Ref<DraftAttachment[]>
+  hasPendingRequest: Ref<boolean>
+  isWorkflowBusy: ComputedRef<boolean>
+  error: Ref<string | null>
+  status: Ref<ChatStatus>
+  tokenUsage: Ref<TokenUsageSnapshot | null>
+  messages: Ref<ChatMessage[]>
+  setComposerError: (messageText: string) => void
+  markAwaitingAssistantOutput: (nextValue: boolean) => void
+  clearAttachments: (options?: { revoke?: boolean }) => void
+  restoreDraftIfPristine: (text: string, submittedAttachments: DraftAttachment[]) => void
+  ensurePendingLiveStream: () => Promise<LiveStream>
+  getClient: (projectId: string) => ReviewRpcClient
+  lockLiveStreamTurnId: (liveStream: LiveStream, turnId: string | null) => void
+  replayBufferedNotifications: (liveStream: LiveStream) => void
+  clearDismissedSlashMatch: () => void
+}
+
+export const useChatReviewWorkflow = (options: UseChatReviewWorkflowOptions) => {
+  const reviewDrawerOpen = ref(false)
+  const reviewDrawerMode = ref<'target' | 'branch'>('target')
+  const reviewDrawerCommandText = ref('/review')
+  const reviewBranches = ref<string[]>([])
+  const reviewCurrentBranch = ref<string | null>(null)
+  const reviewBranchesLoading = ref(false)
+  const reviewBranchesError = ref<string | null>(null)
+  const reviewStartPending = ref(false)
+
+  const reviewBaseBranches = computed(() =>
+    reviewBranches.value.filter(branch => branch !== reviewCurrentBranch.value)
+  )
+
+  const resetReviewDrawerState = () => {
+    reviewDrawerMode.value = 'target'
+    reviewDrawerCommandText.value = '/review'
+    reviewBranchesLoading.value = false
+    reviewBranchesError.value = null
+  }
+
+  const closeReviewDrawer = () => {
+    reviewDrawerOpen.value = false
+    resetReviewDrawerState()
+  }
+
+  const openReviewDrawer = (commandText = '/review') => {
+    options.clearDismissedSlashMatch()
+    reviewDrawerCommandText.value = commandText
+    reviewDrawerMode.value = 'target'
+    reviewBranchesError.value = null
+    reviewDrawerOpen.value = true
+  }
+
+  const fetchProjectGitBranches = async () => {
+    reviewBranchesLoading.value = true
+    reviewBranchesError.value = null
+
+    try {
+      const response = await fetch(resolveProjectGitBranchesUrl({
+        projectId: options.projectId,
+        configuredBase: options.serverBase
+      }))
+
+      const body = await response.json() as ProjectGitBranchesResponse | { error?: { message?: string } }
+      if (!response.ok) {
+        throw new Error(body && typeof body === 'object' && 'error' in body
+          ? body.error?.message ?? 'Failed to load local branches.'
+          : 'Failed to load local branches.')
+      }
+
+      const result = body as ProjectGitBranchesResponse
+      reviewCurrentBranch.value = result.currentBranch
+      reviewBranches.value = result.branches
+    } finally {
+      reviewBranchesLoading.value = false
+    }
+  }
+
+  const openBaseBranchPicker = async () => {
+    reviewDrawerMode.value = 'branch'
+
+    try {
+      await fetchProjectGitBranches()
+      if (!reviewBaseBranches.value.length) {
+        reviewBranchesError.value = 'No local base branches are available to compare against.'
+      }
+    } catch (caughtError) {
+      reviewBranchesError.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
+    }
+  }
+
+  const startReview = async (target: ReviewTarget) => {
+    if (reviewStartPending.value) {
+      return
+    }
+
+    if (options.hasPendingRequest.value || options.isWorkflowBusy.value) {
+      options.setComposerError('Review can only start when the current thread is idle.')
+      return
+    }
+
+    reviewStartPending.value = true
+    const draftText = reviewDrawerCommandText.value
+    const submittedAttachments = options.attachments.value.slice()
+    options.input.value = ''
+    options.clearAttachments({ revoke: false })
+
+    try {
+      const client = options.getClient(options.projectId)
+      const liveStream = await options.ensurePendingLiveStream()
+      options.error.value = null
+      options.status.value = 'submitted'
+      options.tokenUsage.value = null
+      options.markAwaitingAssistantOutput(true)
+
+      const response = await client.request<ReviewStartResponse>('review/start', {
+        threadId: liveStream.threadId,
+        delivery: 'inline',
+        target
+      } satisfies ReviewStartParams)
+
+      for (const item of response.turn.items) {
+        if (item.type === 'userMessage') {
+          continue
+        }
+
+        for (const nextMessage of itemToMessages(item)) {
+          options.messages.value = upsertStreamingMessage(options.messages.value, {
+            ...nextMessage,
+            pending: false
+          })
+        }
+      }
+
+      options.lockLiveStreamTurnId(liveStream, response.turn.id)
+      options.replayBufferedNotifications(liveStream)
+      closeReviewDrawer()
+    } catch (caughtError) {
+      options.restoreDraftIfPristine(draftText, submittedAttachments)
+      options.setComposerError(caughtError instanceof Error ? caughtError.message : String(caughtError))
+    } finally {
+      reviewStartPending.value = false
+    }
+  }
+
+  const handleReviewDrawerOpenChange = (open: boolean) => {
+    if (open) {
+      reviewDrawerOpen.value = true
+      return
+    }
+
+    closeReviewDrawer()
+  }
+
+  const handleReviewDrawerBack = () => {
+    reviewDrawerMode.value = 'target'
+    reviewBranchesError.value = null
+  }
+
+  return {
+    reviewDrawerOpen,
+    reviewDrawerMode,
+    reviewDrawerCommandText,
+    reviewBranches,
+    reviewCurrentBranch,
+    reviewBaseBranches,
+    reviewBranchesLoading,
+    reviewBranchesError,
+    reviewStartPending,
+    openReviewDrawer,
+    closeReviewDrawer,
+    openBaseBranchPicker,
+    startReview,
+    handleReviewDrawerOpenChange,
+    handleReviewDrawerBack
+  }
+}

--- a/packages/client/app/composables/useSubagentPanelsController.ts
+++ b/packages/client/app/composables/useSubagentPanelsController.ts
@@ -1,0 +1,597 @@
+import { ref, type Ref } from 'vue'
+import type { LiveStream, SubagentPanelState } from './useChatSession'
+import {
+  ITEM_PART,
+  eventToMessage,
+  isSubagentActiveStatus,
+  itemToMessages,
+  replaceStreamingMessage,
+  threadToMessages,
+  upsertStreamingMessage,
+  type ChatMessage,
+  type ChatPart,
+  type FileChangeItem,
+  type ItemData,
+  type McpToolCallItem
+} from '~~/shared/codex-chat'
+import {
+  notificationTurnId,
+  type CodexRpcNotification,
+  type CodexThread,
+  type CodexThreadItem,
+  type ThreadReadResponse
+} from '~~/shared/codex-rpc'
+
+type ThreadReadClient = {
+  request<T>(method: 'thread/read', params: { threadId: string, includeTurns: true }): Promise<T>
+}
+
+type UseSubagentPanelsControllerOptions = {
+  projectId: string
+  subagentPanels: Ref<SubagentPanelState[]>
+  ensureProjectRuntime: () => Promise<void>
+  getClient: (projectId: string) => ThreadReadClient
+  isActiveTurnStatus: (value: string | null | undefined) => boolean
+  currentLiveStream: () => LiveStream | null
+}
+
+const shortThreadId = (value: string) => value.slice(0, 8)
+
+const resolveSubagentName = (
+  threadId: string,
+  thread?: Pick<CodexThread, 'agentNickname' | 'name' | 'preview'> | null
+) => {
+  const candidate = thread?.agentNickname?.trim()
+    || thread?.name?.trim()
+    || thread?.preview?.trim()
+
+  if (candidate) {
+    return candidate
+  }
+
+  return `Agent ${shortThreadId(threadId)}`
+}
+
+const isTextPart = (part: ChatPart): part is Extract<ChatPart, { type: 'text' }> =>
+  part.type === 'text'
+
+const isItemPart = (part: ChatPart): part is Extract<ChatPart, { type: typeof ITEM_PART }> =>
+  part.type === ITEM_PART
+
+const getFallbackItemData = (message: ChatMessage) => {
+  const itemPart = message.parts.find(isItemPart)
+  if (!itemPart) {
+    throw new Error('Expected item part in fallback message.')
+  }
+
+  return itemPart.data
+}
+
+const fallbackCommandMessage = (itemId: string): ChatMessage => ({
+  id: itemId,
+  role: 'system',
+  pending: true,
+  parts: [{
+    type: ITEM_PART,
+    data: {
+      kind: 'command_execution',
+      item: {
+        type: 'commandExecution',
+        id: itemId,
+        command: 'Command',
+        aggregatedOutput: '',
+        exitCode: null,
+        status: 'inProgress'
+      }
+    }
+  }]
+})
+
+const fallbackFileChangeMessage = (itemId: string): ChatMessage => ({
+  id: itemId,
+  role: 'system',
+  pending: true,
+  parts: [{
+    type: ITEM_PART,
+    data: {
+      kind: 'file_change',
+      item: {
+        type: 'fileChange',
+        id: itemId,
+        changes: [],
+        status: 'inProgress',
+        liveOutput: ''
+      }
+    }
+  }]
+})
+
+const fallbackMcpToolMessage = (itemId: string): ChatMessage => ({
+  id: itemId,
+  role: 'system',
+  pending: true,
+  parts: [{
+    type: ITEM_PART,
+    data: {
+      kind: 'mcp_tool_call',
+      item: {
+        type: 'mcpToolCall',
+        id: itemId,
+        server: 'mcp',
+        tool: 'tool',
+        arguments: null,
+        result: null,
+        error: null,
+        status: 'inProgress',
+        progressMessages: []
+      }
+    }
+  }]
+})
+
+const fallbackCommandItemData = (itemId: string) =>
+  getFallbackItemData(fallbackCommandMessage(itemId)) as Extract<ItemData, { kind: 'command_execution' }>
+
+const fallbackFileChangeItemData = (itemId: string) =>
+  getFallbackItemData(fallbackFileChangeMessage(itemId)) as Extract<ItemData, { kind: 'file_change' }>
+
+const fallbackMcpToolItemData = (itemId: string) =>
+  getFallbackItemData(fallbackMcpToolMessage(itemId)) as Extract<ItemData, { kind: 'mcp_tool_call' }>
+
+export const useSubagentPanelsController = (options: UseSubagentPanelsControllerOptions) => {
+  const subagentBootstrapPromises = new Map<string, Promise<void>>()
+
+  const getSubagentPanel = (threadId: string) =>
+    options.subagentPanels.value.find(panel => panel.threadId === threadId)
+
+  const createSubagentPanelState = (threadId: string): SubagentPanelState => ({
+    threadId,
+    name: resolveSubagentName(threadId),
+    role: null,
+    status: null,
+    messages: [],
+    firstSeenAt: Date.now(),
+    lastSeenAt: Date.now(),
+    turnId: null,
+    bootstrapped: false,
+    bufferedNotifications: []
+  })
+
+  const upsertSubagentPanel = (
+    threadId: string,
+    updater: (panel: SubagentPanelState | undefined) => SubagentPanelState
+  ) => {
+    const current = getSubagentPanel(threadId)
+    const nextPanel = updater(current)
+    const index = options.subagentPanels.value.findIndex(panel => panel.threadId === threadId)
+
+    if (index === -1) {
+      options.subagentPanels.value = [...options.subagentPanels.value, nextPanel]
+      return nextPanel
+    }
+
+    options.subagentPanels.value = options.subagentPanels.value.map((panel, panelIndex) =>
+      panelIndex === index ? nextPanel : panel
+    )
+    return nextPanel
+  }
+
+  const rememberObservedSubagentThread = (threadId: string) => {
+    options.currentLiveStream()?.observedSubagentThreadIds.add(threadId)
+  }
+
+  const updateSubagentPanelMessages = (
+    threadId: string,
+    updater: (panelMessages: ChatMessage[]) => ChatMessage[]
+  ) => {
+    upsertSubagentPanel(threadId, (panel) => {
+      const basePanel = panel ?? createSubagentPanelState(threadId)
+      return {
+        ...basePanel,
+        messages: updater(basePanel.messages),
+        lastSeenAt: Date.now()
+      }
+    })
+  }
+
+  const updateSubagentMessage = (
+    threadId: string,
+    messageId: string,
+    fallbackMessage: ChatMessage,
+    transform: (message: ChatMessage) => ChatMessage
+  ) => {
+    updateSubagentPanelMessages(threadId, (panelMessages) => {
+      const existing = panelMessages.find(message => message.id === messageId)
+      return upsertStreamingMessage(panelMessages, transform(existing ?? fallbackMessage))
+    })
+  }
+
+  const appendSubagentTextPartDelta = (
+    threadId: string,
+    messageId: string,
+    delta: string,
+    fallbackMessage: ChatMessage
+  ) => {
+    updateSubagentMessage(threadId, messageId, fallbackMessage, (message) => {
+      const partIndex = message.parts.findIndex(isTextPart)
+      const existingTextPart = partIndex === -1 ? null : message.parts[partIndex] as Extract<ChatPart, { type: 'text' }>
+      const nextText = existingTextPart ? `${existingTextPart.text}${delta}` : delta
+      const nextTextPart: Extract<ChatPart, { type: 'text' }> = {
+        type: 'text',
+        text: nextText,
+        state: 'streaming'
+      }
+      const nextParts = partIndex === -1
+        ? [...message.parts, nextTextPart]
+        : message.parts.map((part, index) => index === partIndex ? nextTextPart : part)
+
+      return {
+        ...message,
+        pending: true,
+        parts: nextParts
+      }
+    })
+  }
+
+  const updateSubagentItemPart = (
+    threadId: string,
+    messageId: string,
+    fallbackMessage: ChatMessage,
+    transform: (itemData: ItemData) => ItemData
+  ) => {
+    updateSubagentMessage(threadId, messageId, fallbackMessage, (message) => {
+      const partIndex = message.parts.findIndex(isItemPart)
+      const existingData = partIndex === -1 ? null : (message.parts[partIndex] as Extract<ChatPart, { type: typeof ITEM_PART }>).data
+      const nextData = transform(existingData ?? getFallbackItemData(fallbackMessage))
+      const nextPart: Extract<ChatPart, { type: typeof ITEM_PART }> = {
+        type: ITEM_PART,
+        data: nextData
+      }
+      const nextParts = partIndex === -1
+        ? [...message.parts, nextPart]
+        : message.parts.map((part, index) => index === partIndex ? nextPart : part)
+
+      return {
+        ...message,
+        pending: true,
+        parts: nextParts
+      }
+    })
+  }
+
+  const pushSubagentEventMessage = (threadId: string, kind: 'turn.failed' | 'stream.error', messageText: string) => {
+    updateSubagentPanelMessages(threadId, (panelMessages) =>
+      upsertStreamingMessage(
+        panelMessages,
+        eventToMessage(`subagent-event-${threadId}-${kind}-${Date.now()}`, kind === 'turn.failed'
+          ? {
+              kind,
+              error: {
+                message: messageText
+              }
+            }
+          : {
+              kind,
+              message: messageText
+            })
+      )
+    )
+  }
+
+  const seedSubagentStreamingMessage = (threadId: string, item: CodexThreadItem) => {
+    const [seed] = itemToMessages(item)
+    if (!seed) {
+      return
+    }
+
+    updateSubagentPanelMessages(threadId, (panelMessages) =>
+      upsertStreamingMessage(panelMessages, {
+        ...seed,
+        pending: true
+      })
+    )
+  }
+
+  const bootstrapSubagentPanel = async (threadId: string) => {
+    if (!threadId) {
+      return
+    }
+
+    const existingPromise = subagentBootstrapPromises.get(threadId)
+    if (existingPromise) {
+      await existingPromise
+      return
+    }
+
+    const bootstrapPromise = (async () => {
+      try {
+        await options.ensureProjectRuntime()
+        const client = options.getClient(options.projectId)
+        const response = await client.request<ThreadReadResponse>('thread/read', {
+          threadId,
+          includeTurns: true
+        })
+        const activeTurn = [...response.thread.turns].reverse().find(turn => options.isActiveTurnStatus(turn.status))
+        const pendingNotifications = getSubagentPanel(threadId)?.bufferedNotifications.slice() ?? []
+
+        upsertSubagentPanel(threadId, (panel) => {
+          const basePanel = panel ?? createSubagentPanelState(threadId)
+          return {
+            ...basePanel,
+            name: resolveSubagentName(threadId, response.thread),
+            role: response.thread.agentRole ?? basePanel.role ?? null,
+            messages: threadToMessages(response.thread),
+            turnId: activeTurn?.id ?? null,
+            bootstrapped: true,
+            bufferedNotifications: [],
+            status: panel?.status
+              ?? (activeTurn ? 'running' : basePanel.status)
+              ?? null,
+            lastSeenAt: Date.now()
+          }
+        })
+
+        for (const notification of pendingNotifications) {
+          applySubagentNotification(threadId, notification)
+        }
+      } catch {
+        upsertSubagentPanel(threadId, (panel) => ({
+          ...(panel ?? createSubagentPanelState(threadId)),
+          lastSeenAt: Date.now()
+        }))
+      } finally {
+        subagentBootstrapPromises.delete(threadId)
+      }
+    })()
+
+    subagentBootstrapPromises.set(threadId, bootstrapPromise)
+    await bootstrapPromise
+  }
+
+  const applySubagentActivityItem = (item: Extract<CodexThreadItem, { type: 'collabAgentToolCall' }>) => {
+    const orderedThreadIds = [
+      ...item.receiverThreadIds,
+      ...Object.keys(item.agentsStates).filter(threadId => !item.receiverThreadIds.includes(threadId))
+    ]
+
+    for (const threadId of orderedThreadIds) {
+      const agentState = item.agentsStates[threadId]
+      rememberObservedSubagentThread(threadId)
+      upsertSubagentPanel(threadId, (panel) => {
+        const basePanel = panel ?? createSubagentPanelState(threadId)
+        return {
+          ...basePanel,
+          status: agentState?.status ?? basePanel.status,
+          lastSeenAt: Date.now()
+        }
+      })
+    }
+
+    for (const threadId of orderedThreadIds) {
+      void bootstrapSubagentPanel(threadId)
+    }
+  }
+
+  const rebuildSubagentPanelsFromThread = (thread: CodexThread) => {
+    options.subagentPanels.value = []
+    for (const turn of thread.turns) {
+      for (const item of turn.items) {
+        if (item.type === 'collabAgentToolCall') {
+          applySubagentActivityItem(item)
+        }
+      }
+    }
+  }
+
+  const applySubagentNotification = (threadId: string, notification: CodexRpcNotification) => {
+    const panel = getSubagentPanel(threadId)
+    if (!panel) {
+      return
+    }
+
+    if (!panel.bootstrapped) {
+      upsertSubagentPanel(threadId, (existingPanel) => ({
+        ...(existingPanel ?? createSubagentPanelState(threadId)),
+        bufferedNotifications: [...(existingPanel?.bufferedNotifications ?? []), notification],
+        lastSeenAt: Date.now()
+      }))
+      return
+    }
+
+    const turnId = notificationTurnId(notification)
+    if (panel.turnId && turnId && turnId !== panel.turnId && notification.method !== 'turn/started') {
+      return
+    }
+
+    switch (notification.method) {
+      case 'turn/started': {
+        upsertSubagentPanel(threadId, (existingPanel) => ({
+          ...(existingPanel ?? createSubagentPanelState(threadId)),
+          turnId: notificationTurnId(notification),
+          status: existingPanel?.status === 'completed' ? existingPanel.status : 'running',
+          lastSeenAt: Date.now()
+        }))
+        return
+      }
+      case 'item/started': {
+        const params = notification.params as { item: CodexThreadItem }
+        if (params.item.type === 'collabAgentToolCall') {
+          applySubagentActivityItem(params.item)
+        }
+        seedSubagentStreamingMessage(threadId, params.item)
+        return
+      }
+      case 'item/completed': {
+        const params = notification.params as { item: CodexThreadItem }
+        if (params.item.type === 'collabAgentToolCall') {
+          applySubagentActivityItem(params.item)
+        }
+        for (const nextMessage of itemToMessages(params.item)) {
+          updateSubagentPanelMessages(threadId, (panelMessages) =>
+            replaceStreamingMessage(panelMessages, {
+              ...nextMessage,
+              pending: false
+            })
+          )
+        }
+        return
+      }
+      case 'item/agentMessage/delta':
+      case 'item/plan/delta': {
+        const params = notification.params as { itemId: string, delta: string }
+        appendSubagentTextPartDelta(threadId, params.itemId, params.delta, {
+          id: params.itemId,
+          role: 'assistant',
+          pending: true,
+          parts: [{
+            type: 'text',
+            text: '',
+            state: 'streaming'
+          }]
+        })
+        return
+      }
+      case 'item/reasoning/textDelta':
+      case 'item/reasoning/summaryTextDelta': {
+        const params = notification.params as { itemId: string, delta: string }
+        updateSubagentMessage(threadId, params.itemId, {
+          id: params.itemId,
+          role: 'assistant',
+          pending: true,
+          parts: [{
+            type: 'reasoning',
+            summary: [],
+            content: [],
+            state: 'streaming'
+          }]
+        }, (message) => {
+          const partIndex = message.parts.findIndex(part => part.type === 'reasoning')
+          const existingPart = partIndex === -1
+            ? {
+                type: 'reasoning' as const,
+                summary: [],
+                content: []
+              }
+            : message.parts[partIndex] as Extract<ChatPart, { type: 'reasoning' }>
+          const nextPart: Extract<ChatPart, { type: 'reasoning' }> = {
+            type: 'reasoning',
+            summary: notification.method === 'item/reasoning/summaryTextDelta'
+              ? [...existingPart.summary, params.delta]
+              : existingPart.summary,
+            content: notification.method === 'item/reasoning/textDelta'
+              ? [...existingPart.content, params.delta]
+              : existingPart.content,
+            state: 'streaming'
+          }
+          const nextParts = partIndex === -1
+            ? [...message.parts, nextPart]
+            : message.parts.map((part, index) => index === partIndex ? nextPart : part)
+
+          return {
+            ...message,
+            pending: true,
+            parts: nextParts
+          }
+        })
+        return
+      }
+      case 'item/commandExecution/outputDelta': {
+        const params = notification.params as { itemId: string, delta: string }
+        const fallbackItem = fallbackCommandItemData(params.itemId)
+        updateSubagentItemPart(threadId, params.itemId, fallbackCommandMessage(params.itemId), (itemData) => ({
+          kind: 'command_execution',
+          item: {
+            ...(itemData.kind === 'command_execution' ? itemData.item : fallbackItem.item),
+            aggregatedOutput: `${(itemData.kind === 'command_execution' ? itemData.item.aggregatedOutput : '') ?? ''}${params.delta}`,
+            status: 'inProgress'
+          }
+        }))
+        return
+      }
+      case 'item/fileChange/outputDelta': {
+        const params = notification.params as { itemId: string, delta: string }
+        const fallbackItem = fallbackFileChangeItemData(params.itemId)
+        updateSubagentItemPart(threadId, params.itemId, fallbackFileChangeMessage(params.itemId), (itemData) => {
+          const baseItem: FileChangeItem = itemData.kind === 'file_change'
+            ? itemData.item
+            : fallbackItem.item
+          return {
+            kind: 'file_change',
+            item: {
+              ...baseItem,
+              liveOutput: `${baseItem.liveOutput ?? ''}${params.delta}`,
+              status: 'inProgress'
+            }
+          }
+        })
+        return
+      }
+      case 'item/mcpToolCall/progress': {
+        const params = notification.params as { itemId: string, message: string }
+        const fallbackItem = fallbackMcpToolItemData(params.itemId)
+        updateSubagentItemPart(threadId, params.itemId, fallbackMcpToolMessage(params.itemId), (itemData) => {
+          const baseItem: McpToolCallItem = itemData.kind === 'mcp_tool_call'
+            ? itemData.item
+            : fallbackItem.item
+          return {
+            kind: 'mcp_tool_call',
+            item: {
+              ...baseItem,
+              progressMessages: [...(baseItem.progressMessages ?? []), params.message],
+              status: 'inProgress'
+            }
+          }
+        })
+        return
+      }
+      case 'turn/completed': {
+        upsertSubagentPanel(threadId, (existingPanel) => ({
+          ...(existingPanel ?? createSubagentPanelState(threadId)),
+          turnId: null,
+          status: isSubagentActiveStatus(existingPanel?.status ?? null)
+            ? 'completed'
+            : existingPanel?.status ?? null,
+          lastSeenAt: Date.now()
+        }))
+        return
+      }
+      case 'turn/failed': {
+        const params = notification.params as { error?: { message?: string } }
+        const messageText = params.error?.message ?? 'The turn failed.'
+        pushSubagentEventMessage(threadId, 'turn.failed', messageText)
+        upsertSubagentPanel(threadId, (existingPanel) => ({
+          ...(existingPanel ?? createSubagentPanelState(threadId)),
+          status: 'errored',
+          turnId: null,
+          lastSeenAt: Date.now()
+        }))
+        return
+      }
+      case 'stream/error': {
+        const params = notification.params as { message?: string }
+        const messageText = params.message ?? 'The stream failed.'
+        pushSubagentEventMessage(threadId, 'stream.error', messageText)
+        upsertSubagentPanel(threadId, (existingPanel) => ({
+          ...(existingPanel ?? createSubagentPanelState(threadId)),
+          status: 'errored',
+          turnId: null,
+          lastSeenAt: Date.now()
+        }))
+        return
+      }
+      default:
+        return
+    }
+  }
+
+  return {
+    getSubagentPanel,
+    createSubagentPanelState,
+    upsertSubagentPanel,
+    rememberObservedSubagentThread,
+    bootstrapSubagentPanel,
+    applySubagentActivityItem,
+    rebuildSubagentPanelsFromThread,
+    applySubagentNotification
+  }
+}

--- a/packages/client/app/composables/useSubagentPanelsController.ts
+++ b/packages/client/app/composables/useSubagentPanelsController.ts
@@ -1,4 +1,4 @@
-import { ref, type Ref } from 'vue'
+import type { Ref } from 'vue'
 import type { LiveStream, SubagentPanelState } from './useChatSession'
 import {
   ITEM_PART,
@@ -12,15 +12,16 @@ import {
   type ChatPart,
   type FileChangeItem,
   type ItemData,
-  type McpToolCallItem
+  type McpToolCallItem,
+  type WebSearchStatus
 } from '~~/shared/codex-chat'
 import {
   notificationTurnId,
-  type CodexRpcNotification,
-  type CodexThread,
-  type CodexThreadItem,
-  type ThreadReadResponse
+  type CodexRpcNotification
 } from '~~/shared/codex-rpc'
+import type { Thread } from '~~/shared/generated/codex-app-server/v2/Thread'
+import type { ThreadItem } from '~~/shared/generated/codex-app-server/v2/ThreadItem'
+import type { ThreadReadResponse } from '~~/shared/generated/codex-app-server/v2/ThreadReadResponse'
 
 type ThreadReadClient = {
   request<T>(method: 'thread/read', params: { threadId: string, includeTurns: true }): Promise<T>
@@ -39,7 +40,7 @@ const shortThreadId = (value: string) => value.slice(0, 8)
 
 const resolveSubagentName = (
   threadId: string,
-  thread?: Pick<CodexThread, 'agentNickname' | 'name' | 'preview'> | null
+  thread?: Pick<Thread, 'agentNickname' | 'name' | 'preview'> | null
 ) => {
   const candidate = thread?.agentNickname?.trim()
     || thread?.name?.trim()
@@ -79,9 +80,14 @@ const fallbackCommandMessage = (itemId: string): ChatMessage => ({
         type: 'commandExecution',
         id: itemId,
         command: 'Command',
+        cwd: '',
+        processId: null,
+        source: 'agent',
+        commandActions: [],
         aggregatedOutput: '',
         exitCode: null,
-        status: 'inProgress'
+        status: 'inProgress',
+        durationMs: null
       }
     }
   }]
@@ -99,9 +105,9 @@ const fallbackFileChangeMessage = (itemId: string): ChatMessage => ({
         type: 'fileChange',
         id: itemId,
         changes: [],
-        status: 'inProgress',
-        liveOutput: ''
-      }
+        status: 'inProgress'
+      },
+      liveOutput: ''
     }
   }]
 })
@@ -123,8 +129,9 @@ const fallbackMcpToolMessage = (itemId: string): ChatMessage => ({
         result: null,
         error: null,
         status: 'inProgress',
-        progressMessages: []
-      }
+        durationMs: null
+      },
+      progressMessages: []
     }
   }]
 })
@@ -278,8 +285,42 @@ export const useSubagentPanelsController = (options: UseSubagentPanelsController
     )
   }
 
-  const seedSubagentStreamingMessage = (threadId: string, item: CodexThreadItem) => {
-    const [seed] = itemToMessages(item)
+  const updateWebSearchMessageStatus = (
+    chatMessages: ChatMessage[],
+    status: WebSearchStatus
+  ) => chatMessages.map((message) => {
+    const partIndex = message.parts.findIndex(isItemPart)
+    if (partIndex === -1) {
+      return message
+    }
+
+    const itemPart = message.parts[partIndex] as Extract<ChatPart, { type: typeof ITEM_PART }>
+    if (itemPart.data.kind !== 'web_search') {
+      return message
+    }
+    if (!message.pending && itemPart.data.status !== 'inProgress') {
+      return message
+    }
+
+    const nextPart: Extract<ChatPart, { type: typeof ITEM_PART }> = {
+      ...itemPart,
+      data: {
+        ...itemPart.data,
+        status
+      }
+    }
+
+    return {
+      ...message,
+      pending: status === 'inProgress',
+      parts: message.parts.map((part, index) => index === partIndex ? nextPart : part)
+    }
+  })
+
+  const seedSubagentStreamingMessage = (threadId: string, item: ThreadItem) => {
+    const [seed] = itemToMessages(item, {
+      webSearchStatus: item.type === 'webSearch' ? 'inProgress' : undefined
+    })
     if (!seed) {
       return
     }
@@ -348,7 +389,7 @@ export const useSubagentPanelsController = (options: UseSubagentPanelsController
     await bootstrapPromise
   }
 
-  const applySubagentActivityItem = (item: Extract<CodexThreadItem, { type: 'collabAgentToolCall' }>) => {
+  const applySubagentActivityItem = (item: Extract<ThreadItem, { type: 'collabAgentToolCall' }>) => {
     const orderedThreadIds = [
       ...item.receiverThreadIds,
       ...Object.keys(item.agentsStates).filter(threadId => !item.receiverThreadIds.includes(threadId))
@@ -372,7 +413,7 @@ export const useSubagentPanelsController = (options: UseSubagentPanelsController
     }
   }
 
-  const rebuildSubagentPanelsFromThread = (thread: CodexThread) => {
+  const rebuildSubagentPanelsFromThread = (thread: Thread) => {
     options.subagentPanels.value = []
     for (const turn of thread.turns) {
       for (const item of turn.items) {
@@ -414,7 +455,7 @@ export const useSubagentPanelsController = (options: UseSubagentPanelsController
         return
       }
       case 'item/started': {
-        const params = notification.params as { item: CodexThreadItem }
+        const params = notification.params as { item: ThreadItem }
         if (params.item.type === 'collabAgentToolCall') {
           applySubagentActivityItem(params.item)
         }
@@ -422,7 +463,7 @@ export const useSubagentPanelsController = (options: UseSubagentPanelsController
         return
       }
       case 'item/completed': {
-        const params = notification.params as { item: CodexThreadItem }
+        const params = notification.params as { item: ThreadItem }
         if (params.item.type === 'collabAgentToolCall') {
           applySubagentActivityItem(params.item)
         }
@@ -515,13 +556,16 @@ export const useSubagentPanelsController = (options: UseSubagentPanelsController
           const baseItem: FileChangeItem = itemData.kind === 'file_change'
             ? itemData.item
             : fallbackItem.item
+          const liveOutput = itemData.kind === 'file_change'
+            ? itemData.liveOutput
+            : fallbackItem.liveOutput
           return {
             kind: 'file_change',
             item: {
               ...baseItem,
-              liveOutput: `${baseItem.liveOutput ?? ''}${params.delta}`,
               status: 'inProgress'
-            }
+            },
+            liveOutput: `${liveOutput ?? ''}${params.delta}`
           }
         })
         return
@@ -533,13 +577,16 @@ export const useSubagentPanelsController = (options: UseSubagentPanelsController
           const baseItem: McpToolCallItem = itemData.kind === 'mcp_tool_call'
             ? itemData.item
             : fallbackItem.item
+          const progressMessages = itemData.kind === 'mcp_tool_call'
+            ? itemData.progressMessages
+            : fallbackItem.progressMessages
           return {
             kind: 'mcp_tool_call',
             item: {
               ...baseItem,
-              progressMessages: [...(baseItem.progressMessages ?? []), params.message],
               status: 'inProgress'
-            }
+            },
+            progressMessages: [...(progressMessages ?? []), params.message]
           }
         })
         return
@@ -559,6 +606,9 @@ export const useSubagentPanelsController = (options: UseSubagentPanelsController
         const params = notification.params as { error?: { message?: string } }
         const messageText = params.error?.message ?? 'The turn failed.'
         pushSubagentEventMessage(threadId, 'turn.failed', messageText)
+        updateSubagentPanelMessages(threadId, (panelMessages) =>
+          updateWebSearchMessageStatus(panelMessages, 'failed')
+        )
         upsertSubagentPanel(threadId, (existingPanel) => ({
           ...(existingPanel ?? createSubagentPanelState(threadId)),
           status: 'errored',


### PR DESCRIPTION
## Summary
- extract the review workflow orchestration from `ChatWorkspace.vue` into `useChatReviewWorkflow`
- extract plan mode and implementation-prompt orchestration into `useChatPlanWorkflow`
- extract subagent panel lifecycle handling into `useSubagentPanelsController` and thin the main notification router
- hoist `ensureProjectRuntime` to avoid setup-order failures when the selected project is already running

## Why
`ChatWorkspace.vue` had accumulated several workflow controllers in one file, which made the notification path and workflow state harder to reason about and review. This branch separates those controller responsibilities without changing the existing drawer and panel contracts.

## Impact
The chat workspace keeps the same user-facing behaviors while moving review, plan, and subagent orchestration into dedicated composables. The final fix also prevents a runtime initialization error during mount for already-running projects.

## Root cause
The component mixed workflow state machines, panel reducers, and stream routing in a single setup block, so extracting them introduced a setup-order edge where an immediate watcher could touch `ensureProjectRuntime` before initialization.

## Validation
- `pnpm --filter @codori/client typecheck`
- `pnpm --filter @codori/client test`
