### PR TITLE
feat: add global command palette

### DIFF
--- a/packages/client/app/components/GlobalCommandPalette.vue
+++ b/packages/client/app/components/GlobalCommandPalette.vue
@@ -49,7 +49,6 @@ const {
   loaded: projectsLoaded,
   loading: projectsLoading,
   refreshProjects,
-  startProject
 } = useProjects()
 
 const isMac = computed(() => isMacLikePlatform(platform.value))
@@ -266,7 +265,6 @@ const searchProjectThreads = async (
   query: string
 ) => {
   try {
-    await startProject(project.projectId)
     const client = getClient(project.projectId)
     const response = await client.request<ThreadListResponse>('thread/list', {
       limit: THREAD_SEARCH_LIMIT_PER_PROJECT,
@@ -317,8 +315,9 @@ const searchThreads = async (query: string) => {
       return
     }
 
+    const runningProjects = projects.value.filter(project => project.status === 'running')
     const results = await runLimited(
-      projects.value,
+      runningProjects,
       THREAD_SEARCH_CONCURRENCY,
       project => searchProjectThreads(project, query)
     )

--- a/packages/client/app/components/GlobalCommandPalette.vue
+++ b/packages/client/app/components/GlobalCommandPalette.vue
@@ -287,6 +287,21 @@ const searchProjectThreads = async (
   }
 }
 
+const waitForProjectsRefresh = async () => {
+  if (projectsLoaded.value || !projectsLoading.value) {
+    return
+  }
+
+  await new Promise<void>((resolve) => {
+    const stop = watch([projectsLoaded, projectsLoading], ([loaded, loading]) => {
+      if (loaded || !loading) {
+        stop()
+        resolve()
+      }
+    })
+  })
+}
+
 const searchThreads = async (query: string) => {
   const sequence = ++threadSearchSequence
   threadSearchLoading.value = true
@@ -295,6 +310,11 @@ const searchThreads = async (query: string) => {
   try {
     if (!projectsLoaded.value) {
       await refreshProjects()
+      await waitForProjectsRefresh()
+    }
+
+    if (sequence !== threadSearchSequence) {
+      return
     }
 
     const results = await runLimited(

--- a/packages/client/app/components/GlobalCommandPalette.vue
+++ b/packages/client/app/components/GlobalCommandPalette.vue
@@ -1,0 +1,208 @@
+<script setup lang="ts">
+import type { CommandPaletteGroup } from '@nuxt/ui'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useChats } from '../composables/useChats'
+import { useCodoriRouter } from '../composables/useCodoriRouter'
+import { useProjects } from '../composables/useProjects'
+import {
+  isEditableShortcutTarget,
+  isGlobalCommandPaletteShortcut,
+  isMacLikePlatform
+} from '../utils/global-command-palette-shortcut'
+import { sortSidebarProjects } from '../utils/project-sidebar-order'
+import { toChatRoute, toChatsRoute, toProjectRoute } from '~~/shared/codori'
+
+const open = ref(false)
+const searchTerm = ref('')
+const platform = ref('')
+const router = useCodoriRouter()
+const {
+  chats,
+  loaded: chatsLoaded,
+  loading: chatsLoading,
+  refreshChats
+} = useChats()
+const {
+  projects,
+  loaded: projectsLoaded,
+  loading: projectsLoading,
+  refreshProjects
+} = useProjects()
+
+const isMac = computed(() => isMacLikePlatform(platform.value))
+const commandKbds = computed(() => [isMac.value ? 'meta' : 'ctrl', 'K'])
+
+const ensurePaletteData = () => {
+  if (!chatsLoaded.value) {
+    void refreshChats()
+  }
+  if (!projectsLoaded.value) {
+    void refreshProjects()
+  }
+}
+
+const openPalette = () => {
+  open.value = true
+  ensurePaletteData()
+}
+
+const closePalette = () => {
+  open.value = false
+}
+
+const selectNewChat = async () => {
+  closePalette()
+  await router.push(toChatsRoute())
+}
+
+const selectChat = async (chatId: string) => {
+  closePalette()
+  await router.push(toChatRoute(chatId))
+}
+
+const selectProject = async (projectId: string) => {
+  closePalette()
+  await router.push(toProjectRoute(projectId))
+}
+
+const formatChatTitle = (chat: { chatId: string, title: string | null }) =>
+  chat.title?.trim() || chat.chatId || 'New Chat'
+
+const formatChatDate = (chat: { createdAt: number | null }) => {
+  if (!chat.createdAt) {
+    return 'Date unavailable'
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  }).format(new Date(chat.createdAt))
+}
+
+const chatItems = computed(() => {
+  if (chatsLoading.value && !chatsLoaded.value) {
+    return [{
+      label: 'Loading recent chats...',
+      icon: 'i-lucide-loader-circle',
+      disabled: true
+    }]
+  }
+
+  return chats.value.map(chat => ({
+    label: formatChatTitle(chat),
+    suffix: formatChatDate(chat),
+    icon: 'i-lucide-message-square',
+    onSelect: () => selectChat(chat.chatId)
+  }))
+})
+
+const projectItems = computed(() => {
+  if (projectsLoading.value && !projectsLoaded.value) {
+    return [{
+      label: 'Loading projects...',
+      icon: 'i-lucide-loader-circle',
+      disabled: true
+    }]
+  }
+
+  if (!projects.value.length && projectsLoaded.value) {
+    return [{
+      label: 'No projects found',
+      icon: 'i-lucide-folder-x',
+      disabled: true
+    }]
+  }
+
+  return sortSidebarProjects(projects.value, null).map(project => ({
+    label: project.projectId,
+    suffix: project.projectPath,
+    icon: 'i-lucide-folder-git-2',
+    onSelect: () => selectProject(project.projectId)
+  }))
+})
+
+const groups = computed<CommandPaletteGroup[]>(() => [
+  {
+    id: 'actions',
+    label: 'Actions',
+    items: [{
+      label: 'New Chat',
+      icon: 'i-lucide-message-square-plus',
+      kbds: commandKbds.value,
+      onSelect: selectNewChat
+    }]
+  },
+  {
+    id: 'chats',
+    label: 'Recent Chats',
+    items: chatItems.value
+  },
+  {
+    id: 'projects',
+    label: 'Recent Projects',
+    items: projectItems.value
+  }
+])
+
+const onKeydown = (event: KeyboardEvent) => {
+  if (
+    isEditableShortcutTarget(event.target)
+    || !isGlobalCommandPaletteShortcut(event, platform.value)
+  ) {
+    return
+  }
+
+  event.preventDefault()
+  openPalette()
+}
+
+watch(open, (nextOpen) => {
+  if (!nextOpen) {
+    searchTerm.value = ''
+  }
+})
+
+onMounted(() => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  platform.value = navigator.platform
+  window.addEventListener('keydown', onKeydown)
+})
+
+onBeforeUnmount(() => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  window.removeEventListener('keydown', onKeydown)
+})
+</script>
+
+<template>
+  <UModal
+    v-model:open="open"
+    :ui="{ content: 'p-0 sm:max-w-2xl' }"
+  >
+    <template #content>
+      <UCommandPalette
+        v-model:search-term="searchTerm"
+        :groups="groups"
+        :loading="projectsLoading || chatsLoading"
+        placeholder="Search Codori"
+        close
+        class="max-h-[min(72vh,42rem)]"
+        :ui="{
+          root: 'min-h-0',
+          content: 'max-h-[min(60vh,34rem)] overflow-y-auto p-2',
+          item: 'rounded-lg',
+          input: 'border-0 bg-transparent'
+        }"
+        @update:open="open = $event"
+      />
+    </template>
+  </UModal>
+</template>

--- a/packages/client/app/components/GlobalCommandPalette.vue
+++ b/packages/client/app/components/GlobalCommandPalette.vue
@@ -30,7 +30,7 @@ const THREAD_SEARCH_CONCURRENCY = 4
 const THREAD_SEARCH_LIMIT_PER_PROJECT = 3
 const THREAD_SEARCH_TOTAL_LIMIT = 10
 
-const open = ref(false)
+const open = defineModel<boolean>('open', { default: false })
 const searchTerm = ref('')
 const platform = ref('')
 const threadSearchResults = ref<ThreadSearchResult[]>([])

--- a/packages/client/app/components/GlobalCommandPalette.vue
+++ b/packages/client/app/components/GlobalCommandPalette.vue
@@ -4,18 +4,40 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useChats } from '../composables/useChats'
 import { useCodoriRouter } from '../composables/useCodoriRouter'
 import { useProjects } from '../composables/useProjects'
+import { useRpc } from '../composables/useRpc'
+import { resolveThreadSummaryTitle } from '../composables/useThreadSummaries'
 import {
   isEditableShortcutTarget,
   isGlobalCommandPaletteShortcut,
   isMacLikePlatform
 } from '../utils/global-command-palette-shortcut'
 import { sortSidebarProjects } from '../utils/project-sidebar-order'
-import { toChatRoute, toChatsRoute, toProjectRoute } from '~~/shared/codori'
+import { toChatRoute, toChatsRoute, toProjectRoute, toProjectThreadRoute } from '~~/shared/codori'
+import type { ThreadListParams } from '~~/shared/generated/codex-app-server/v2/ThreadListParams'
+import type { ThreadListResponse } from '~~/shared/generated/codex-app-server/v2/ThreadListResponse'
+
+type ThreadSearchResult = {
+  threadId: string
+  title: string
+  updatedAt: number
+  projectId: string
+  projectPath: string
+}
+
+const THREAD_SEARCH_MIN_LENGTH = 2
+const THREAD_SEARCH_DEBOUNCE_MS = 250
+const THREAD_SEARCH_CONCURRENCY = 4
+const THREAD_SEARCH_LIMIT_PER_PROJECT = 3
+const THREAD_SEARCH_TOTAL_LIMIT = 10
 
 const open = ref(false)
 const searchTerm = ref('')
 const platform = ref('')
+const threadSearchResults = ref<ThreadSearchResult[]>([])
+const threadSearchLoading = ref(false)
+const threadSearchError = ref<string | null>(null)
 const router = useCodoriRouter()
+const { getClient } = useRpc()
 const {
   chats,
   loaded: chatsLoaded,
@@ -26,11 +48,14 @@ const {
   projects,
   loaded: projectsLoaded,
   loading: projectsLoading,
-  refreshProjects
+  refreshProjects,
+  startProject
 } = useProjects()
 
 const isMac = computed(() => isMacLikePlatform(platform.value))
 const commandKbds = computed(() => [isMac.value ? 'meta' : 'ctrl', 'K'])
+let threadSearchTimer: ReturnType<typeof setTimeout> | null = null
+let threadSearchSequence = 0
 
 const ensurePaletteData = () => {
   if (!chatsLoaded.value) {
@@ -65,20 +90,26 @@ const selectProject = async (projectId: string) => {
   await router.push(toProjectRoute(projectId))
 }
 
+const selectThread = async (thread: ThreadSearchResult) => {
+  closePalette()
+  await router.push(toProjectThreadRoute(thread.projectId, thread.threadId))
+}
+
 const formatChatTitle = (chat: { chatId: string, title: string | null }) =>
   chat.title?.trim() || chat.chatId || 'New Chat'
 
-const formatChatDate = (chat: { createdAt: number | null }) => {
-  if (!chat.createdAt) {
+const formatTimestamp = (timestamp: number | null) => {
+  if (!timestamp) {
     return 'Date unavailable'
   }
 
+  const milliseconds = timestamp < 10_000_000_000 ? timestamp * 1000 : timestamp
   return new Intl.DateTimeFormat(undefined, {
     month: 'short',
     day: 'numeric',
     hour: '2-digit',
     minute: '2-digit'
-  }).format(new Date(chat.createdAt))
+  }).format(new Date(milliseconds))
 }
 
 const chatItems = computed(() => {
@@ -92,7 +123,7 @@ const chatItems = computed(() => {
 
   return chats.value.map(chat => ({
     label: formatChatTitle(chat),
-    suffix: formatChatDate(chat),
+    suffix: formatTimestamp(chat.createdAt),
     icon: 'i-lucide-message-square',
     onSelect: () => selectChat(chat.chatId)
   }))
@@ -123,7 +154,61 @@ const projectItems = computed(() => {
   }))
 })
 
+const threadItems = computed(() =>
+  threadSearchResults.value.map(thread => ({
+    label: thread.title,
+    suffix: `${thread.projectId} • ${formatTimestamp(thread.updatedAt)}`,
+    icon: 'i-lucide-message-square-text',
+    onSelect: () => selectThread(thread)
+  }))
+)
+
+const threadSearchGroup = computed<CommandPaletteGroup | null>(() => {
+  const normalizedSearch = searchTerm.value.trim()
+  if (normalizedSearch.length < THREAD_SEARCH_MIN_LENGTH) {
+    return null
+  }
+
+  if (threadSearchLoading.value && !threadSearchResults.value.length) {
+    return {
+      id: 'threads',
+      label: 'Matching Threads',
+      ignoreFilter: true,
+      items: [{
+        label: 'Searching threads...',
+        icon: 'i-lucide-loader-circle',
+        disabled: true
+      }]
+    }
+  }
+
+  if (threadSearchError.value && !threadSearchResults.value.length) {
+    return {
+      id: 'threads',
+      label: 'Matching Threads',
+      ignoreFilter: true,
+      items: [{
+        label: threadSearchError.value,
+        icon: 'i-lucide-circle-alert',
+        disabled: true
+      }]
+    }
+  }
+
+  if (!threadItems.value.length) {
+    return null
+  }
+
+  return {
+    id: 'threads',
+    label: 'Matching Threads',
+    ignoreFilter: true,
+    items: threadItems.value
+  }
+})
+
 const groups = computed<CommandPaletteGroup[]>(() => [
+  ...(threadSearchGroup.value ? [threadSearchGroup.value] : []),
   {
     id: 'actions',
     label: 'Actions',
@@ -146,6 +231,117 @@ const groups = computed<CommandPaletteGroup[]>(() => [
   }
 ])
 
+const clearThreadSearchTimer = () => {
+  if (threadSearchTimer) {
+    clearTimeout(threadSearchTimer)
+    threadSearchTimer = null
+  }
+}
+
+const runLimited = async <T, R>(
+  items: T[],
+  limit: number,
+  worker: (item: T) => Promise<R>
+) => {
+  const results: R[] = []
+  let nextIndex = 0
+
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex
+      nextIndex += 1
+      const item = items[currentIndex]
+      if (item) {
+        results[currentIndex] = await worker(item)
+      }
+    }
+  })
+
+  await Promise.all(workers)
+  return results
+}
+
+const searchProjectThreads = async (
+  project: { projectId: string, projectPath: string },
+  query: string
+) => {
+  try {
+    await startProject(project.projectId)
+    const client = getClient(project.projectId)
+    const response = await client.request<ThreadListResponse>('thread/list', {
+      limit: THREAD_SEARCH_LIMIT_PER_PROJECT,
+      sortKey: 'updated_at',
+      cwd: project.projectPath,
+      searchTerm: query
+    } satisfies ThreadListParams)
+
+    return response.data.map(thread => ({
+      threadId: thread.id,
+      title: resolveThreadSummaryTitle(thread),
+      updatedAt: thread.updatedAt,
+      projectId: project.projectId,
+      projectPath: project.projectPath
+    }))
+  } catch {
+    return []
+  }
+}
+
+const searchThreads = async (query: string) => {
+  const sequence = ++threadSearchSequence
+  threadSearchLoading.value = true
+  threadSearchError.value = null
+
+  try {
+    if (!projectsLoaded.value) {
+      await refreshProjects()
+    }
+
+    const results = await runLimited(
+      projects.value,
+      THREAD_SEARCH_CONCURRENCY,
+      project => searchProjectThreads(project, query)
+    )
+
+    if (sequence !== threadSearchSequence) {
+      return
+    }
+
+    threadSearchResults.value = results
+      .flat()
+      .sort((left, right) => right.updatedAt - left.updatedAt)
+      .slice(0, THREAD_SEARCH_TOTAL_LIMIT)
+  } catch (caughtError) {
+    if (sequence !== threadSearchSequence) {
+      return
+    }
+
+    threadSearchResults.value = []
+    threadSearchError.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
+  } finally {
+    if (sequence === threadSearchSequence) {
+      threadSearchLoading.value = false
+    }
+  }
+}
+
+const scheduleThreadSearch = () => {
+  clearThreadSearchTimer()
+
+  const query = searchTerm.value.trim()
+  if (!open.value || query.length < THREAD_SEARCH_MIN_LENGTH) {
+    threadSearchSequence += 1
+    threadSearchResults.value = []
+    threadSearchError.value = null
+    threadSearchLoading.value = false
+    return
+  }
+
+  threadSearchTimer = setTimeout(() => {
+    void searchThreads(query)
+  }, THREAD_SEARCH_DEBOUNCE_MS)
+}
+
 const onKeydown = (event: KeyboardEvent) => {
   if (
     isEditableShortcutTarget(event.target)
@@ -161,7 +357,15 @@ const onKeydown = (event: KeyboardEvent) => {
 watch(open, (nextOpen) => {
   if (!nextOpen) {
     searchTerm.value = ''
+    scheduleThreadSearch()
+    return
   }
+
+  scheduleThreadSearch()
+})
+
+watch(searchTerm, () => {
+  scheduleThreadSearch()
 })
 
 onMounted(() => {
@@ -174,6 +378,8 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  clearThreadSearchTimer()
+
   if (typeof window === 'undefined') {
     return
   }
@@ -191,7 +397,7 @@ onBeforeUnmount(() => {
       <UCommandPalette
         v-model:search-term="searchTerm"
         :groups="groups"
-        :loading="projectsLoading || chatsLoading"
+        :loading="projectsLoading || chatsLoading || threadSearchLoading"
         placeholder="Search Codori"
         close
         class="max-h-[min(72vh,42rem)]"

--- a/packages/client/app/components/ProjectSidebar.vue
+++ b/packages/client/app/components/ProjectSidebar.vue
@@ -5,6 +5,7 @@ import { useChats } from '../composables/useChats'
 import { useCodoriRoute } from '../composables/useCodoriRoute'
 import { useCodoriRouter } from '../composables/useCodoriRouter'
 import { useProjects } from '../composables/useProjects'
+import { isMacLikePlatform } from '../utils/global-command-palette-shortcut'
 import { sortSidebarProjects } from '../utils/project-sidebar-order'
 import { toChatRoute, toChatsRoute, toProjectRoute } from '~~/shared/codori'
 
@@ -31,6 +32,8 @@ type ChatNavigationItem = NavigationMenuItem & {
 const route = useCodoriRoute()
 const router = useCodoriRouter()
 const addProjectOpen = ref(false)
+const platform = ref(typeof navigator === 'undefined' ? '' : navigator.platform)
+const isMac = computed(() => isMacLikePlatform(platform.value))
 const {
   projects,
   loaded,
@@ -60,6 +63,9 @@ const activeChatId = computed(() => {
 })
 
 onMounted(() => {
+  if (typeof navigator !== 'undefined') {
+    platform.value = navigator.platform
+  }
   if (!loaded.value) {
     void refreshProjects()
   }
@@ -252,7 +258,7 @@ const isActiveProject = (item: ProjectNavigationItem) => activeProjectId.value =
             <template #trailing>
               <span class="flex items-center gap-1">
                 <UKbd
-                  value="meta"
+                  :value="isMac ? 'meta' : 'ctrl'"
                   size="sm"
                 />
                 <UKbd

--- a/packages/client/app/components/ProjectSidebar.vue
+++ b/packages/client/app/components/ProjectSidebar.vue
@@ -1,14 +1,18 @@
 <script setup lang="ts">
 import type { NavigationMenuItem } from '@nuxt/ui'
-import { useRoute, useRouter } from '#imports'
 import { computed, onMounted, ref } from 'vue'
 import { useChats } from '../composables/useChats'
+import { useCodoriRoute } from '../composables/useCodoriRoute'
+import { useCodoriRouter } from '../composables/useCodoriRouter'
 import { useProjects } from '../composables/useProjects'
 import { sortSidebarProjects } from '../utils/project-sidebar-order'
 import { toChatRoute, toChatsRoute, toProjectRoute } from '~~/shared/codori'
 
 const props = defineProps<{
   collapsed?: boolean
+}>()
+const emit = defineEmits<{
+  openCommandPalette: []
 }>()
 type ProjectNavigationItem = NavigationMenuItem & {
   projectId: string
@@ -24,8 +28,8 @@ type ChatNavigationItem = NavigationMenuItem & {
   updatedAt: number | null
 }
 
-const route = useRoute()
-const router = useRouter()
+const route = useCodoriRoute()
+const router = useCodoriRouter()
 const addProjectOpen = ref(false)
 const {
   projects,
@@ -221,6 +225,44 @@ const isActiveProject = (item: ProjectNavigationItem) => activeProjectId.value =
         Projects
       </div>
       <div class="flex items-center gap-1">
+        <UTooltip text="Search Codori">
+          <UButton
+            v-if="props.collapsed"
+            icon="i-lucide-search"
+            color="neutral"
+            variant="ghost"
+            size="xs"
+            square
+            aria-label="Search Codori"
+            @click="emit('openCommandPalette')"
+          />
+          <UButton
+            v-else
+            icon="i-lucide-search"
+            color="neutral"
+            variant="outline"
+            size="xs"
+            class="min-w-32 justify-start"
+            aria-label="Search Codori"
+            @click="emit('openCommandPalette')"
+          >
+            <span class="min-w-0 flex-1 truncate text-left">
+              Search
+            </span>
+            <template #trailing>
+              <span class="flex items-center gap-1">
+                <UKbd
+                  value="meta"
+                  size="sm"
+                />
+                <UKbd
+                  value="K"
+                  size="sm"
+                />
+              </span>
+            </template>
+          </UButton>
+        </UTooltip>
         <UTooltip text="Add project">
           <UButton
             icon="i-lucide-plus"

--- a/packages/client/app/composables/useCodoriRoute.ts
+++ b/packages/client/app/composables/useCodoriRoute.ts
@@ -1,0 +1,3 @@
+import { useRoute } from '#imports'
+
+export const useCodoriRoute = () => useRoute()

--- a/packages/client/app/layouts/default.vue
+++ b/packages/client/app/layouts/default.vue
@@ -127,6 +127,8 @@ const sidebarUi = computed(() =>
       </template>
     </UDashboardSidebar>
 
+    <GlobalCommandPalette />
+
     <NuxtPage />
   </UDashboardGroup>
 </template>

--- a/packages/client/app/layouts/default.vue
+++ b/packages/client/app/layouts/default.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue'
 import { useProjects } from '../composables/useProjects'
 
 const sidebarCollapsed = ref(false)
+const commandPaletteOpen = ref(false)
 const { serviceUpdate, serviceUpdatePending, triggerServiceUpdate } = useProjects()
 
 const showServiceUpdateButton = computed(() =>
@@ -109,7 +110,10 @@ const sidebarUi = computed(() =>
       </template>
 
       <template #default="{ collapsed }">
-        <ProjectSidebar :collapsed="collapsed" />
+        <ProjectSidebar
+          :collapsed="collapsed"
+          @open-command-palette="commandPaletteOpen = true"
+        />
       </template>
 
       <template #footer>
@@ -127,7 +131,7 @@ const sidebarUi = computed(() =>
       </template>
     </UDashboardSidebar>
 
-    <GlobalCommandPalette />
+    <GlobalCommandPalette v-model:open="commandPaletteOpen" />
 
     <NuxtPage />
   </UDashboardGroup>

--- a/packages/client/app/utils/global-command-palette-shortcut.ts
+++ b/packages/client/app/utils/global-command-palette-shortcut.ts
@@ -1,0 +1,41 @@
+const editableSelector = 'input, textarea, select, [contenteditable=""], [contenteditable="true"]'
+
+export const isMacLikePlatform = (platform: string | null | undefined) =>
+  /Mac|iPhone|iPad|iPod/i.test(platform ?? '')
+
+export const isEditableShortcutTarget = (target: EventTarget | null) => {
+  if (!(target instanceof Element)) {
+    return false
+  }
+
+  if (target instanceof HTMLElement) {
+    const contentEditable = target.getAttribute('contenteditable') ?? target.contentEditable
+    if (
+      target.isContentEditable
+      || contentEditable === ''
+      || contentEditable === 'true'
+      || contentEditable === 'plaintext-only'
+    ) {
+      return true
+    }
+  }
+
+  return target.matches(editableSelector) || target.closest(editableSelector) !== null
+}
+
+export const isGlobalCommandPaletteShortcut = (
+  event: Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'defaultPrevented' | 'isComposing' | 'key' | 'metaKey' | 'shiftKey'>,
+  platform: string | null | undefined
+) => {
+  if (event.defaultPrevented || event.isComposing || event.altKey || event.shiftKey) {
+    return false
+  }
+
+  if (event.key.toLowerCase() !== 'k') {
+    return false
+  }
+
+  return isMacLikePlatform(platform)
+    ? event.metaKey && !event.ctrlKey
+    : event.ctrlKey && !event.metaKey
+}

--- a/packages/client/test/global-command-palette.test.ts
+++ b/packages/client/test/global-command-palette.test.ts
@@ -1,0 +1,343 @@
+/* eslint-disable vue/one-component-per-file */
+// @vitest-environment jsdom
+
+import { flushPromises, mount } from '@vue/test-utils'
+import type { VueWrapper } from '@vue/test-utils'
+import { computed, defineComponent, h, nextTick, ref } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import GlobalCommandPalette from '../app/components/GlobalCommandPalette.vue'
+import {
+  isEditableShortcutTarget,
+  isGlobalCommandPaletteShortcut
+} from '../app/utils/global-command-palette-shortcut'
+
+const mockRouterPush = vi.fn()
+const mockRefreshProjects = vi.fn()
+const mockRefreshChats = vi.fn()
+const mockProjects = ref<Array<{
+  projectId: string
+  projectPath: string
+  status: 'running' | 'stopped' | 'error'
+  error: string | null
+}>>([])
+const mockProjectsLoaded = ref(false)
+const mockProjectsLoading = ref(false)
+const mockChats = ref<Array<{
+  chatId: string
+  chatPath: string
+  title: string | null
+  createdAt: number
+  updatedAt: number | null
+  status: 'running' | 'stopped' | 'error'
+  error: string | null
+  threadId: string | null
+}>>([])
+const mockChatsLoaded = ref(false)
+const mockChatsLoading = ref(false)
+const mountedWrappers: VueWrapper[] = []
+
+vi.mock('../app/composables/useCodoriRouter', () => ({
+  useCodoriRouter: () => ({
+    push: mockRouterPush
+  })
+}))
+
+vi.mock('../app/composables/useProjects', () => ({
+  useProjects: () => ({
+    projects: mockProjects,
+    loaded: mockProjectsLoaded,
+    loading: mockProjectsLoading,
+    refreshProjects: mockRefreshProjects
+  })
+}))
+
+vi.mock('../app/composables/useChats', () => ({
+  useChats: () => ({
+    chats: mockChats,
+    loaded: mockChatsLoaded,
+    loading: mockChatsLoading,
+    refreshChats: mockRefreshChats
+  })
+}))
+
+const ModalStub = defineComponent({
+  name: 'ModalStub',
+  props: {
+    open: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['update:open'],
+  setup(props, { slots }) {
+    return () => props.open
+      ? h('div', { class: 'modal-stub' }, slots.content?.())
+      : null
+  }
+})
+
+const CommandPaletteStub = defineComponent({
+  name: 'CommandPaletteStub',
+  props: {
+    groups: {
+      type: Array,
+      default: () => []
+    },
+    searchTerm: {
+      type: String,
+      default: ''
+    }
+  },
+  emits: ['update:searchTerm', 'update:open'],
+  setup(props, { emit }) {
+    const visibleGroups = computed(() => {
+      const search = props.searchTerm.trim().toLowerCase()
+      return (props.groups as Array<{
+        id: string
+        label?: string
+        items?: Array<Record<string, unknown>>
+      }>).map(group => ({
+        ...group,
+        items: (group.items ?? []).filter((item) => {
+          if (!search) {
+            return true
+          }
+
+          return `${String(item.label ?? '')} ${String(item.suffix ?? '')}`.toLowerCase().includes(search)
+        })
+      })).filter(group => group.items.length > 0)
+    })
+
+    return () => h('div', { class: 'command-palette-stub' }, [
+      h('input', {
+        class: 'command-search',
+        value: props.searchTerm,
+        onInput: (event: Event) => emit('update:searchTerm', (event.target as HTMLInputElement).value)
+      }),
+      h('button', {
+        type: 'button',
+        class: 'command-close',
+        onClick: () => emit('update:open', false)
+      }, 'Close'),
+      ...visibleGroups.value.flatMap(group => [
+        h('div', { class: 'command-group' }, group.label),
+        ...(group.items ?? []).map(item => h('button', {
+          type: 'button',
+          class: 'command-item',
+          disabled: Boolean(item.disabled),
+          onClick: () => {
+            const onSelect = item.onSelect
+            if (typeof onSelect === 'function') {
+              onSelect(new Event('select'))
+            }
+          }
+        }, `${String(item.label ?? '')} ${String(item.suffix ?? '')}`))
+      ])
+    ])
+  }
+})
+
+const mountPalette = () => {
+  const wrapper = mount(GlobalCommandPalette, {
+    attachTo: document.body,
+    global: {
+      stubs: {
+        UModal: ModalStub,
+        UCommandPalette: CommandPaletteStub
+      }
+    }
+  })
+  mountedWrappers.push(wrapper)
+  return wrapper
+}
+
+const dispatchShortcut = (init: KeyboardEventInit) => {
+  const event = new KeyboardEvent('keydown', {
+    key: 'k',
+    bubbles: true,
+    cancelable: true,
+    ...init
+  })
+  window.dispatchEvent(event)
+  return event
+}
+
+describe('global command palette shortcut helpers', () => {
+  it('matches the platform command shortcut only with the expected modifier', () => {
+    expect(isGlobalCommandPaletteShortcut({
+      key: 'k',
+      metaKey: true,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: false,
+      defaultPrevented: false,
+      isComposing: false
+    }, 'MacIntel')).toBe(true)
+
+    expect(isGlobalCommandPaletteShortcut({
+      key: 'k',
+      metaKey: false,
+      ctrlKey: true,
+      altKey: false,
+      shiftKey: false,
+      defaultPrevented: false,
+      isComposing: false
+    }, 'Linux x86_64')).toBe(true)
+
+    expect(isGlobalCommandPaletteShortcut({
+      key: 'k',
+      metaKey: false,
+      ctrlKey: true,
+      altKey: false,
+      shiftKey: false,
+      defaultPrevented: false,
+      isComposing: false
+    }, 'MacIntel')).toBe(false)
+  })
+
+  it('detects editable shortcut targets', () => {
+    const input = document.createElement('input')
+    const button = document.createElement('button')
+    const editable = document.createElement('div')
+
+    editable.contentEditable = 'true'
+
+    expect(isEditableShortcutTarget(input)).toBe(true)
+    expect(isEditableShortcutTarget(editable)).toBe(true)
+    expect(isEditableShortcutTarget(button)).toBe(false)
+  })
+})
+
+describe('global command palette', () => {
+  let platformSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    mockRouterPush.mockReset()
+    mockRefreshProjects.mockReset().mockResolvedValue(undefined)
+    mockRefreshChats.mockReset().mockResolvedValue(undefined)
+    mockProjects.value = [
+      {
+        projectId: 'team/api',
+        projectPath: '/Users/comfuture/Project/team-api',
+        status: 'stopped',
+        error: null
+      },
+      {
+        projectId: 'codori',
+        projectPath: '/Users/comfuture/Project/codori',
+        status: 'running',
+        error: null
+      }
+    ]
+    mockProjectsLoaded.value = false
+    mockProjectsLoading.value = false
+    mockChats.value = [{
+      chatId: 'chat alpha',
+      chatPath: '/Users/comfuture/Documents/Chats/chat-alpha',
+      title: 'Design notes',
+      createdAt: Date.UTC(2026, 0, 2, 3, 4),
+      updatedAt: null,
+      status: 'stopped',
+      error: null,
+      threadId: null
+    }]
+    mockChatsLoaded.value = false
+    mockChatsLoading.value = false
+    platformSpy = vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('MacIntel')
+  })
+
+  afterEach(() => {
+    for (const wrapper of mountedWrappers.splice(0)) {
+      wrapper.unmount()
+    }
+    platformSpy.mockRestore()
+  })
+
+  it('opens on the macOS command shortcut and refreshes unloaded data', async () => {
+    const wrapper = mountPalette()
+
+    dispatchShortcut({ metaKey: true })
+    await nextTick()
+
+    expect(wrapper.text()).toContain('New Chat')
+    expect(wrapper.text()).toContain('Recent Chats')
+    expect(wrapper.text()).toContain('Design notes')
+    expect(wrapper.text()).toContain('Recent Projects')
+    expect(wrapper.text()).toContain('team/api')
+    expect(mockRefreshChats).toHaveBeenCalledTimes(1)
+    expect(mockRefreshProjects).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses Ctrl+K on non-macOS platforms', async () => {
+    platformSpy.mockReturnValue('Linux x86_64')
+    const wrapper = mountPalette()
+
+    dispatchShortcut({ ctrlKey: true })
+    await nextTick()
+
+    expect(wrapper.text()).toContain('New Chat')
+  })
+
+  it('does not open from editable targets', async () => {
+    const wrapper = mountPalette()
+    const input = document.createElement('input')
+    document.body.append(input)
+
+    input.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'k',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true
+    }))
+    await nextTick()
+
+    expect(wrapper.text()).not.toContain('New Chat')
+  })
+
+  it('routes and closes after selecting an action, chat, or project', async () => {
+    mockProjectsLoaded.value = true
+    mockChatsLoaded.value = true
+    mockRouterPush.mockResolvedValue(undefined)
+    const wrapper = mountPalette()
+
+    dispatchShortcut({ metaKey: true })
+    await nextTick()
+
+    await wrapper.findAll('.command-item').find(button => button.text().includes('New Chat'))!.trigger('click')
+    await flushPromises()
+
+    expect(mockRouterPush).toHaveBeenCalledWith('/chats')
+    expect(wrapper.text()).not.toContain('New Chat')
+
+    dispatchShortcut({ metaKey: true })
+    await nextTick()
+    await wrapper.findAll('.command-item').find(button => button.text().includes('Design notes'))!.trigger('click')
+    await flushPromises()
+
+    expect(mockRouterPush).toHaveBeenCalledWith('/chats/chat%20alpha')
+
+    dispatchShortcut({ metaKey: true })
+    await nextTick()
+    await wrapper.findAll('.command-item').find(button => button.text().includes('team/api'))!.trigger('click')
+    await flushPromises()
+
+    expect(mockRouterPush).toHaveBeenCalledWith('/projects/team/api')
+    expect(wrapper.text()).not.toContain('team/api')
+  })
+
+  it('filters palette entries through the command palette search term', async () => {
+    mockProjectsLoaded.value = true
+    mockChatsLoaded.value = true
+    const wrapper = mountPalette()
+
+    dispatchShortcut({ metaKey: true })
+    await nextTick()
+
+    await wrapper.get('.command-search').setValue('codori')
+
+    expect(wrapper.text()).toContain('codori')
+    expect(wrapper.text()).not.toContain('team/api')
+    expect(wrapper.text()).not.toContain('Design notes')
+  })
+})

--- a/packages/client/test/global-command-palette.test.ts
+++ b/packages/client/test/global-command-palette.test.ts
@@ -148,8 +148,9 @@ const CommandPaletteStub = defineComponent({
   }
 })
 
-const mountPalette = () => {
+const mountPalette = (props: Record<string, unknown> = {}) => {
   const wrapper = mount(GlobalCommandPalette, {
+    props,
     attachTo: document.body,
     global: {
       stubs: {
@@ -287,6 +288,20 @@ describe('global command palette', () => {
     expect(wrapper.text()).toContain('team/api')
     expect(mockRefreshChats).toHaveBeenCalledTimes(1)
     expect(mockRefreshProjects).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens from an external model and emits close updates', async () => {
+    const wrapper = mountPalette({
+      open: true
+    })
+
+    await nextTick()
+
+    expect(wrapper.text()).toContain('New Chat')
+
+    await wrapper.get('.command-close').trigger('click')
+
+    expect(wrapper.emitted('update:open')?.[0]).toEqual([false])
   })
 
   it('uses Ctrl+K on non-macOS platforms', async () => {

--- a/packages/client/test/global-command-palette.test.ts
+++ b/packages/client/test/global-command-palette.test.ts
@@ -380,6 +380,20 @@ describe('global command palette', () => {
     vi.useFakeTimers()
     mockProjectsLoaded.value = true
     mockChatsLoaded.value = true
+    mockProjects.value = [
+      {
+        projectId: 'team/api',
+        projectPath: '/Users/comfuture/Project/team-api',
+        status: 'running',
+        error: null
+      },
+      {
+        projectId: 'codori',
+        projectPath: '/Users/comfuture/Project/codori',
+        status: 'stopped',
+        error: null
+      }
+    ]
     mockRouterPush.mockResolvedValue(undefined)
     mockThreadResponses.set('team/api', [{
       id: 'thread-1',
@@ -397,9 +411,9 @@ describe('global command palette', () => {
     await vi.advanceTimersByTimeAsync(250)
     await flushPromises()
 
-    expect(mockStartProject).toHaveBeenCalledWith('team/api')
-    expect(mockStartProject).toHaveBeenCalledWith('codori')
+    expect(mockStartProject).not.toHaveBeenCalled()
     expect(mockGetClient).toHaveBeenCalledWith('team/api')
+    expect(mockGetClient).not.toHaveBeenCalledWith('codori')
     const teamClient = mockGetClient.mock.results.find(result => result.type === 'return')?.value
     expect(teamClient.request).toHaveBeenCalledWith('thread/list', {
       limit: 3,
@@ -452,7 +466,7 @@ describe('global command palette', () => {
     await nextTick()
     await flushPromises()
 
-    expect(mockStartProject).toHaveBeenCalledWith('codori')
+    expect(mockStartProject).not.toHaveBeenCalled()
     expect(wrapper.text()).toContain('Matching Threads')
     expect(wrapper.text()).toContain('Codori command palette work')
   })

--- a/packages/client/test/global-command-palette.test.ts
+++ b/packages/client/test/global-command-palette.test.ts
@@ -417,4 +417,43 @@ describe('global command palette', () => {
     expect(mockRouterPush).toHaveBeenCalledWith('/projects/team/api/threads/thread-1')
     expect(wrapper.text()).not.toContain('Review API plan')
   })
+
+  it('waits for in-flight project loading before searching threads', async () => {
+    vi.useFakeTimers()
+    mockProjects.value = []
+    mockProjectsLoaded.value = false
+    mockProjectsLoading.value = true
+    mockChatsLoaded.value = true
+    mockThreadResponses.set('codori', [{
+      id: 'thread-codori',
+      name: 'Codori command palette work',
+      preview: 'Fallback preview',
+      updatedAt: 1_767_000_001
+    }])
+    const wrapper = mountPalette()
+
+    dispatchShortcut({ metaKey: true })
+    await nextTick()
+    await wrapper.get('.command-search').setValue('codori')
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(250)
+    await flushPromises()
+
+    expect(mockStartProject).not.toHaveBeenCalled()
+
+    mockProjects.value = [{
+      projectId: 'codori',
+      projectPath: '/Users/comfuture/Project/codori',
+      status: 'running',
+      error: null
+    }]
+    mockProjectsLoaded.value = true
+    mockProjectsLoading.value = false
+    await nextTick()
+    await flushPromises()
+
+    expect(mockStartProject).toHaveBeenCalledWith('codori')
+    expect(wrapper.text()).toContain('Matching Threads')
+    expect(wrapper.text()).toContain('Codori command palette work')
+  })
 })

--- a/packages/client/test/global-command-palette.test.ts
+++ b/packages/client/test/global-command-palette.test.ts
@@ -14,6 +14,8 @@ import {
 const mockRouterPush = vi.fn()
 const mockRefreshProjects = vi.fn()
 const mockRefreshChats = vi.fn()
+const mockStartProject = vi.fn()
+const mockGetClient = vi.fn()
 const mockProjects = ref<Array<{
   projectId: string
   projectPath: string
@@ -35,6 +37,7 @@ const mockChats = ref<Array<{
 const mockChatsLoaded = ref(false)
 const mockChatsLoading = ref(false)
 const mountedWrappers: VueWrapper[] = []
+const mockThreadResponses = new Map<string, unknown[]>()
 
 vi.mock('../app/composables/useCodoriRouter', () => ({
   useCodoriRouter: () => ({
@@ -47,7 +50,14 @@ vi.mock('../app/composables/useProjects', () => ({
     projects: mockProjects,
     loaded: mockProjectsLoaded,
     loading: mockProjectsLoading,
-    refreshProjects: mockRefreshProjects
+    refreshProjects: mockRefreshProjects,
+    startProject: mockStartProject
+  })
+}))
+
+vi.mock('../app/composables/useRpc', () => ({
+  useRpc: () => ({
+    getClient: mockGetClient
   })
 }))
 
@@ -95,11 +105,12 @@ const CommandPaletteStub = defineComponent({
       return (props.groups as Array<{
         id: string
         label?: string
+        ignoreFilter?: boolean
         items?: Array<Record<string, unknown>>
       }>).map(group => ({
         ...group,
         items: (group.items ?? []).filter((item) => {
-          if (!search) {
+          if (!search || group.ignoreFilter) {
             return true
           }
 
@@ -216,6 +227,14 @@ describe('global command palette', () => {
     mockRouterPush.mockReset()
     mockRefreshProjects.mockReset().mockResolvedValue(undefined)
     mockRefreshChats.mockReset().mockResolvedValue(undefined)
+    mockStartProject.mockReset().mockResolvedValue(undefined)
+    mockGetClient.mockReset().mockImplementation((projectId: string) => ({
+      request: vi.fn().mockResolvedValue({
+        data: mockThreadResponses.get(projectId) ?? [],
+        nextCursor: null
+      })
+    }))
+    mockThreadResponses.clear()
     mockProjects.value = [
       {
         projectId: 'team/api',
@@ -251,6 +270,7 @@ describe('global command palette', () => {
     for (const wrapper of mountedWrappers.splice(0)) {
       wrapper.unmount()
     }
+    vi.useRealTimers()
     platformSpy.mockRestore()
   })
 
@@ -339,5 +359,47 @@ describe('global command palette', () => {
     expect(wrapper.text()).toContain('codori')
     expect(wrapper.text()).not.toContain('team/api')
     expect(wrapper.text()).not.toContain('Design notes')
+  })
+
+  it('searches matching project thread titles while typing', async () => {
+    vi.useFakeTimers()
+    mockProjectsLoaded.value = true
+    mockChatsLoaded.value = true
+    mockRouterPush.mockResolvedValue(undefined)
+    mockThreadResponses.set('team/api', [{
+      id: 'thread-1',
+      name: 'Review API plan',
+      preview: 'Fallback preview',
+      updatedAt: 1_767_000_000
+    }])
+    mockThreadResponses.set('codori', [])
+    const wrapper = mountPalette()
+
+    dispatchShortcut({ metaKey: true })
+    await nextTick()
+    await wrapper.get('.command-search').setValue('review')
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(250)
+    await flushPromises()
+
+    expect(mockStartProject).toHaveBeenCalledWith('team/api')
+    expect(mockStartProject).toHaveBeenCalledWith('codori')
+    expect(mockGetClient).toHaveBeenCalledWith('team/api')
+    const teamClient = mockGetClient.mock.results.find(result => result.type === 'return')?.value
+    expect(teamClient.request).toHaveBeenCalledWith('thread/list', {
+      limit: 3,
+      sortKey: 'updated_at',
+      cwd: '/Users/comfuture/Project/team-api',
+      searchTerm: 'review'
+    })
+    expect(wrapper.text()).toContain('Matching Threads')
+    expect(wrapper.text()).toContain('Review API plan')
+    expect(wrapper.text()).toContain('team/api')
+
+    await wrapper.findAll('.command-item').find(button => button.text().includes('Review API plan'))!.trigger('click')
+    await flushPromises()
+
+    expect(mockRouterPush).toHaveBeenCalledWith('/projects/team/api/threads/thread-1')
+    expect(wrapper.text()).not.toContain('Review API plan')
   })
 })

--- a/packages/client/test/project-sidebar-command-palette.test.ts
+++ b/packages/client/test/project-sidebar-command-palette.test.ts
@@ -1,0 +1,165 @@
+/* eslint-disable vue/one-component-per-file */
+// @vitest-environment jsdom
+
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ProjectSidebar from '../app/components/ProjectSidebar.vue'
+
+const mockRoute = {
+  params: {}
+}
+const mockRouterPush = vi.fn()
+const mockRefreshProjects = vi.fn()
+const mockRefreshChats = vi.fn()
+const mockProjects = ref([])
+const mockChats = ref([])
+
+vi.mock('../app/composables/useCodoriRoute', () => ({
+  useCodoriRoute: () => mockRoute
+}))
+
+vi.mock('../app/composables/useCodoriRouter', () => ({
+  useCodoriRouter: () => ({
+    push: mockRouterPush
+  })
+}))
+
+vi.mock('../app/composables/useProjects', () => ({
+  useProjects: () => ({
+    projects: mockProjects,
+    loaded: ref(true),
+    loading: ref(false),
+    refreshProjects: mockRefreshProjects
+  })
+}))
+
+vi.mock('../app/composables/useChats', () => ({
+  useChats: () => ({
+    chats: mockChats,
+    loaded: ref(true),
+    loading: ref(false),
+    createPending: ref(false),
+    deletePendingId: ref(null),
+    refreshChats: mockRefreshChats,
+    deleteChat: vi.fn()
+  })
+}))
+
+const ButtonStub = defineComponent({
+  name: 'ButtonStub',
+  props: {
+    label: {
+      type: String,
+      default: ''
+    },
+    ariaLabel: {
+      type: String,
+      default: ''
+    }
+  },
+  emits: ['click'],
+  setup(props, { attrs, emit, slots }) {
+    const ariaLabel = () =>
+      String(attrs['aria-label'] ?? props.ariaLabel ?? props.label ?? '')
+
+    return () => h('button', {
+      type: 'button',
+      'aria-label': ariaLabel(),
+      onClick: (event: MouseEvent) => emit('click', event)
+    }, [
+      slots.default?.() ?? props.label,
+      slots.trailing?.()
+    ])
+  }
+})
+
+const TooltipStub = defineComponent({
+  name: 'TooltipStub',
+  setup(_, { slots }) {
+    return () => h('div', { class: 'tooltip-stub' }, slots.default?.())
+  }
+})
+
+const KbdStub = defineComponent({
+  name: 'KbdStub',
+  props: {
+    value: {
+      type: String,
+      default: ''
+    }
+  },
+  setup(props) {
+    return () => h('kbd', { class: 'kbd-stub' }, props.value)
+  }
+})
+
+const mountSidebar = (props: Record<string, unknown> = {}) =>
+  mount(ProjectSidebar, {
+    props,
+    global: {
+      stubs: {
+        UTooltip: TooltipStub,
+        UButton: ButtonStub,
+        UKbd: KbdStub,
+        UNavigationMenu: defineComponent({
+          name: 'NavigationMenuStub',
+          setup() {
+            return () => h('nav')
+          }
+        }),
+        AddProjectModal: defineComponent({
+          name: 'AddProjectModalStub',
+          setup() {
+            return () => null
+          }
+        }),
+        ProjectStatusDot: defineComponent({
+          name: 'ProjectStatusDotStub',
+          setup() {
+            return () => h('span')
+          }
+        })
+      }
+    }
+  })
+
+describe('project sidebar command palette trigger', () => {
+  beforeEach(() => {
+    mockRouterPush.mockReset()
+    mockRefreshProjects.mockReset()
+    mockRefreshChats.mockReset()
+    mockProjects.value = []
+    mockChats.value = []
+  })
+
+  it('renders an input-like expanded search trigger before project action buttons', async () => {
+    const wrapper = mountSidebar({
+      collapsed: false
+    })
+
+    expect(wrapper.text()).toContain('Search')
+    expect(wrapper.text()).toContain('meta')
+    expect(wrapper.text()).toContain('K')
+
+    const actionLabels = wrapper.findAll('button').map(button => button.attributes('aria-label') ?? button.text())
+    expect(actionLabels.indexOf('Search Codori')).toBeLessThan(actionLabels.indexOf('Add project'))
+    expect(actionLabels.indexOf('Add project')).toBeLessThan(actionLabels.indexOf('Refresh projects'))
+
+    await wrapper.get('button[aria-label="Search Codori"]').trigger('click')
+
+    expect(wrapper.emitted('openCommandPalette')).toHaveLength(1)
+  })
+
+  it('renders a compact search trigger when collapsed', async () => {
+    const wrapper = mountSidebar({
+      collapsed: true
+    })
+
+    expect(wrapper.text()).not.toContain('Search')
+
+    await wrapper.get('button[aria-label="Search Codori"]').trigger('click')
+
+    expect(wrapper.emitted('openCommandPalette')).toHaveLength(1)
+  })
+})

--- a/packages/client/test/project-sidebar-command-palette.test.ts
+++ b/packages/client/test/project-sidebar-command-palette.test.ts
@@ -3,7 +3,7 @@
 
 import { mount } from '@vue/test-utils'
 import { defineComponent, h, ref } from 'vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import ProjectSidebar from '../app/components/ProjectSidebar.vue'
 
 const mockRoute = {
@@ -125,12 +125,19 @@ const mountSidebar = (props: Record<string, unknown> = {}) =>
   })
 
 describe('project sidebar command palette trigger', () => {
+  let platformSpy: ReturnType<typeof vi.spyOn>
+
   beforeEach(() => {
     mockRouterPush.mockReset()
     mockRefreshProjects.mockReset()
     mockRefreshChats.mockReset()
     mockProjects.value = []
     mockChats.value = []
+    platformSpy = vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('MacIntel')
+  })
+
+  afterEach(() => {
+    platformSpy.mockRestore()
   })
 
   it('renders an input-like expanded search trigger before project action buttons', async () => {
@@ -149,6 +156,16 @@ describe('project sidebar command palette trigger', () => {
     await wrapper.get('button[aria-label="Search Codori"]').trigger('click')
 
     expect(wrapper.emitted('openCommandPalette')).toHaveLength(1)
+  })
+
+  it('renders the non-macOS shortcut modifier in the expanded search trigger', async () => {
+    platformSpy.mockReturnValue('Linux x86_64')
+    const wrapper = mountSidebar({
+      collapsed: false
+    })
+
+    expect(wrapper.text()).toContain('ctrl')
+    expect(wrapper.text()).toContain('K')
   })
 
   it('renders a compact search trigger when collapsed', async () => {


### PR DESCRIPTION
Closes #53

## Changes
- Added a Nuxt UI command palette available through Cmd/Ctrl+K with actions for New Chat, recent chats, and projects.
- Added typed thread-title search using codex app-server `thread/list` with `ThreadListParams.searchTerm`, scoped to already-running projects to avoid starting stopped runtimes from search.
- Added a Projects sidebar search trigger connected to the same palette, including platform-aware shortcut hints.
- Covered shortcut handling, routing, thread search, sidebar trigger behavior, in-flight project loading, stopped-project search gating, and platform shortcut hints with tests.

## Review follow-up
- `c8a358d fix: address command palette review feedback` handles the review threads by avoiding stopped-project runtime startup during thread search and making the sidebar shortcut modifier explicit per platform.

## Why
This gives Codori a global navigation surface for quickly opening chats, projects, and matching project threads without forcing users through sidebar-only navigation or starting unrelated stopped runtimes during search.

## Validation
- `pnpm --filter @codori/client exec vitest run test/global-command-palette.test.ts test/project-sidebar-command-palette.test.ts`
- `pnpm --filter @codori/client test`
- `pnpm --filter @codori/client lint`
- `pnpm --filter @codori/client typecheck`
- `pnpm build`
- Built server verification at `http://127.0.0.1:4310/projects/codori`: sidebar trigger, Cmd+K, thread suggestions, and thread navigation verified.
