### PR TITLE
Add project cloning flow from the Projects sidebar

### DIFF
--- a/packages/client/app/components/AddProjectModal.vue
+++ b/packages/client/app/components/AddProjectModal.vue
@@ -1,0 +1,176 @@
+<script setup lang="ts">
+import type { FetchError } from 'ofetch'
+import { computed, ref, watch } from 'vue'
+import { useProjects } from '../composables/useProjects'
+import { useCodoriRouter } from '../composables/useCodoriRouter'
+import { toProjectRoute } from '../../shared/codori'
+
+const props = withDefaults(defineProps<{
+  open?: boolean
+}>(), {
+  open: false
+})
+
+const emit = defineEmits<{
+  'update:open': [open: boolean]
+}>()
+
+const router = useCodoriRouter()
+const {
+  clonePending,
+  cloneProject,
+  refreshProjects
+} = useProjects()
+
+const repositoryUrl = ref('')
+const destination = ref('')
+const error = ref<string | null>(null)
+
+const isOpen = computed({
+  get: () => props.open,
+  set: (open: boolean) => {
+    emit('update:open', open)
+  }
+})
+
+const resetState = () => {
+  repositoryUrl.value = ''
+  destination.value = ''
+  error.value = null
+}
+
+watch(() => props.open, (open, previous) => {
+  if (open && !previous) {
+    resetState()
+  }
+})
+
+const close = () => {
+  if (clonePending.value) {
+    return
+  }
+
+  isOpen.value = false
+}
+
+const toErrorMessage = (caughtError: unknown) => {
+  const fetchError = caughtError as FetchError<{
+    error?: {
+      message?: string
+    }
+  }>
+  return fetchError.data?.error?.message
+    ?? (caughtError instanceof Error ? caughtError.message : String(caughtError))
+}
+
+const submit = async () => {
+  if (clonePending.value) {
+    return
+  }
+
+  const trimmedRepositoryUrl = repositoryUrl.value.trim()
+  const trimmedDestination = destination.value.trim()
+
+  if (!trimmedRepositoryUrl) {
+    error.value = 'Git repository URL is required.'
+    return
+  }
+
+  error.value = null
+
+  try {
+    const project = await cloneProject({
+      repositoryUrl: trimmedRepositoryUrl,
+      destination: trimmedDestination || null
+    })
+
+    await refreshProjects()
+    isOpen.value = false
+    await router.push(toProjectRoute(project.projectId))
+  } catch (caughtError) {
+    error.value = toErrorMessage(caughtError)
+  }
+}
+</script>
+
+<template>
+  <UModal
+    v-model:open="isOpen"
+    title="Add project"
+    :dismissible="!clonePending"
+  >
+    <template #body>
+      <form
+        class="space-y-4"
+        @submit.prevent="submit"
+      >
+        <div class="space-y-3">
+          <UFormField
+            label="Git repository URL"
+            required
+            size="sm"
+          >
+            <UInput
+              v-model="repositoryUrl"
+              autofocus
+              placeholder="git@github.com:owner/repo.git"
+              size="sm"
+              color="neutral"
+              variant="subtle"
+              :disabled="clonePending"
+              :ui="{
+                base: 'min-h-10 rounded-lg px-3 text-sm'
+              }"
+            />
+          </UFormField>
+
+          <UFormField
+            label="Directory name"
+            description="Optional relative path under the configured Codori root."
+            size="sm"
+          >
+            <UInput
+              v-model="destination"
+              placeholder="team/repo"
+              size="sm"
+              color="neutral"
+              variant="subtle"
+              :disabled="clonePending"
+              :ui="{
+                base: 'min-h-10 rounded-lg px-3 text-sm'
+              }"
+            />
+          </UFormField>
+        </div>
+
+        <UAlert
+          v-if="error"
+          color="error"
+          variant="soft"
+          icon="i-lucide-circle-alert"
+          :title="error"
+        />
+
+        <div class="flex items-center justify-end gap-2">
+          <UButton
+            type="button"
+            color="neutral"
+            variant="ghost"
+            :disabled="clonePending"
+            @click="close"
+          >
+            Cancel
+          </UButton>
+          <UButton
+            type="submit"
+            color="primary"
+            :loading="clonePending"
+            :disabled="clonePending"
+          >
+            Clone project
+          </UButton>
+        </div>
+      </form>
+    </template>
+  </UModal>
+</template>

--- a/packages/client/app/components/AddProjectModal.vue
+++ b/packages/client/app/components/AddProjectModal.vue
@@ -101,14 +101,19 @@ const submit = async () => {
   >
     <template #body>
       <form
-        class="space-y-4"
+        class="w-full space-y-4"
         @submit.prevent="submit"
       >
-        <div class="space-y-3">
+        <div class="w-full space-y-3">
           <UFormField
             label="Git repository URL"
             required
             size="sm"
+            class="w-full"
+            :ui="{
+              root: 'w-full',
+              container: 'w-full'
+            }"
           >
             <UInput
               v-model="repositoryUrl"
@@ -117,9 +122,11 @@ const submit = async () => {
               size="sm"
               color="neutral"
               variant="subtle"
+              class="w-full"
               :disabled="clonePending"
               :ui="{
-                base: 'min-h-10 rounded-lg px-3 text-sm'
+                root: 'w-full',
+                base: 'min-h-10 w-full rounded-lg px-3 text-sm'
               }"
             />
           </UFormField>
@@ -128,16 +135,23 @@ const submit = async () => {
             label="Directory name"
             description="Optional relative path under the configured Codori root."
             size="sm"
+            class="w-full"
+            :ui="{
+              root: 'w-full',
+              container: 'w-full'
+            }"
           >
             <UInput
               v-model="destination"
-              placeholder="team/repo"
+              placeholder="reponame"
               size="sm"
               color="neutral"
               variant="subtle"
+              class="w-full"
               :disabled="clonePending"
               :ui="{
-                base: 'min-h-10 rounded-lg px-3 text-sm'
+                root: 'w-full',
+                base: 'min-h-10 w-full rounded-lg px-3 text-sm'
               }"
             />
           </UFormField>

--- a/packages/client/app/components/ProjectSidebar.vue
+++ b/packages/client/app/components/ProjectSidebar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { NavigationMenuItem } from '@nuxt/ui'
 import { useRoute } from '#imports'
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useProjects } from '../composables/useProjects'
 import { sortSidebarProjects } from '../utils/project-sidebar-order'
 import { toProjectRoute } from '~~/shared/codori'
@@ -17,6 +17,7 @@ type ProjectNavigationItem = NavigationMenuItem & {
 }
 
 const route = useRoute()
+const addProjectOpen = ref(false)
 const {
   projects,
   loaded,
@@ -68,15 +69,31 @@ const isActiveProject = (item: ProjectNavigationItem) => activeProjectId.value =
       >
         Projects
       </div>
-      <UButton
-        icon="i-lucide-refresh-cw"
-        color="neutral"
-        variant="ghost"
-        size="xs"
-        :loading="loading"
-        :square="props.collapsed"
-        @click="refreshProjects"
-      />
+      <div class="flex items-center gap-1">
+        <UTooltip text="Add project">
+          <UButton
+            icon="i-lucide-plus"
+            color="neutral"
+            variant="ghost"
+            size="xs"
+            :square="props.collapsed"
+            aria-label="Add project"
+            @click="addProjectOpen = true"
+          />
+        </UTooltip>
+        <UTooltip text="Refresh projects">
+          <UButton
+            icon="i-lucide-refresh-cw"
+            color="neutral"
+            variant="ghost"
+            size="xs"
+            :loading="loading"
+            :square="props.collapsed"
+            aria-label="Refresh projects"
+            @click="refreshProjects"
+          />
+        </UTooltip>
+      </div>
     </div>
 
     <div
@@ -143,5 +160,7 @@ const isActiveProject = (item: ProjectNavigationItem) => activeProjectId.value =
         </template>
       </UNavigationMenu>
     </div>
+
+    <AddProjectModal v-model:open="addProjectOpen" />
   </div>
 </template>

--- a/packages/client/app/composables/useCodoriRouter.ts
+++ b/packages/client/app/composables/useCodoriRouter.ts
@@ -1,0 +1,3 @@
+import { useRouter } from '#imports'
+
+export const useCodoriRouter = () => useRouter()

--- a/packages/client/app/composables/useProjects.ts
+++ b/packages/client/app/composables/useProjects.ts
@@ -3,6 +3,7 @@ import { $fetch } from 'ofetch'
 import { encodeProjectIdSegment } from '~~/shared/codori'
 import { resolveApiUrl, shouldUseServerProxy } from '~~/shared/network'
 import type {
+  CloneProjectRequest,
   ProjectRecord,
   ProjectResponse,
   ProjectsResponse,
@@ -27,6 +28,7 @@ export const useProjects = () => {
   }))
   const loaded = useState<boolean>('codori-projects-loaded', () => false)
   const loading = useState<boolean>('codori-projects-loading', () => false)
+  const clonePending = useState<boolean>('codori-projects-clone-pending', () => false)
   const serviceUpdatePending = useState<boolean>('codori-service-update-pending', () => false)
   const pendingProjectId = useState<string | null>('codori-projects-pending-id', () => null)
   const error = useState<string | null>('codori-projects-error', () => null)
@@ -98,6 +100,24 @@ export const useProjects = () => {
     }
   }
 
+  const cloneProject = async (input: CloneProjectRequest) => {
+    if (clonePending.value) {
+      throw new Error('A project clone is already in progress.')
+    }
+
+    clonePending.value = true
+    error.value = null
+    try {
+      const response = await $fetch<ProjectResponse>(toApiUrl('/projects/clone'), {
+        method: 'POST',
+        body: input
+      })
+      return applyProjectResponse(response)
+    } finally {
+      clonePending.value = false
+    }
+  }
+
   const getProject = (projectId: string | null) => {
     if (!projectId) {
       return null
@@ -131,11 +151,13 @@ export const useProjects = () => {
     serviceUpdate,
     loaded,
     loading,
+    clonePending,
     serviceUpdatePending,
     error,
     pendingProjectId,
     refreshProjects,
     triggerServiceUpdate,
+    cloneProject,
     startProject,
     stopProject,
     getProject

--- a/packages/client/server/api/codori/projects/clone.post.ts
+++ b/packages/client/server/api/codori/projects/clone.post.ts
@@ -1,0 +1,16 @@
+import { defineEventHandler, readBody } from 'h3'
+import type { CloneProjectRequest, ProjectResponse } from '~~/shared/codori'
+import { proxyServerRequest } from '../../../utils/server-proxy'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody<CloneProjectRequest>(event)
+
+  return await proxyServerRequest<ProjectResponse>(
+    event,
+    '/api/projects/clone',
+    {
+      method: 'POST',
+      body
+    }
+  )
+})

--- a/packages/client/shared/codori.ts
+++ b/packages/client/shared/codori.ts
@@ -36,6 +36,11 @@ export type ProjectResponse = {
   project: ProjectRecord | StartProjectResult
 }
 
+export type CloneProjectRequest = {
+  repositoryUrl: string
+  destination?: string | null
+}
+
 export type ServiceUpdateResponse = {
   serviceUpdate: ServiceUpdateStatus
 }

--- a/packages/client/test/add-project-modal.test.ts
+++ b/packages/client/test/add-project-modal.test.ts
@@ -199,4 +199,11 @@ describe('add project modal', () => {
     expect(mockRefreshProjects).not.toHaveBeenCalled()
     expect(mockRouterPush).not.toHaveBeenCalled()
   })
+
+  it('uses a single-directory placeholder for the optional destination field', () => {
+    const wrapper = mountModal()
+    const inputs = wrapper.findAll('input')
+
+    expect(inputs[1]?.attributes('placeholder')).toBe('reponame')
+  })
 })

--- a/packages/client/test/add-project-modal.test.ts
+++ b/packages/client/test/add-project-modal.test.ts
@@ -1,0 +1,202 @@
+/* eslint-disable vue/one-component-per-file */
+// @vitest-environment jsdom
+
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent, h, ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import AddProjectModal from '../app/components/AddProjectModal.vue'
+
+const mockRouterPush = vi.fn()
+const mockCloneProject = vi.fn()
+const mockRefreshProjects = vi.fn()
+const mockClonePending = ref(false)
+
+vi.mock('../app/composables/useCodoriRouter', () => ({
+  useCodoriRouter: () => ({
+    push: mockRouterPush
+  })
+}))
+
+vi.mock('../app/composables/useProjects', () => ({
+  useProjects: () => ({
+    clonePending: mockClonePending,
+    cloneProject: mockCloneProject,
+    refreshProjects: mockRefreshProjects
+  })
+}))
+
+const ModalStub = defineComponent({
+  name: 'ModalStub',
+  props: {
+    open: {
+      type: Boolean,
+      default: false
+    }
+  },
+  setup(props, { slots }) {
+    return () => props.open
+      ? h('div', { class: 'modal-stub' }, [
+          h('div', { class: 'modal-body' }, slots.body?.())
+        ])
+      : null
+  }
+})
+
+const FormFieldStub = defineComponent({
+  name: 'FormFieldStub',
+  props: {
+    label: {
+      type: String,
+      default: ''
+    },
+    description: {
+      type: String,
+      default: ''
+    }
+  },
+  setup(props, { slots }) {
+    return () => h('label', { class: 'form-field-stub' }, [
+      h('span', { class: 'field-label' }, props.label),
+      props.description ? h('span', { class: 'field-description' }, props.description) : null,
+      slots.default?.()
+    ])
+  }
+})
+
+const InputStub = defineComponent({
+  name: 'InputStub',
+  props: {
+    modelValue: {
+      type: String,
+      default: ''
+    },
+    placeholder: {
+      type: String,
+      default: ''
+    },
+    size: {
+      type: String,
+      default: ''
+    },
+    disabled: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () => h('input', {
+      class: 'input-stub',
+      value: props.modelValue,
+      placeholder: props.placeholder,
+      disabled: props.disabled,
+      onInput: (event: Event) => emit('update:modelValue', (event.target as HTMLInputElement).value)
+    })
+  }
+})
+
+const ButtonStub = defineComponent({
+  name: 'ButtonStub',
+  props: {
+    type: {
+      type: String,
+      default: 'button'
+    },
+    disabled: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['click'],
+  setup(props, { emit, slots }) {
+    return () => h('button', {
+      type: props.type,
+      disabled: props.disabled,
+      onClick: (event: MouseEvent) => emit('click', event)
+    }, slots.default?.())
+  }
+})
+
+const AlertStub = defineComponent({
+  name: 'AlertStub',
+  props: {
+    title: {
+      type: String,
+      default: ''
+    }
+  },
+  setup(props) {
+    return () => h('div', { class: 'alert-stub' }, props.title)
+  }
+})
+
+const mountModal = (props: Record<string, unknown> = {}) =>
+  mount(AddProjectModal, {
+    props: {
+      open: true,
+      ...props
+    },
+    global: {
+      stubs: {
+        UModal: ModalStub,
+        UFormField: FormFieldStub,
+        UInput: InputStub,
+        UButton: ButtonStub,
+        UAlert: AlertStub
+      }
+    }
+  })
+
+describe('add project modal', () => {
+  beforeEach(() => {
+    mockRouterPush.mockReset()
+    mockCloneProject.mockReset()
+    mockRefreshProjects.mockReset()
+    mockClonePending.value = false
+  })
+
+  it('submits the clone request, refreshes projects, and navigates to the new project', async () => {
+    mockCloneProject.mockResolvedValue({
+      projectId: 'team/codori'
+    })
+    mockRefreshProjects.mockResolvedValue(undefined)
+    mockRouterPush.mockResolvedValue(undefined)
+
+    const wrapper = mountModal()
+    const inputs = wrapper.findAll('input')
+
+    await inputs[0]!.setValue('  https://github.com/comfuture/codori  ')
+    await inputs[1]!.setValue(' team/codori ')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    expect(mockCloneProject).toHaveBeenCalledWith({
+      repositoryUrl: 'https://github.com/comfuture/codori',
+      destination: 'team/codori'
+    })
+    expect(mockRefreshProjects).toHaveBeenCalledTimes(1)
+    expect(mockRouterPush).toHaveBeenCalledWith('/projects/team/codori')
+    expect(wrapper.emitted('update:open')).toEqual([[false]])
+  })
+
+  it('renders inline clone errors from the server response', async () => {
+    mockCloneProject.mockRejectedValue({
+      data: {
+        error: {
+          message: 'Destination "team/codori" already exists under the configured Codori root.'
+        }
+      }
+    })
+
+    const wrapper = mountModal()
+    const inputs = wrapper.findAll('input')
+
+    await inputs[0]!.setValue('https://github.com/comfuture/codori')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Destination "team/codori" already exists under the configured Codori root.')
+    expect(mockRefreshProjects).not.toHaveBeenCalled()
+    expect(mockRouterPush).not.toHaveBeenCalled()
+  })
+})

--- a/packages/server/src/git.ts
+++ b/packages/server/src/git.ts
@@ -1,11 +1,11 @@
 import { execFile } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import { rm, stat } from 'node:fs/promises'
-import { basename, isAbsolute, relative, resolve } from 'node:path'
+import { mkdir, realpath, rm, stat } from 'node:fs/promises'
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { promisify } from 'node:util'
 import { isPathInsideDirectory } from './attachment-store.js'
 import { CodoriError } from './errors.js'
-import { IGNORED_PROJECT_DIRECTORY_NAMES, scanProjects } from './project-scanner.js'
+import { IGNORED_PROJECT_DIRECTORY_NAMES } from './project-scanner.js'
 
 export type GitBranchesResult = {
   currentBranch: string | null
@@ -285,6 +285,23 @@ const ensureRootDirectory = async (rootDirectory: string) => {
   }
 }
 
+const ensureCloneParentDirectory = async (projectPath: string, rootDirectory: string) => {
+  const parentPath = dirname(projectPath)
+  await mkdir(parentPath, { recursive: true })
+
+  const [realRootPath, realParentPath] = await Promise.all([
+    realpath(rootDirectory),
+    realpath(parentPath)
+  ])
+
+  if (!isPathInsideDirectory(realParentPath, realRootPath)) {
+    throw new CodoriError(
+      'INVALID_PROJECT_DESTINATION',
+      'Destination must stay inside the configured Codori root after resolving symlinks.'
+    )
+  }
+}
+
 const cleanupCloneDestination = async (projectPath: string) => {
   if (!existsSync(projectPath)) {
     return
@@ -325,6 +342,8 @@ export const cloneProjectIntoRoot = async (input: CloneProjectInput): Promise<Cl
     )
   }
 
+  await ensureCloneParentDirectory(projectPath, rootDirectory)
+
   let cloneUrl = cloneTarget.candidates[0]?.cloneUrl ?? cloneTarget.normalizedRepositoryUrl
   let lastCloneError: unknown = null
 
@@ -358,10 +377,7 @@ export const cloneProjectIntoRoot = async (input: CloneProjectInput): Promise<Cl
     )
   }
 
-  const discoveredProject = scanProjects(rootDirectory)
-    .find(project => project.path === projectPath)
-
-  if (!discoveredProject) {
+  if (!existsSync(join(projectPath, '.git'))) {
     await cleanupCloneDestination(projectPath)
     throw new CodoriError(
       'CLONED_PROJECT_NOT_DISCOVERED',
@@ -370,8 +386,8 @@ export const cloneProjectIntoRoot = async (input: CloneProjectInput): Promise<Cl
   }
 
   return {
-    projectId: discoveredProject.id,
-    projectPath: discoveredProject.path,
+    projectId: destination,
+    projectPath,
     repositoryUrl: cloneTarget.normalizedRepositoryUrl,
     cloneUrl
   }

--- a/packages/server/src/git.ts
+++ b/packages/server/src/git.ts
@@ -1,9 +1,32 @@
 import { execFile } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { rm, stat } from 'node:fs/promises'
+import { basename, isAbsolute, relative, resolve } from 'node:path'
 import { promisify } from 'node:util'
+import { isPathInsideDirectory } from './attachment-store.js'
+import { CodoriError } from './errors.js'
+import { IGNORED_PROJECT_DIRECTORY_NAMES, scanProjects } from './project-scanner.js'
 
 export type GitBranchesResult = {
   currentBranch: string | null
   branches: string[]
+}
+
+export type CloneProjectInput = {
+  rootDirectory: string
+  repositoryUrl: string
+  destination?: string | null
+}
+
+export type CloneProjectResult = {
+  projectId: string
+  projectPath: string
+  repositoryUrl: string
+  cloneUrl: string
+}
+
+type CloneCandidate = {
+  cloneUrl: string
 }
 
 const execFileAsync = promisify(execFile)
@@ -11,7 +34,11 @@ const execFileAsync = promisify(execFile)
 const runGit = async (projectPath: string, args: string[]) => {
   const { stdout } = await execFileAsync('git', args, {
     cwd: projectPath,
-    encoding: 'utf8'
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GIT_TERMINAL_PROMPT: process.env.GIT_TERMINAL_PROMPT ?? '0'
+    }
   })
 
   return stdout.trim()
@@ -54,5 +81,298 @@ export const listGitBranches = async (projectPath: string): Promise<GitBranchesR
   return {
     currentBranch,
     branches: [...branchSet]
+  }
+}
+
+const SCP_STYLE_REPOSITORY_PATTERN = /^(?<user>[A-Za-z0-9._-]+)@(?<host>[^:/\s]+):(?<path>.+)$/u
+const WINDOWS_DRIVE_PATTERN = /^[a-z]:[/\\]/iu
+const WINDOWS_UNC_PATTERN = /^\\\\[^\\]+\\[^\\]+/u
+
+const trimGitSuffix = (value: string) => value.replace(/\.git$/iu, '')
+
+const ensureGitSuffix = (value: string) =>
+  value.toLowerCase().endsWith('.git') ? value : `${value}.git`
+
+const isAbsoluteDestination = (value: string) =>
+  isAbsolute(value)
+  || WINDOWS_DRIVE_PATTERN.test(value)
+  || WINDOWS_UNC_PATTERN.test(value)
+
+const normalizeRepositoryPath = (value: string) => {
+  const normalized = value.replace(/^\/+|\/+$/gu, '')
+  if (!normalized) {
+    throw new CodoriError('INVALID_GIT_URL', 'Repository URL must include an owner and repository name.')
+  }
+
+  const segments = normalized
+    .split('/')
+    .map(segment => segment.trim())
+    .filter(Boolean)
+  if (segments.length < 2) {
+    throw new CodoriError('INVALID_GIT_URL', 'Repository URL must include an owner and repository name.')
+  }
+
+  return segments.join('/')
+}
+
+const deriveDefaultDestination = (repositoryPath: string) => {
+  const repositoryName = basename(trimGitSuffix(repositoryPath))
+  if (!repositoryName) {
+    throw new CodoriError('INVALID_GIT_URL', 'Repository URL must include a repository name.')
+  }
+
+  return repositoryName
+}
+
+const resolveCloneCandidates = (repositoryUrl: string): { normalizedRepositoryUrl: string, candidates: CloneCandidate[], defaultDestination: string } => {
+  const trimmed = repositoryUrl.trim()
+  if (!trimmed) {
+    throw new CodoriError('INVALID_GIT_URL', 'Repository URL is required.')
+  }
+
+  const scpMatch = trimmed.match(SCP_STYLE_REPOSITORY_PATTERN)
+  if (scpMatch?.groups) {
+    const repositoryPath = normalizeRepositoryPath(scpMatch.groups.path)
+    return {
+      normalizedRepositoryUrl: `${scpMatch.groups.user}@${scpMatch.groups.host}:${ensureGitSuffix(repositoryPath)}`,
+      candidates: [{
+        cloneUrl: `${scpMatch.groups.user}@${scpMatch.groups.host}:${ensureGitSuffix(repositoryPath)}`
+      }],
+      defaultDestination: deriveDefaultDestination(repositoryPath)
+    }
+  }
+
+  let parsed: URL
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    throw new CodoriError(
+      'INVALID_GIT_URL',
+      'Repository URL must be a valid SSH or HTTPS Git repository URL.'
+    )
+  }
+
+  if (parsed.search || parsed.hash) {
+    throw new CodoriError(
+      'INVALID_GIT_URL',
+      'Repository URL must not include query parameters or fragments.'
+    )
+  }
+
+  const repositoryPath = normalizeRepositoryPath(parsed.pathname)
+  const repositoryPathWithGit = ensureGitSuffix(repositoryPath)
+  const defaultDestination = deriveDefaultDestination(repositoryPath)
+
+  switch (parsed.protocol) {
+    case 'https:': {
+      if (parsed.username || parsed.password) {
+        throw new CodoriError(
+          'INVALID_GIT_URL',
+          'Repository URL must not embed credentials. Codori uses the server git environment instead.'
+        )
+      }
+
+      const normalizedRepositoryUrl = `https://${parsed.host}/${repositoryPathWithGit}`
+      const candidates: CloneCandidate[] = []
+
+      if (!parsed.port) {
+        candidates.push({
+          cloneUrl: `git@${parsed.hostname}:${repositoryPathWithGit}`
+        })
+      }
+
+      candidates.push({
+        cloneUrl: normalizedRepositoryUrl
+      })
+
+      return {
+        normalizedRepositoryUrl,
+        candidates,
+        defaultDestination
+      }
+    }
+    case 'ssh:': {
+      if (parsed.password) {
+        throw new CodoriError(
+          'INVALID_GIT_URL',
+          'Repository URL must not embed credentials. Codori uses the server git environment instead.'
+        )
+      }
+
+      const authority = parsed.username
+        ? `${parsed.username}@${parsed.host}`
+        : parsed.host
+      const normalizedRepositoryUrl = `ssh://${authority}/${repositoryPathWithGit}`
+      return {
+        normalizedRepositoryUrl,
+        candidates: [{
+          cloneUrl: normalizedRepositoryUrl
+        }],
+        defaultDestination
+      }
+    }
+    default:
+      throw new CodoriError(
+        'INVALID_GIT_URL',
+        'Repository URL must use HTTPS or SSH.'
+      )
+  }
+}
+
+const normalizeDestination = (value: string | null | undefined, fallback: string) => {
+  const normalizedValue = (value ?? '').trim()
+  const candidate = normalizedValue.length > 0 ? normalizedValue : fallback
+  const slashNormalized = candidate.replaceAll('\\', '/')
+
+  if (isAbsoluteDestination(slashNormalized)) {
+    throw new CodoriError(
+      'INVALID_PROJECT_DESTINATION',
+      'Destination must be a relative path inside the configured Codori root.'
+    )
+  }
+
+  const segments = slashNormalized
+    .split('/')
+    .map(segment => segment.trim())
+    .filter(Boolean)
+
+  if (segments.length === 0) {
+    throw new CodoriError(
+      'INVALID_PROJECT_DESTINATION',
+      'Destination directory name is required.'
+    )
+  }
+
+  for (const segment of segments) {
+    if (segment === '.' || segment === '..') {
+      throw new CodoriError(
+        'INVALID_PROJECT_DESTINATION',
+        'Destination must stay inside the configured Codori root.'
+      )
+    }
+
+    if (segment === '.git') {
+      throw new CodoriError(
+        'INVALID_PROJECT_DESTINATION',
+        'Destination segments cannot be named ".git".'
+      )
+    }
+
+    if (IGNORED_PROJECT_DIRECTORY_NAMES.has(segment)) {
+      throw new CodoriError(
+        'INVALID_PROJECT_DESTINATION',
+        `Destination segment "${segment}" is reserved because Codori project discovery skips it.`
+      )
+    }
+  }
+
+  return segments.join('/')
+}
+
+const ensureRootDirectory = async (rootDirectory: string) => {
+  let rootStats
+  try {
+    rootStats = await stat(rootDirectory)
+  } catch {
+    rootStats = null
+  }
+
+  if (!rootStats?.isDirectory()) {
+    throw new CodoriError(
+      'MISSING_ROOT',
+      `Project root "${rootDirectory}" does not exist or is not a directory.`
+    )
+  }
+}
+
+const cleanupCloneDestination = async (projectPath: string) => {
+  if (!existsSync(projectPath)) {
+    return
+  }
+
+  await rm(projectPath, {
+    recursive: true,
+    force: true
+  })
+}
+
+const toGitErrorMessage = (error: unknown) => {
+  const details = error as { stderr?: string, stdout?: string }
+  const stderr = details.stderr?.trim()
+  const stdout = details.stdout?.trim()
+  return stderr || stdout || (error instanceof Error ? error.message : String(error))
+}
+
+export const cloneProjectIntoRoot = async (input: CloneProjectInput): Promise<CloneProjectResult> => {
+  const rootDirectory = resolve(input.rootDirectory)
+  await ensureRootDirectory(rootDirectory)
+
+  const cloneTarget = resolveCloneCandidates(input.repositoryUrl)
+  const destination = normalizeDestination(input.destination, cloneTarget.defaultDestination)
+  const projectPath = resolve(rootDirectory, destination)
+
+  if (!isPathInsideDirectory(projectPath, rootDirectory)) {
+    throw new CodoriError(
+      'INVALID_PROJECT_DESTINATION',
+      'Destination must stay inside the configured Codori root.'
+    )
+  }
+
+  if (existsSync(projectPath)) {
+    throw new CodoriError(
+      'DESTINATION_EXISTS',
+      `Destination "${destination}" already exists under the configured Codori root.`
+    )
+  }
+
+  let cloneUrl = cloneTarget.candidates[0]?.cloneUrl ?? cloneTarget.normalizedRepositoryUrl
+  let lastCloneError: unknown = null
+
+  for (const candidate of cloneTarget.candidates) {
+    try {
+      await execFileAsync('git', ['clone', '--', candidate.cloneUrl, projectPath], {
+        cwd: rootDirectory,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          GIT_TERMINAL_PROMPT: process.env.GIT_TERMINAL_PROMPT ?? '0'
+        }
+      })
+      cloneUrl = candidate.cloneUrl
+      lastCloneError = null
+      break
+    } catch (error) {
+      lastCloneError = error
+      await cleanupCloneDestination(projectPath)
+    }
+  }
+
+  if (lastCloneError) {
+    throw new CodoriError(
+      'PROJECT_CLONE_FAILED',
+      `Failed to clone ${cloneTarget.normalizedRepositoryUrl}: ${toGitErrorMessage(lastCloneError)}`,
+      {
+        repositoryUrl: cloneTarget.normalizedRepositoryUrl,
+        attemptedCloneUrls: cloneTarget.candidates.map(candidate => candidate.cloneUrl)
+      }
+    )
+  }
+
+  const discoveredProject = scanProjects(rootDirectory)
+    .find(project => project.path === projectPath)
+
+  if (!discoveredProject) {
+    await cleanupCloneDestination(projectPath)
+    throw new CodoriError(
+      'CLONED_PROJECT_NOT_DISCOVERED',
+      `Cloned repository at "${relative(rootDirectory, projectPath) || '.'}" is not discoverable as a Git project.`
+    )
+  }
+
+  return {
+    projectId: discoveredProject.id,
+    projectPath: discoveredProject.path,
+    repositoryUrl: cloneTarget.normalizedRepositoryUrl,
+    cloneUrl
   }
 }

--- a/packages/server/src/http-server.ts
+++ b/packages/server/src/http-server.ts
@@ -37,6 +37,7 @@ type MaybePromise<T> = T | Promise<T>
 export type RuntimeManagerLike = {
   listProjectStatuses: () => MaybePromise<ProjectStatusRecord[]>
   getProjectStatus: (projectId: string) => MaybePromise<ProjectStatusRecord>
+  cloneProject?: (input: { repositoryUrl: string, destination?: string | null }) => MaybePromise<ProjectStatusRecord>
   startProject: (projectId: string) => MaybePromise<StartProjectResult>
   stopProject: (projectId: string) => MaybePromise<ProjectStatusRecord>
   noteProjectActivity?: (projectId: string) => MaybePromise<ProjectStatusRecord | void>
@@ -118,14 +119,19 @@ const toStatusCode = (error: CodoriError) => {
     case 'PROJECT_NOT_FOUND':
       return 404
     case 'INVALID_CONFIG':
+    case 'INVALID_GIT_URL':
+    case 'INVALID_PROJECT_DESTINATION':
     case 'MISSING_PROJECT_ID':
     case 'MISSING_THREAD_ID':
     case 'INVALID_ATTACHMENT':
     case 'MISSING_ROOT':
       return 400
+    case 'DESTINATION_EXISTS':
     case 'SERVICE_UPDATE_UNAVAILABLE':
     case 'SERVICE_UPDATE_IN_PROGRESS':
       return 409
+    case 'PROJECT_CLONE_FAILED':
+      return 502
     default:
       return 500
   }
@@ -302,6 +308,31 @@ export const createHttpServer = async (
   app.get('/api/projects', async (): Promise<ProjectsResponse> => ({
     projects: await resolveValue(manager.listProjectStatuses())
   }))
+
+  app.post<{ Body: { repositoryUrl?: string, destination?: string | null } }>(
+    '/api/projects/clone',
+    async (request, reply): Promise<ProjectResponse> => {
+      if (!manager.cloneProject) {
+        throw new CodoriError(
+          'INVALID_CONFIG',
+          'Project cloning is not available because the runtime manager does not support it.'
+        )
+      }
+
+      const repositoryUrl = request.body?.repositoryUrl?.trim() ?? ''
+      const destination = typeof request.body?.destination === 'string'
+        ? request.body.destination
+        : null
+
+      reply.status(201)
+      return {
+        project: await resolveValue(manager.cloneProject({
+          repositoryUrl,
+          destination
+        }))
+      }
+    }
+  )
 
   app.get('/api/service/update', async (): Promise<ServiceUpdateResponse> => ({
     serviceUpdate: serviceUpdateController

--- a/packages/server/src/process-manager.ts
+++ b/packages/server/src/process-manager.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcess } from 'node:child_process'
 import os from 'node:os'
 import { resolveConfig } from './config.js'
 import { CodoriError } from './errors.js'
+import { cloneProjectIntoRoot } from './git.js'
 import { findAvailablePort } from './ports.js'
 import { scanProjects } from './project-scanner.js'
 import { RuntimeStore } from './runtime-store.js'
@@ -249,6 +250,16 @@ export class RuntimeManager {
 
   getProjectStatus(projectId: string) {
     return this.readRunningRuntime(this.resolveProject(projectId))
+  }
+
+  async cloneProject(input: { repositoryUrl: string, destination?: string | null }) {
+    const clonedProject = await cloneProjectIntoRoot({
+      rootDirectory: this.config.root,
+      repositoryUrl: input.repositoryUrl,
+      destination: input.destination
+    })
+
+    return this.getProjectStatus(clonedProject.projectId)
   }
 
   async startProject(projectId: string): Promise<StartProjectResult> {

--- a/packages/server/src/project-scanner.ts
+++ b/packages/server/src/project-scanner.ts
@@ -2,7 +2,7 @@ import { readdirSync } from 'node:fs'
 import { join, relative, resolve, sep } from 'node:path'
 import type { ProjectRecord } from './types.js'
 
-const IGNORED_DIRECTORY_NAMES = new Set([
+export const IGNORED_PROJECT_DIRECTORY_NAMES = new Set([
   '.git',
   '.nuxt',
   '.output',
@@ -38,7 +38,7 @@ export const scanProjects = (rootDirectory: string): ProjectRecord[] => {
       if (!entry.isDirectory()) {
         continue
       }
-      if (IGNORED_DIRECTORY_NAMES.has(entry.name)) {
+      if (IGNORED_PROJECT_DIRECTORY_NAMES.has(entry.name)) {
         continue
       }
       queue.push(join(current, entry.name))
@@ -47,4 +47,3 @@ export const scanProjects = (rootDirectory: string): ProjectRecord[] => {
 
   return projects.sort((left, right) => left.id.localeCompare(right.id))
 }
-

--- a/packages/server/test/git.test.ts
+++ b/packages/server/test/git.test.ts
@@ -1,0 +1,114 @@
+import { mkdirSync, mkdtempSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import os from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock
+}))
+
+import { cloneProjectIntoRoot } from '../src/git.js'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  execFileMock.mockReset()
+
+  for (const directory of tempDirs.splice(0, tempDirs.length)) {
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+const createRoot = () => {
+  const root = mkdtempSync(join(os.tmpdir(), 'codori-clone-root-'))
+  tempDirs.push(root)
+  return root
+}
+
+describe('cloneProjectIntoRoot', () => {
+  it('falls back from SSH to HTTPS for pasted HTTPS repository URLs and returns the discovered project', async () => {
+    const root = createRoot()
+    let cloneAttempt = 0
+
+    execFileMock.mockImplementation((
+      _command: string,
+      args: string[],
+      _options: unknown,
+      callback: (error: Error | null, stdout: string, stderr: string) => void
+    ) => {
+      if (args[0] !== 'clone') {
+        callback(new Error(`Unexpected git args: ${args.join(' ')}`), '', '')
+        return
+      }
+
+      cloneAttempt += 1
+
+      if (cloneAttempt === 1) {
+        const error = new Error('Permission denied (publickey).') as Error & { stderr?: string }
+        error.stderr = 'Permission denied (publickey).'
+        callback(error, '', error.stderr)
+        return
+      }
+
+      const destination = args[3]
+      mkdirSync(join(destination!, '.git'), { recursive: true })
+      callback(null, '', '')
+    })
+
+    const result = await cloneProjectIntoRoot({
+      rootDirectory: root,
+      repositoryUrl: 'https://github.com/comfuture/codori',
+      destination: 'team/codori'
+    })
+
+    expect(cloneAttempt).toBe(2)
+    expect(result).toEqual({
+      projectId: 'team/codori',
+      projectPath: join(root, 'team', 'codori'),
+      repositoryUrl: 'https://github.com/comfuture/codori.git',
+      cloneUrl: 'https://github.com/comfuture/codori.git'
+    })
+  })
+
+  it('rejects destinations that Codori project discovery intentionally skips', async () => {
+    const root = createRoot()
+
+    await expect(cloneProjectIntoRoot({
+      rootDirectory: root,
+      repositoryUrl: 'git@github.com:comfuture/codori.git',
+      destination: 'node_modules/codori'
+    })).rejects.toMatchObject({
+      code: 'INVALID_PROJECT_DESTINATION',
+      message: 'Destination segment "node_modules" is reserved because Codori project discovery skips it.'
+    })
+  })
+
+  it('surfaces clone stderr when all clone attempts fail', async () => {
+    const root = createRoot()
+
+    execFileMock.mockImplementation((
+      _command: string,
+      _args: string[],
+      _options: unknown,
+      callback: (error: Error | null, stdout: string, stderr: string) => void
+    ) => {
+      const error = new Error('Authentication failed.') as Error & { stderr?: string }
+      error.stderr = 'Authentication failed.'
+      callback(error, '', error.stderr)
+    })
+
+    await expect(cloneProjectIntoRoot({
+      rootDirectory: root,
+      repositoryUrl: 'https://github.com/comfuture/private-repo',
+      destination: 'private-repo'
+    })).rejects.toMatchObject({
+      code: 'PROJECT_CLONE_FAILED',
+      message: 'Failed to clone https://github.com/comfuture/private-repo.git: Authentication failed.'
+    })
+  })
+})

--- a/packages/server/test/git.test.ts
+++ b/packages/server/test/git.test.ts
@@ -1,7 +1,7 @@
-import { mkdirSync, mkdtempSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, symlinkSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
 import os from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const { execFileMock } = vi.hoisted(() => ({
@@ -56,6 +56,10 @@ describe('cloneProjectIntoRoot', () => {
       }
 
       const destination = args[3]
+      if (!existsSync(dirname(destination!))) {
+        callback(new Error('Missing parent directory.'), '', 'Missing parent directory.')
+        return
+      }
       mkdirSync(join(destination!, '.git'), { recursive: true })
       callback(null, '', '')
     })
@@ -110,5 +114,23 @@ describe('cloneProjectIntoRoot', () => {
       code: 'PROJECT_CLONE_FAILED',
       message: 'Failed to clone https://github.com/comfuture/private-repo.git: Authentication failed.'
     })
+  })
+
+  it('rejects clone destinations that escape the configured root through symlinked parents', async () => {
+    const root = createRoot()
+    const external = mkdtempSync(join(os.tmpdir(), 'codori-clone-external-'))
+    tempDirs.push(external)
+    symlinkSync(external, join(root, 'team'))
+
+    await expect(cloneProjectIntoRoot({
+      rootDirectory: root,
+      repositoryUrl: 'git@github.com:comfuture/codori.git',
+      destination: 'team/codori'
+    })).rejects.toMatchObject({
+      code: 'INVALID_PROJECT_DESTINATION',
+      message: 'Destination must stay inside the configured Codori root after resolving symlinks.'
+    })
+
+    expect(execFileMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/server/test/http-server.test.ts
+++ b/packages/server/test/http-server.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import WebSocket, { WebSocketServer } from 'ws'
 import { resolveProjectAttachmentsDir } from '../src/attachment-store.js'
+import { CodoriError } from '../src/errors.js'
 import { createHttpServer, type RuntimeManagerLike } from '../src/http-server.js'
 import type { ServiceUpdateController } from '../src/service-update.js'
 import type { ProjectStatusRecord, StartProjectResult } from '../src/types.js'
@@ -72,6 +73,7 @@ const createProjectRecord = (): ProjectStatusRecord => ({
 const createManager = (overrides: Partial<RuntimeManagerLike> = {}): RuntimeManagerLike => ({
   listProjectStatuses: () => [createProjectRecord()],
   getProjectStatus: () => createProjectRecord(),
+  cloneProject: () => createProjectRecord(),
   startProject: () => ({
     ...createProjectRecord(),
     reusedExisting: true
@@ -145,6 +147,66 @@ describe('createHttpServer', () => {
       project: {
         ...createProjectRecord(),
         reusedExisting: true
+      }
+    })
+  })
+
+  it('clones a project through the management API', async () => {
+    const app = await createHttpServer(createManager({
+      cloneProject: ({ repositoryUrl, destination }) => ({
+        ...createProjectRecord(),
+        projectId: destination ?? 'demo',
+        projectPath: `/tmp/${destination ?? 'demo'}`,
+        error: repositoryUrl ? null : 'missing'
+      })
+    }))
+    startedApps.push(app)
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/projects/clone',
+      payload: {
+        repositoryUrl: 'https://github.com/comfuture/codori',
+        destination: 'team/codori'
+      }
+    })
+
+    expect(response.statusCode).toBe(201)
+    expect(response.json()).toEqual({
+      project: {
+        ...createProjectRecord(),
+        projectId: 'team/codori',
+        projectPath: '/tmp/team/codori'
+      }
+    })
+  })
+
+  it('maps clone validation errors to structured API responses', async () => {
+    const app = await createHttpServer(createManager({
+      cloneProject: () => {
+        throw new CodoriError(
+          'DESTINATION_EXISTS',
+          'Destination "team/codori" already exists under the configured Codori root.'
+        )
+      }
+    }))
+    startedApps.push(app)
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/projects/clone',
+      payload: {
+        repositoryUrl: 'https://github.com/comfuture/codori',
+        destination: 'team/codori'
+      }
+    })
+
+    expect(response.statusCode).toBe(409)
+    expect(response.json()).toEqual({
+      error: {
+        code: 'DESTINATION_EXISTS',
+        message: 'Destination "team/codori" already exists under the configured Codori root.',
+        details: null
       }
     })
   })


### PR DESCRIPTION
Closes #49

## Summary
- add a server-side project clone API that validates repository URLs and destination names, clones only inside the configured Codori root, and reuses the server git credential environment
- add a sidebar add-project action with a dedicated clone modal, inline validation/errors, automatic project refresh, and navigation to the discovered project
- tighten the modal follow-up UX so both inputs use the full modal width and the directory placeholder matches the intended `reponame` shape

## Validation
- pnpm --filter @codori/server test
- pnpm --filter @codori/server typecheck
- pnpm --filter @codori/client test
- pnpm --filter @codori/client typecheck
- pnpm test
- pnpm typecheck
