### PR TITLE
Add grouped tool-call transcript cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codori",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "packageManager": "pnpm@10.33.0",
   "scripts": {
     "build": "pnpm --filter @codori/client build && pnpm --filter @codori/server build",

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -62,6 +62,7 @@ import {
   eventToMessage,
   findLatestCompletedPlanTurnId,
   findLatestPlanTurnId,
+  groupTranscriptMessages,
   isSubagentActiveStatus,
   itemToMessages,
   replaceStreamingMessage,
@@ -442,6 +443,7 @@ const composerPlaceholder = computed(() =>
 const chatMessagesStatus = computed(() =>
   resolveChatMessagesStatus(status.value, awaitingAssistantOutput.value)
 )
+const displayMessages = computed(() => groupTranscriptMessages(messages.value))
 const chatSpacingOffset = computed(() =>
   Math.max(140, stickyFooterHeight.value + 24)
 )
@@ -4361,7 +4363,7 @@ watch(
 
       <UChatMessages
         v-else
-        :messages="messages"
+        :messages="displayMessages"
         :status="chatMessagesStatus"
         :should-auto-scroll="false"
         :should-scroll-to-bottom="false"

--- a/packages/client/app/components/MessagePartRenderer.ts
+++ b/packages/client/app/components/MessagePartRenderer.ts
@@ -1,12 +1,13 @@
 import { defineComponent, h, type PropType } from 'vue'
 import { UChatReasoning } from '#components'
-import { EVENT_PART, ITEM_PART, type ChatMessage, type ChatPart } from '~~/shared/codex-chat'
+import { EVENT_PART, ITEM_PART, TOOL_GROUP_PART, type ChatMessage, type ChatPart } from '~~/shared/codex-chat'
 import type { WorkspaceAttachmentScope } from '~~/shared/chat-attachments'
 import MessagePartAttachment from './message-part/Attachment.vue'
 import MessagePartEvent from './message-part/Event.vue'
 import MessagePartItem from './message-part/Item'
 import MessagePartPlan from './message-part/Plan.vue'
 import MessagePartText from './message-part/Text.vue'
+import MessagePartToolGroup from './message-part/ToolGroup.vue'
 
 export default defineComponent({
   name: 'MessagePartRenderer',
@@ -73,6 +74,10 @@ export default defineComponent({
           return h(MessagePartItem, {
             part: props.part,
             messagePending: props.message?.pending ?? false
+          })
+        case TOOL_GROUP_PART:
+          return h(MessagePartToolGroup, {
+            part: props.part
           })
         default:
           return h('pre', {

--- a/packages/client/app/components/message-part/ToolGroup.vue
+++ b/packages/client/app/components/message-part/ToolGroup.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  ITEM_PART,
+  TOOL_GROUP_PART,
+  type ChatPart
+} from '~~/shared/codex-chat'
+import MessagePartItem from './Item'
+
+const props = defineProps<{
+  part: Extract<ChatPart, { type: typeof TOOL_GROUP_PART }>
+}>()
+
+const open = ref(false)
+
+const childItemParts = props.part.data.messages.flatMap(message =>
+  message.parts.filter((part): part is Extract<ChatPart, { type: typeof ITEM_PART }> =>
+    part.type === ITEM_PART
+  )
+)
+</script>
+
+<template>
+  <UChatTool
+    :text="part.data.summary"
+    :suffix="part.data.details"
+    icon="i-lucide-list-collapse"
+    variant="card"
+    chevron="leading"
+    :open="open"
+    :default-open="false"
+    @update:open="open = $event"
+  >
+    <div class="space-y-3">
+      <MessagePartItem
+        v-for="childPart in childItemParts"
+        :key="childPart.data.item.id"
+        :part="childPart"
+      />
+    </div>
+  </UChatTool>
+</template>

--- a/packages/client/app/components/message-part/ToolGroup.vue
+++ b/packages/client/app/components/message-part/ToolGroup.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import {
   ITEM_PART,
   TOOL_GROUP_PART,
@@ -13,9 +13,11 @@ const props = defineProps<{
 
 const open = ref(false)
 
-const childItemParts = props.part.data.messages.flatMap(message =>
-  message.parts.filter((part): part is Extract<ChatPart, { type: typeof ITEM_PART }> =>
-    part.type === ITEM_PART
+const childItemParts = computed(() =>
+  props.part.data.messages.flatMap(message =>
+    message.parts.filter((part): part is Extract<ChatPart, { type: typeof ITEM_PART }> =>
+      part.type === ITEM_PART
+    )
   )
 )
 </script>

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codori/client",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": false,
   "description": "Codori Nuxt dashboard for project browsing, Codex chat, and thread resume.",
   "type": "module",

--- a/packages/client/shared/codex-chat.ts
+++ b/packages/client/shared/codex-chat.ts
@@ -206,6 +206,11 @@ const hasAssistantOutputPart = (message: ChatMessage) =>
     || part.type === 'plan'
   )
 
+const isDisplayOnlySystemEvent = (message: ChatMessage) =>
+  message.role === 'system'
+  && message.parts.length === 1
+  && message.parts[0]?.type === EVENT_PART
+
 const buildToolGroupData = (messages: ChatMessage[]): ToolCallGroupData => {
   const counts = new Map<GroupableToolKind, number>()
   for (const message of messages) {
@@ -252,22 +257,36 @@ const groupToolRun = (toolRun: ChatMessage[]): ChatMessage[] => {
 export const groupTranscriptMessages = (messages: ChatMessage[]): ChatMessage[] => {
   const grouped: ChatMessage[] = []
   let pendingToolRun: ChatMessage[] = []
+  let pendingSystemEvents: ChatMessage[] = []
 
   for (const message of messages) {
     if (getGroupableToolKind(message)) {
+      if (pendingSystemEvents.length > 0) {
+        grouped.push(...pendingToolRun, ...pendingSystemEvents)
+        pendingToolRun = []
+        pendingSystemEvents = []
+      }
+
       pendingToolRun.push(message)
       continue
     }
 
     if (pendingToolRun.length > 0) {
+      if (isDisplayOnlySystemEvent(message)) {
+        pendingSystemEvents.push(message)
+        continue
+      }
+
       grouped.push(...(hasAssistantOutputPart(message) ? groupToolRun(pendingToolRun) : pendingToolRun))
+      grouped.push(...pendingSystemEvents)
       pendingToolRun = []
+      pendingSystemEvents = []
     }
 
     grouped.push(message)
   }
 
-  grouped.push(...pendingToolRun)
+  grouped.push(...pendingToolRun, ...pendingSystemEvents)
   return grouped
 }
 

--- a/packages/client/shared/codex-chat.ts
+++ b/packages/client/shared/codex-chat.ts
@@ -198,6 +198,31 @@ const getGroupableToolKind = (message: ChatMessage): GroupableToolKind | null =>
     : null
 }
 
+const isSuccessfullyCompletedToolMessage = (message: ChatMessage) => {
+  if (message.pending || message.parts.length !== 1) {
+    return false
+  }
+
+  const [part] = message.parts
+  if (part?.type !== ITEM_PART) {
+    return false
+  }
+
+  switch (part.data.kind) {
+    case 'command_execution':
+    case 'file_change':
+    case 'mcp_tool_call':
+    case 'dynamic_tool_call':
+      return part.data.item.status === 'completed'
+    case 'web_search':
+      return part.data.status === 'completed'
+    case 'context_compaction':
+      return true
+    default:
+      return false
+  }
+}
+
 const hasAssistantOutputPart = (message: ChatMessage) =>
   message.role === 'assistant'
   && message.parts.some(part =>
@@ -239,7 +264,7 @@ const buildToolGroupData = (messages: ChatMessage[]): ToolCallGroupData => {
 }
 
 const groupToolRun = (toolRun: ChatMessage[]): ChatMessage[] => {
-  if (toolRun.length <= 1 || toolRun.some(message => message.pending)) {
+  if (toolRun.length <= 1 || toolRun.some(message => !isSuccessfullyCompletedToolMessage(message))) {
     return toolRun
   }
 
@@ -260,7 +285,8 @@ export const groupTranscriptMessages = (messages: ChatMessage[]): ChatMessage[] 
   let pendingSystemEvents: ChatMessage[] = []
 
   for (const message of messages) {
-    if (getGroupableToolKind(message)) {
+    const toolKind = getGroupableToolKind(message)
+    if (toolKind && isSuccessfullyCompletedToolMessage(message)) {
       if (pendingSystemEvents.length > 0) {
         grouped.push(...pendingToolRun, ...pendingSystemEvents)
         pendingToolRun = []

--- a/packages/client/shared/codex-chat.ts
+++ b/packages/client/shared/codex-chat.ts
@@ -7,6 +7,7 @@ import type { UserInput } from './generated/codex-app-server/v2/UserInput'
 
 export const EVENT_PART = 'data-thread-event' as const
 export const ITEM_PART = 'data-thread-item' as const
+export const TOOL_GROUP_PART = 'data-tool-call-group' as const
 
 export type ThreadEventData =
   | {
@@ -104,6 +105,15 @@ export type ItemData =
       item: Extract<ThreadItem, { type: 'contextCompaction' }>
     }
 
+export type GroupableToolKind = Exclude<ItemData['kind'], 'subagent_activity'>
+
+export type ToolCallGroupData = {
+  id: string
+  messages: ChatMessage[]
+  summary: string
+  details: string
+}
+
 export type ChatPart =
   | {
       type: 'text'
@@ -139,12 +149,126 @@ export type ChatPart =
       type: typeof ITEM_PART
       data: ItemData
     }
+  | {
+      type: typeof TOOL_GROUP_PART
+      data: ToolCallGroupData
+    }
 
 export type ChatMessage = {
   id: string
   role: 'user' | 'assistant' | 'system'
   pending?: boolean
   parts: ChatPart[]
+}
+
+const groupableToolKinds: GroupableToolKind[] = [
+  'command_execution',
+  'file_change',
+  'mcp_tool_call',
+  'dynamic_tool_call',
+  'web_search',
+  'context_compaction'
+]
+
+const groupableToolKindLabels: Record<GroupableToolKind, { singular: string, plural: string }> = {
+  command_execution: { singular: 'command', plural: 'commands' },
+  file_change: { singular: 'edit', plural: 'edits' },
+  mcp_tool_call: { singular: 'MCP tool', plural: 'MCP tools' },
+  dynamic_tool_call: { singular: 'internal tool', plural: 'internal tools' },
+  web_search: { singular: 'web search', plural: 'web searches' },
+  context_compaction: { singular: 'compaction', plural: 'compactions' }
+}
+
+const pluralize = (count: number, labels: { singular: string, plural: string }) =>
+  `${count} ${count === 1 ? labels.singular : labels.plural}`
+
+const getGroupableToolKind = (message: ChatMessage): GroupableToolKind | null => {
+  if (message.role !== 'system' || message.parts.length !== 1) {
+    return null
+  }
+
+  const [part] = message.parts
+  if (part?.type !== ITEM_PART) {
+    return null
+  }
+
+  const kind = part.data.kind
+  return groupableToolKinds.includes(kind as GroupableToolKind)
+    ? kind as GroupableToolKind
+    : null
+}
+
+const hasAssistantOutputPart = (message: ChatMessage) =>
+  message.role === 'assistant'
+  && message.parts.some(part =>
+    part.type === 'text'
+    || part.type === 'reasoning'
+    || part.type === 'plan'
+  )
+
+const buildToolGroupData = (messages: ChatMessage[]): ToolCallGroupData => {
+  const counts = new Map<GroupableToolKind, number>()
+  for (const message of messages) {
+    const kind = getGroupableToolKind(message)
+    if (!kind) {
+      continue
+    }
+
+    counts.set(kind, (counts.get(kind) ?? 0) + 1)
+  }
+
+  const details = groupableToolKinds
+    .map((kind) => {
+      const count = counts.get(kind) ?? 0
+      return count > 0 ? pluralize(count, groupableToolKindLabels[kind]) : null
+    })
+    .filter((detail): detail is string => Boolean(detail))
+    .join(', ')
+
+  return {
+    id: `tool-group:${messages.length}:${messages[0]?.id ?? 'start'}:${messages[messages.length - 1]?.id ?? 'end'}`,
+    messages,
+    summary: pluralize(messages.length, { singular: 'tool call', plural: 'tool calls' }),
+    details
+  }
+}
+
+const groupToolRun = (toolRun: ChatMessage[]): ChatMessage[] => {
+  if (toolRun.length <= 1 || toolRun.some(message => message.pending)) {
+    return toolRun
+  }
+
+  const data = buildToolGroupData(toolRun)
+  return [{
+    id: data.id,
+    role: 'system',
+    parts: [{
+      type: TOOL_GROUP_PART,
+      data
+    }]
+  }]
+}
+
+export const groupTranscriptMessages = (messages: ChatMessage[]): ChatMessage[] => {
+  const grouped: ChatMessage[] = []
+  let pendingToolRun: ChatMessage[] = []
+
+  for (const message of messages) {
+    if (getGroupableToolKind(message)) {
+      pendingToolRun.push(message)
+      continue
+    }
+
+    if (pendingToolRun.length > 0) {
+      grouped.push(...(hasAssistantOutputPart(message) ? groupToolRun(pendingToolRun) : pendingToolRun))
+      pendingToolRun = []
+    }
+
+    grouped.push(message)
+  }
+
+  grouped.push(...pendingToolRun)
+  return grouped
 }
 
 export const asAgentMessageItem = (input: {

--- a/packages/client/test/chat-transcript.test.ts
+++ b/packages/client/test/chat-transcript.test.ts
@@ -563,6 +563,47 @@ describe('chat transcript stability', () => {
     ])
   })
 
+  it('keeps failed and declined tool items out of grouped cards', () => {
+    const failedCommand = itemToMessages({
+      type: 'commandExecution',
+      id: 'cmd-failed',
+      command: 'pnpm test',
+      cwd: '/tmp',
+      processId: null,
+      source: 'agent',
+      status: 'failed',
+      commandActions: [],
+      aggregatedOutput: 'Tests failed',
+      exitCode: 1,
+      durationMs: 30
+    })
+    const declinedEdit = itemToMessages({
+      type: 'fileChange',
+      id: 'edit-declined',
+      changes: [],
+      status: 'declined'
+    })
+    const assistant: ChatMessage = {
+      id: 'assistant-1',
+      role: 'assistant',
+      parts: [{
+        type: 'text',
+        text: 'I found a failure.',
+        state: 'done'
+      }]
+    }
+
+    expect(groupTranscriptMessages([
+      ...failedCommand,
+      ...declinedEdit,
+      assistant
+    ])).toEqual([
+      ...failedCommand,
+      ...declinedEdit,
+      assistant
+    ])
+  })
+
   it('does not group single tool items or tool runs before non-assistant boundaries', () => {
     const singleTool = itemToMessages({
       type: 'contextCompaction',

--- a/packages/client/test/chat-transcript.test.ts
+++ b/packages/client/test/chat-transcript.test.ts
@@ -3,9 +3,11 @@ import type { Thread } from '../shared/generated/codex-app-server/v2/Thread'
 import type { Turn } from '../shared/generated/codex-app-server/v2/Turn'
 import {
   ITEM_PART,
+  TOOL_GROUP_PART,
   asAgentMessageItem,
   findLatestCompletedPlanTurnId,
   findLatestPlanTurnId,
+  groupTranscriptMessages,
   itemToMessages,
   threadToMessages,
   replaceStreamingMessage,
@@ -477,5 +479,146 @@ describe('chat transcript stability', () => {
         }
       }]
     }])
+  })
+
+  it('groups consecutive completed tool messages once assistant output follows', () => {
+    const command = itemToMessages({
+      type: 'commandExecution',
+      id: 'cmd-1',
+      command: 'rg groupTranscriptMessages',
+      cwd: '/tmp',
+      processId: null,
+      source: 'agent',
+      status: 'completed',
+      commandActions: [],
+      aggregatedOutput: 'packages/client/shared/codex-chat.ts',
+      exitCode: 0,
+      durationMs: 42
+    })
+    const search = itemToMessages({
+      type: 'webSearch',
+      id: 'search-1',
+      query: 'openai codex tool grouping',
+      action: null
+    })
+    const assistant: ChatMessage = {
+      id: 'assistant-1',
+      role: 'assistant',
+      parts: [{
+        type: 'text',
+        text: 'Done',
+        state: 'done'
+      }]
+    }
+
+    const grouped = groupTranscriptMessages([...command, ...search, assistant])
+
+    expect(grouped).toHaveLength(2)
+    expect(grouped[0]?.id).toBe('tool-group:2:cmd-1:search-1')
+    expect(grouped[0]?.role).toBe('system')
+    expect(grouped[0]?.parts[0]).toMatchObject({
+      type: TOOL_GROUP_PART,
+      data: {
+        summary: '2 tool calls',
+        details: '1 command, 1 web search',
+        messages: [...command, ...search]
+      }
+    })
+    expect(grouped[1]).toBe(assistant)
+  })
+
+  it('keeps the active streaming tool tail ungrouped', () => {
+    const running = itemToMessages({
+      type: 'mcpToolCall',
+      id: 'mcp-1',
+      server: 'filesystem',
+      tool: 'read_file',
+      arguments: { path: '/tmp/demo.txt' },
+      result: null,
+      error: null,
+      status: 'inProgress',
+      durationMs: null
+    })
+    const completed = itemToMessages({
+      type: 'webSearch',
+      id: 'search-1',
+      query: 'codori',
+      action: null
+    })
+    const assistant: ChatMessage = {
+      id: 'assistant-1',
+      role: 'assistant',
+      parts: [{
+        type: 'reasoning',
+        summary: ['Checking'],
+        content: [],
+        state: 'done'
+      }]
+    }
+
+    expect(groupTranscriptMessages([...running, ...completed, assistant])).toEqual([
+      ...running,
+      ...completed,
+      assistant
+    ])
+  })
+
+  it('does not group single tool items or tool runs before non-assistant boundaries', () => {
+    const singleTool = itemToMessages({
+      type: 'contextCompaction',
+      id: 'compact-1'
+    })
+    const user: ChatMessage = {
+      id: 'user-1',
+      role: 'user',
+      parts: [{
+        type: 'text',
+        text: 'Next request',
+        state: 'done'
+      }]
+    }
+    const assistant: ChatMessage = {
+      id: 'assistant-1',
+      role: 'assistant',
+      parts: [{
+        type: 'text',
+        text: 'Done',
+        state: 'done'
+      }]
+    }
+
+    expect(groupTranscriptMessages([...singleTool, assistant])).toEqual([
+      ...singleTool,
+      assistant
+    ])
+    expect(groupTranscriptMessages([
+      ...itemToMessages({
+        type: 'webSearch',
+        id: 'search-1',
+        query: 'codori',
+        action: null
+      }),
+      ...itemToMessages({
+        type: 'webSearch',
+        id: 'search-2',
+        query: 'openai codex',
+        action: null
+      }),
+      user
+    ])).toEqual([
+      ...itemToMessages({
+        type: 'webSearch',
+        id: 'search-1',
+        query: 'codori',
+        action: null
+      }),
+      ...itemToMessages({
+        type: 'webSearch',
+        id: 'search-2',
+        query: 'openai codex',
+        action: null
+      }),
+      user
+    ])
   })
 })

--- a/packages/client/test/chat-transcript.test.ts
+++ b/packages/client/test/chat-transcript.test.ts
@@ -621,4 +621,56 @@ describe('chat transcript stability', () => {
       user
     ])
   })
+
+  it('groups completed tools across display-only review completion events', () => {
+    const command = itemToMessages({
+      type: 'commandExecution',
+      id: 'cmd-1',
+      command: 'pnpm test',
+      cwd: '/tmp',
+      processId: null,
+      source: 'agent',
+      status: 'completed',
+      commandActions: [],
+      aggregatedOutput: 'Tests passed',
+      exitCode: 0,
+      durationMs: 50
+    })
+    const edit = itemToMessages({
+      type: 'fileChange',
+      id: 'edit-1',
+      changes: [{
+        path: 'packages/client/shared/codex-chat.ts',
+        kind: {
+          type: 'update',
+          move_path: null
+        },
+        diff: ''
+      }],
+      status: 'completed'
+    })
+    const reviewCompleted = itemToMessages({
+      type: 'exitedReviewMode',
+      id: 'review-1',
+      review: 'Final review output'
+    })
+
+    const grouped = groupTranscriptMessages([
+      ...command,
+      ...edit,
+      ...reviewCompleted
+    ])
+
+    expect(grouped).toHaveLength(3)
+    expect(grouped[0]?.parts[0]).toMatchObject({
+      type: TOOL_GROUP_PART,
+      data: {
+        summary: '2 tool calls',
+        details: '1 command, 1 edit',
+        messages: [...command, ...edit]
+      }
+    })
+    expect(grouped[1]).toEqual(reviewCompleted[0])
+    expect(grouped[2]).toEqual(reviewCompleted[1])
+  })
 })

--- a/packages/client/test/tool-group-message-part.test.ts
+++ b/packages/client/test/tool-group-message-part.test.ts
@@ -1,0 +1,126 @@
+/* eslint-disable vue/one-component-per-file */
+// @vitest-environment jsdom
+
+import { defineComponent } from 'vue'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import MessagePartToolGroup from '../app/components/message-part/ToolGroup.vue'
+import {
+  ITEM_PART,
+  TOOL_GROUP_PART,
+  type ChatPart
+} from '../shared/codex-chat'
+
+const UChatToolStub = defineComponent({
+  name: 'UChatTool',
+  props: {
+    text: {
+      type: String,
+      default: ''
+    },
+    suffix: {
+      type: String,
+      default: ''
+    },
+    open: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['update:open'],
+  template: `
+    <section data-testid="tool-group">
+      <button type="button" data-testid="trigger" @click="$emit('update:open', !open)">
+        <span data-testid="text">{{ text }}</span>
+        <span data-testid="suffix">{{ suffix }}</span>
+      </button>
+      <div v-if="open" data-testid="body">
+        <slot />
+      </div>
+    </section>
+  `
+})
+
+const MessagePartItemStub = defineComponent({
+  name: 'MessagePartItem',
+  props: {
+    part: {
+      type: Object,
+      required: true
+    }
+  },
+  template: '<article data-testid="child">{{ part.data.kind }}:{{ part.data.item.id }}</article>'
+})
+
+describe('MessagePartToolGroup', () => {
+  it('renders a collapsed summary and expands existing child item renderers', async () => {
+    const part: Extract<ChatPart, { type: typeof TOOL_GROUP_PART }> = {
+      type: TOOL_GROUP_PART,
+      data: {
+        id: 'tool-group:2:cmd-1:search-1',
+        summary: '2 tool calls',
+        details: '1 command, 1 web search',
+        messages: [{
+          id: 'cmd-1',
+          role: 'system',
+          parts: [{
+            type: ITEM_PART,
+            data: {
+              kind: 'command_execution',
+              item: {
+                type: 'commandExecution',
+                id: 'cmd-1',
+                command: 'rg grouped',
+                cwd: '/tmp',
+                processId: null,
+                source: 'agent',
+                status: 'completed',
+                commandActions: [],
+                aggregatedOutput: null,
+                exitCode: 0,
+                durationMs: 10
+              }
+            }
+          }]
+        }, {
+          id: 'search-1',
+          role: 'system',
+          parts: [{
+            type: ITEM_PART,
+            data: {
+              kind: 'web_search',
+              item: {
+                type: 'webSearch',
+                id: 'search-1',
+                query: 'openai codex grouping',
+                action: null
+              },
+              status: 'completed'
+            }
+          }]
+        }]
+      }
+    }
+
+    const wrapper = mount(MessagePartToolGroup, {
+      props: { part },
+      global: {
+        stubs: {
+          UChatTool: UChatToolStub,
+          MessagePartItem: MessagePartItemStub
+        }
+      }
+    })
+
+    expect(wrapper.get('[data-testid="text"]').text()).toBe('2 tool calls')
+    expect(wrapper.get('[data-testid="suffix"]').text()).toBe('1 command, 1 web search')
+    expect(wrapper.find('[data-testid="body"]').exists()).toBe(false)
+
+    await wrapper.get('[data-testid="trigger"]').trigger('click')
+
+    expect(wrapper.findAll('[data-testid="child"]').map(child => child.text())).toEqual([
+      'command_execution:cmd-1',
+      'web_search:search-1'
+    ])
+  })
+})

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codori/server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": false,
   "description": "Codori server for Git project discovery, Codex runtime management, and bundled dashboard serving.",
   "type": "module",


### PR DESCRIPTION
## Summary
- add a deterministic display-layer grouper for completed consecutive tool transcript items
- render grouped tool runs as UChatTool-style collapsed cards with existing child item renderers on expand
- feed UChatMessages a grouped display transcript while keeping raw session messages flat
- address review follow-up by preserving grouped tool runs across display-only system events and making ToolGroup child item state computed
- keep failed and declined tool items outside grouped cards so error state stays visible
- bump synchronized workspace package versions to 0.3.0 for deployment

## Commits
- b5afb62 feat: add transcript tool grouping
- c8bfc3e feat: render grouped tool call cards
- ab8e6c5 fix: preserve grouped tool runs across events
- b4dc556 chore: bump version to 0.3.0
- a523c69 fix: keep failed tools visible in transcript

## Notes
- checked current openai/codex main at c8c30d9: upstream now groups only narrow TUI exec exploration cells, so this implements Codori issue #37 as a broader display-layer adaptation rather than exact upstream parity
- replied to and resolved the two ToolGroup.vue review threads after commit ab8e6c5
- replied to and resolved the failed-tool visibility review thread after commit a523c69
- release dry-run reports @codori/client@0.3.0 and @codori/server@0.3.0 would publish

## Validation
- pnpm --filter @codori/client exec vitest run test/chat-transcript.test.ts test/tool-group-message-part.test.ts
- pnpm --filter @codori/client typecheck
- pnpm --filter @codori/client test
- pnpm --filter @codori/client lint
- node scripts/publish-release.mjs --dry-run --tag=v0.3.0
- pnpm test
- pnpm typecheck
- pnpm build
- pnpm --filter @codori/client exec vitest run test/chat-transcript.test.ts
- git diff --check

Closes #37