### PR TITLE
Fix release pnpm setup version source

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.33.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v5


### PR DESCRIPTION
## Summary
- Remove the explicit pnpm/action-setup version from the release workflow
- Let pnpm/action-setup read the single pnpm version source from package.json packageManager (`pnpm@10.33.2`)
- Avoid future release failures when packageManager is bumped without duplicating the same value in GitHub Actions

## Why
The failed release job stopped in `pnpm/action-setup@v4` because the workflow requested `10.33.0` while package.json declares `pnpm@10.33.2`. The action reports this as multiple pnpm versions and asks to remove one source.

Runner/action details from the failed job:
- GitHub Actions runner: 2.334.0 on ubuntu-24.04 image 20260413.86.1
- pnpm/action-setup@v4: b906affcce14559ad1aafd4ab0e942779e9f58b1
- actions/setup-node@v5: a0853c24544627f65ddf259abe73b1d18a591444

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-release.yml"); puts "yaml ok"'
- git diff --check origin/main...HEAD
- npm view pnpm@10.33.2 version
- gh run view 25310070358 --job 74194630140 --log-failed