### PR TITLE
Render skill references as badges

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codori",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "packageManager": "pnpm@10.33.2",
   "scripts": {
     "build": "pnpm --filter @codori/client build && pnpm --filter @codori/server build",

--- a/packages/client/app/components/message-part/SkillReferenceBadge.vue
+++ b/packages/client/app/components/message-part/SkillReferenceBadge.vue
@@ -19,12 +19,7 @@ const props = defineProps<{
 
 const SKILL_FALLBACK_ICON = '🛠️'
 
-type SkillCatalogState = {
-  promise: Promise<SkillAutocompleteEntry[]>
-  skills: SkillAutocompleteEntry[] | null
-}
-
-const skillCatalogCache = new Map<string, SkillCatalogState>()
+const skillCatalogCache = new Map<string, Promise<SkillAutocompleteEntry[]>>()
 
 const { getProject } = useProjects()
 const { getWorkspaceClient } = useRpc()
@@ -59,24 +54,23 @@ const loadSkillCatalog = (workspace: WorkspaceLocalFileScope, cwd: string) => {
   const cacheKey = `${workspace.kind}:${workspace.id}:${cwd}`
   const existing = skillCatalogCache.get(cacheKey)
   if (existing) {
-    return existing.promise
+    return existing
   }
 
-  const state: SkillCatalogState = {
-    skills: null,
-    promise: getWorkspaceClient(workspace)
-      .request('skills/list', { cwds: [cwd] })
-      .then((response) => {
-        const entries = normalizeSkillsListResponse(response)
-        const entry = entries.find(candidate => candidate.cwd === cwd) ?? entries[0] ?? null
-        const skills = entry?.skills.filter(skill => skill.enabled) ?? []
-        state.skills = skills
-        return skills
-      })
-      .catch(() => [])
-  }
-  skillCatalogCache.set(cacheKey, state)
-  return state.promise
+  const promise = getWorkspaceClient(workspace)
+    .request('skills/list', { cwds: [cwd] })
+    .then((response) => {
+      const entries = normalizeSkillsListResponse(response)
+      const entry = entries.find(candidate => candidate.cwd === cwd) ?? entries[0] ?? null
+      return entry?.skills.filter(skill => skill.enabled) ?? []
+    })
+    .catch((error: unknown) => {
+      skillCatalogCache.delete(cacheKey)
+      throw error
+    })
+
+  skillCatalogCache.set(cacheKey, promise)
+  return promise
 }
 
 const fallbackLabel = computed(() => {
@@ -84,34 +78,62 @@ const fallbackLabel = computed(() => {
   return `${SKILL_FALLBACK_ICON}${normalizedName}`
 })
 
+const isCurrentSkill = (skill: SkillAutocompleteEntry) => {
+  const normalizedName = props.name.replace(/^\$/u, '')
+  const path = props.path ?? null
+  if (path && skill.path !== path) {
+    return false
+  }
+
+  return skill.name.toLowerCase() === normalizedName.toLowerCase()
+}
+
 const label = computed(() => {
   const skill = resolvedSkill.value
-  return skill?.displayName?.trim()
+  if (!skill || !isCurrentSkill(skill)) {
+    return fallbackLabel.value
+  }
+
+  return skill.displayName?.trim()
     || skill?.name
-    || fallbackLabel.value
 })
 
-watchEffect(async () => {
+watchEffect(async (onCleanup) => {
   const name = props.name.replace(/^\$/u, '')
   const workspace = props.workspace
     ?? (props.projectId ? { kind: 'project' as const, id: props.projectId } : null)
   const cwd = workspaceCwd.value
   const key = workspaceKey.value
+  const path = props.path ?? null
 
-  resolvedSkill.value = null
+  let active = true
+  onCleanup(() => {
+    active = false
+  })
+
   if (!workspace || !cwd || !key) {
+    resolvedSkill.value = null
     return
   }
 
-  const skills = await loadSkillCatalog(workspace, cwd)
-  const path = props.path ?? null
-  resolvedSkill.value = skills.find((skill) => {
-    if (path && skill.path === path) {
-      return true
+  try {
+    const skills = await loadSkillCatalog(workspace, cwd)
+    if (!active) {
+      return
     }
 
-    return skill.name.toLowerCase() === name.toLowerCase()
-  }) ?? null
+    resolvedSkill.value = skills.find((skill) => {
+      if (path && skill.path === path) {
+        return true
+      }
+
+      return skill.name.toLowerCase() === name.toLowerCase()
+    }) ?? null
+  } catch {
+    if (active) {
+      resolvedSkill.value = null
+    }
+  }
 })
 </script>
 

--- a/packages/client/app/components/message-part/SkillReferenceBadge.vue
+++ b/packages/client/app/components/message-part/SkillReferenceBadge.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+import { computed, ref, watchEffect } from 'vue'
+import { useProjects } from '../../composables/useProjects'
+import { useRpc } from '../../composables/useRpc'
+import {
+  normalizeSkillsListResponse,
+  type SkillAutocompleteEntry
+} from '../../../shared/skill-autocomplete'
+import type { WorkspaceLocalFileScope } from '../../../shared/local-files'
+
+const props = defineProps<{
+  name: string
+  path?: string | null
+  raw?: string | null
+  projectId?: string | null
+  workspace?: WorkspaceLocalFileScope | null
+  workspaceRootPath?: string | null
+}>()
+
+const SKILL_FALLBACK_ICON = '🛠️'
+
+type SkillCatalogState = {
+  promise: Promise<SkillAutocompleteEntry[]>
+  skills: SkillAutocompleteEntry[] | null
+}
+
+const skillCatalogCache = new Map<string, SkillCatalogState>()
+
+const { getProject } = useProjects()
+const { getWorkspaceClient } = useRpc()
+
+const resolvedSkill = ref<SkillAutocompleteEntry | null>(null)
+
+const badgeUi = {
+  base: 'align-middle rounded-md bg-[#7c3aed]/15 px-1.5 py-0.5 text-[11px] font-bold text-[#d8b4fe] ring-1 ring-inset ring-[#a855f7]/30 dark:bg-[#7c3aed]/20 dark:text-[#e9d5ff] dark:ring-[#c084fc]/35'
+}
+
+const workspaceKey = computed(() => {
+  if (props.workspace?.id) {
+    return `${props.workspace.kind}:${props.workspace.id}`
+  }
+
+  if (props.projectId) {
+    return `project:${props.projectId}`
+  }
+
+  return null
+})
+
+const workspaceCwd = computed(() => {
+  if (props.workspaceRootPath) {
+    return props.workspaceRootPath
+  }
+
+  return getProject(props.projectId ?? null)?.projectPath ?? null
+})
+
+const loadSkillCatalog = (workspace: WorkspaceLocalFileScope, cwd: string) => {
+  const cacheKey = `${workspace.kind}:${workspace.id}:${cwd}`
+  const existing = skillCatalogCache.get(cacheKey)
+  if (existing) {
+    return existing.promise
+  }
+
+  const state: SkillCatalogState = {
+    skills: null,
+    promise: getWorkspaceClient(workspace)
+      .request('skills/list', { cwds: [cwd] })
+      .then((response) => {
+        const entries = normalizeSkillsListResponse(response)
+        const entry = entries.find(candidate => candidate.cwd === cwd) ?? entries[0] ?? null
+        const skills = entry?.skills.filter(skill => skill.enabled) ?? []
+        state.skills = skills
+        return skills
+      })
+      .catch(() => [])
+  }
+  skillCatalogCache.set(cacheKey, state)
+  return state.promise
+}
+
+const fallbackLabel = computed(() => {
+  const normalizedName = props.name.replace(/^\$/u, '')
+  return `${SKILL_FALLBACK_ICON}${normalizedName}`
+})
+
+const label = computed(() => {
+  const skill = resolvedSkill.value
+  return skill?.displayName?.trim()
+    || skill?.name
+    || fallbackLabel.value
+})
+
+watchEffect(async () => {
+  const name = props.name.replace(/^\$/u, '')
+  const workspace = props.workspace
+    ?? (props.projectId ? { kind: 'project' as const, id: props.projectId } : null)
+  const cwd = workspaceCwd.value
+  const key = workspaceKey.value
+
+  resolvedSkill.value = null
+  if (!workspace || !cwd || !key) {
+    return
+  }
+
+  const skills = await loadSkillCatalog(workspace, cwd)
+  const path = props.path ?? null
+  resolvedSkill.value = skills.find((skill) => {
+    if (path && skill.path === path) {
+      return true
+    }
+
+    return skill.name.toLowerCase() === name.toLowerCase()
+  }) ?? null
+})
+</script>
+
+<template>
+  <UBadge
+    as="span"
+    color="primary"
+    variant="soft"
+    size="sm"
+    :ui="badgeUi"
+    :title="path ?? undefined"
+  >
+    {{ label }}
+  </UBadge>
+</template>

--- a/packages/client/app/components/message-part/Text.vue
+++ b/packages/client/app/components/message-part/Text.vue
@@ -3,11 +3,13 @@ import { Comark } from '@comark/vue'
 import highlight from '@comark/vue/plugins/highlight'
 import math, { Math as ComarkMath } from '@comark/vue/plugins/math'
 import mermaid from '@comark/vue/plugins/mermaid'
-import { computed } from 'vue'
+import { computed, defineComponent, h } from 'vue'
 import { ChatMarkdownMermaid } from './ChatMarkdownMermaid'
 import ReviewPriorityBadge from './ReviewPriorityBadge.vue'
+import SkillReferenceBadge from './SkillReferenceBadge.vue'
 import { createChatMarkdownLocalFileLink } from './createChatMarkdownLocalFileLink'
 import { reviewPriorityBadgePlugin } from '../../utils/review-priority-badge'
+import { skillReferenceBadgePlugin } from '../../utils/skill-reference-badge'
 import type { WorkspaceLocalFileScope } from '../../../shared/local-files'
 
 const props = defineProps<{
@@ -28,14 +30,43 @@ const ChatMarkdownLocalFileLink = createChatMarkdownLocalFileLink(() => ({
   workspaceRootPath: props.workspaceRootPath ?? null
 }))
 
+const ChatMarkdownSkillReferenceBadge = defineComponent({
+  name: 'ChatMarkdownSkillReferenceBadge',
+  props: {
+    name: {
+      type: String,
+      required: true
+    },
+    path: {
+      type: String,
+      default: null
+    },
+    raw: {
+      type: String,
+      default: null
+    }
+  },
+  setup(componentProps) {
+    return () => h(SkillReferenceBadge, {
+      name: componentProps.name,
+      path: componentProps.path,
+      projectId: props.projectId ?? null,
+      workspace: props.workspace ?? null,
+      workspaceRootPath: props.workspaceRootPath ?? null
+    })
+  }
+})
+
 const components = {
   a: ChatMarkdownLocalFileLink,
   math: ComarkMath,
   mermaid: ChatMarkdownMermaid,
-  'review-priority-badge': ReviewPriorityBadge
+  'review-priority-badge': ReviewPriorityBadge,
+  'skill-reference-badge': ChatMarkdownSkillReferenceBadge
 }
 
 const plugins = [
+  skillReferenceBadgePlugin(),
   math(),
   mermaid(),
   reviewPriorityBadgePlugin(),

--- a/packages/client/app/utils/skill-reference-badge.ts
+++ b/packages/client/app/utils/skill-reference-badge.ts
@@ -2,9 +2,10 @@ import type { ComarkElement, ComarkNode, ComarkPlugin, ComarkTree } from '@comar
 
 export const SKILL_REFERENCE_BADGE_TAG = 'skill-reference-badge'
 
-const RAW_SKILL_PATTERN = /^\$([a-z][a-z0-9:._/-]*)/u
-const SKILL_LINK_LABEL_PATTERN = /^\$([a-z][a-z0-9:._/-]*)$/u
+const RAW_SKILL_PATTERN = /^\$([a-z0-9][a-z0-9:._/-]*)/iu
+const SKILL_LINK_LABEL_PATTERN = /^\$([a-z0-9][a-z0-9:._/-]*)$/iu
 const SKILL_MARKDOWN_PATH_PATTERN = /(?:^|[/\\])SKILL\.md(?:$|[#?:])/iu
+const TRAILING_RAW_SKILL_PUNCTUATION_PATTERN = /[.,!?;:]+$/u
 
 type MarkdownItStateInline = {
   src: string
@@ -31,6 +32,24 @@ type MarkdownItParser = {
 
 const isElementNode = (node: ComarkNode): node is ComarkElement => {
   return Array.isArray(node) && typeof node[0] === 'string'
+}
+
+const getRawSkillMatch = (source: string) => {
+  const match = RAW_SKILL_PATTERN.exec(source)
+  const rawName = match?.[1]
+  if (!rawName) {
+    return null
+  }
+
+  const name = rawName.replace(TRAILING_RAW_SKILL_PUNCTUATION_PATTERN, '')
+  if (name.length < 2) {
+    return null
+  }
+
+  return {
+    name,
+    length: name.length + 1
+  }
 }
 
 const createSkillReferenceBadgeNode = (input: {
@@ -87,6 +106,60 @@ const getSkillLinkReference = (node: ComarkElement) => {
   }
 }
 
+const isRawSkillReferenceNode = (node: ComarkNode) => {
+  return isElementNode(node)
+    && node[0] === SKILL_REFERENCE_BADGE_TAG
+    && node[1].raw === 'true'
+}
+
+const removeRawSkillAutoCloseMarkers = (children: ComarkNode[]) => {
+  const nextChildren = [...children]
+  let shouldTrimTrailingMarker = false
+
+  for (let index = 0; index < nextChildren.length; index += 1) {
+    const child = nextChildren[index]
+    if (!child || !isRawSkillReferenceNode(child)) {
+      continue
+    }
+
+    const nextChild = nextChildren[index + 1]
+    if (typeof nextChild === 'string' && nextChild.startsWith('$')) {
+      const trimmed = nextChild.slice(1)
+      if (trimmed) {
+        nextChildren[index + 1] = trimmed
+      } else {
+        nextChildren.splice(index + 1, 1)
+      }
+      continue
+    }
+
+    shouldTrimTrailingMarker = true
+  }
+
+  if (!shouldTrimTrailingMarker) {
+    return nextChildren
+  }
+
+  for (let index = nextChildren.length - 1; index >= 0; index -= 1) {
+    const child = nextChildren[index]
+    if (typeof child !== 'string') {
+      continue
+    }
+
+    const trimmed = child.replace(/\$(\s*)$/u, '$1')
+    if (trimmed !== child) {
+      if (trimmed) {
+        nextChildren[index] = trimmed
+      } else {
+        nextChildren.splice(index, 1)
+      }
+    }
+    break
+  }
+
+  return nextChildren
+}
+
 const transformNode = (node: ComarkNode): ComarkNode => {
   if (!isElementNode(node)) {
     return node
@@ -98,25 +171,9 @@ const transformNode = (node: ComarkNode): ComarkNode => {
   }
 
   const [tag, props, ...children] = node
-  const nextChildren = children.map(child => transformNode(child))
-  const hasRawSkillReference = nextChildren.some((child) => {
-    return isElementNode(child)
-      && child[0] === SKILL_REFERENCE_BADGE_TAG
-      && child[1].raw === 'true'
-  })
-
-  if (hasRawSkillReference) {
-    const lastIndex = nextChildren.length - 1
-    const lastChild = nextChildren[lastIndex]
-    if (typeof lastChild === 'string' && lastChild.endsWith('$')) {
-      const trimmed = lastChild.slice(0, -1)
-      if (trimmed) {
-        nextChildren[lastIndex] = trimmed
-      } else {
-        nextChildren.pop()
-      }
-    }
-  }
+  const nextChildren = removeRawSkillAutoCloseMarkers(
+    children.map(child => transformNode(child))
+  )
 
   return [
     tag,
@@ -135,8 +192,8 @@ export const transformSkillReferenceBadges = (tree: ComarkTree): ComarkTree => {
 const skillReferenceBadgeMarkdownItPlugin = (md: MarkdownItParser) => {
   md.inline.ruler.before('escape', 'skill_reference_badge', (state, silent) => {
     const source = state.src.slice(state.pos, state.posMax)
-    const match = RAW_SKILL_PATTERN.exec(source)
-    if (!match?.[1]) {
+    const match = getRawSkillMatch(source)
+    if (!match) {
       return false
     }
 
@@ -145,11 +202,11 @@ const skillReferenceBadgeMarkdownItPlugin = (md: MarkdownItParser) => {
     }
 
     const token = state.push('mdc_inline_component', SKILL_REFERENCE_BADGE_TAG, 0)
-    token.attrSet('name', match[1])
+    token.attrSet('name', match.name)
     token.attrSet('raw', 'true')
     token.markup = '$'
-    token.content = match[1]
-    state.pos += match[0].length
+    token.content = match.name
+    state.pos += match.length
     return true
   })
 }

--- a/packages/client/app/utils/skill-reference-badge.ts
+++ b/packages/client/app/utils/skill-reference-badge.ts
@@ -1,0 +1,165 @@
+import type { ComarkElement, ComarkNode, ComarkPlugin, ComarkTree } from '@comark/vue'
+
+export const SKILL_REFERENCE_BADGE_TAG = 'skill-reference-badge'
+
+const RAW_SKILL_PATTERN = /^\$([a-z][a-z0-9:._/-]*)/u
+const SKILL_LINK_LABEL_PATTERN = /^\$([a-z][a-z0-9:._/-]*)$/u
+const SKILL_MARKDOWN_PATH_PATTERN = /(?:^|[/\\])SKILL\.md(?:$|[#?:])/iu
+
+type MarkdownItStateInline = {
+  src: string
+  pos: number
+  posMax: number
+  push: (type: string, tag: string, nesting: number) => {
+    attrSet: (name: string, value: string) => void
+    content?: string
+    markup?: string
+  }
+}
+
+type MarkdownItParser = {
+  inline: {
+    ruler: {
+      before: (
+        beforeName: string,
+        ruleName: string,
+        rule: (state: MarkdownItStateInline, silent: boolean) => boolean
+      ) => void
+    }
+  }
+}
+
+const isElementNode = (node: ComarkNode): node is ComarkElement => {
+  return Array.isArray(node) && typeof node[0] === 'string'
+}
+
+const createSkillReferenceBadgeNode = (input: {
+  name: string
+  path?: string | null
+  raw?: boolean
+}): ComarkElement => {
+  return [
+    SKILL_REFERENCE_BADGE_TAG,
+    {
+      name: input.name,
+      ...(input.path ? { path: input.path } : {}),
+      ...(input.raw ? { raw: 'true' } : {})
+    }
+  ]
+}
+
+const decodeSkillHref = (href: unknown) => {
+  if (typeof href !== 'string') {
+    return null
+  }
+
+  try {
+    return decodeURI(href)
+  } catch {
+    return href
+  }
+}
+
+const getSkillLinkReference = (node: ComarkElement) => {
+  if (node[0] !== 'a') {
+    return null
+  }
+
+  const props = node[1]
+  const href = decodeSkillHref(props.href)
+  if (!href || !SKILL_MARKDOWN_PATH_PATTERN.test(href)) {
+    return null
+  }
+
+  const children = node.slice(2)
+  if (children.length !== 1 || typeof children[0] !== 'string') {
+    return null
+  }
+
+  const match = SKILL_LINK_LABEL_PATTERN.exec(children[0].trim())
+  if (!match?.[1]) {
+    return null
+  }
+
+  return {
+    name: match[1],
+    path: href
+  }
+}
+
+const transformNode = (node: ComarkNode): ComarkNode => {
+  if (!isElementNode(node)) {
+    return node
+  }
+
+  const skillReference = getSkillLinkReference(node)
+  if (skillReference) {
+    return createSkillReferenceBadgeNode(skillReference)
+  }
+
+  const [tag, props, ...children] = node
+  const nextChildren = children.map(child => transformNode(child))
+  const hasRawSkillReference = nextChildren.some((child) => {
+    return isElementNode(child)
+      && child[0] === SKILL_REFERENCE_BADGE_TAG
+      && child[1].raw === 'true'
+  })
+
+  if (hasRawSkillReference) {
+    const lastIndex = nextChildren.length - 1
+    const lastChild = nextChildren[lastIndex]
+    if (typeof lastChild === 'string' && lastChild.endsWith('$')) {
+      const trimmed = lastChild.slice(0, -1)
+      if (trimmed) {
+        nextChildren[lastIndex] = trimmed
+      } else {
+        nextChildren.pop()
+      }
+    }
+  }
+
+  return [
+    tag,
+    props,
+    ...nextChildren
+  ]
+}
+
+export const transformSkillReferenceBadges = (tree: ComarkTree): ComarkTree => {
+  return {
+    ...tree,
+    nodes: tree.nodes.map(node => transformNode(node))
+  }
+}
+
+const skillReferenceBadgeMarkdownItPlugin = (md: MarkdownItParser) => {
+  md.inline.ruler.before('escape', 'skill_reference_badge', (state, silent) => {
+    const source = state.src.slice(state.pos, state.posMax)
+    const match = RAW_SKILL_PATTERN.exec(source)
+    if (!match?.[1]) {
+      return false
+    }
+
+    if (silent) {
+      return true
+    }
+
+    const token = state.push('mdc_inline_component', SKILL_REFERENCE_BADGE_TAG, 0)
+    token.attrSet('name', match[1])
+    token.attrSet('raw', 'true')
+    token.markup = '$'
+    token.content = match[1]
+    state.pos += match[0].length
+    return true
+  })
+}
+
+export const skillReferenceBadgePlugin = (): ComarkPlugin => {
+  return {
+    name: 'skill-reference-badge',
+    markdownItPlugins: [skillReferenceBadgeMarkdownItPlugin],
+    post: (state) => {
+      state.tree = transformSkillReferenceBadges(state.tree)
+    }
+  }
+}

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codori/client",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": false,
   "description": "Codori Nuxt dashboard for project browsing, Codex chat, and thread resume.",
   "type": "module",

--- a/packages/client/test/message-part-text.test.ts
+++ b/packages/client/test/message-part-text.test.ts
@@ -70,6 +70,72 @@ vi.mock('@comark/vue', () => {
           })
         }
 
+        type MockComarkNode = string | [string, Record<string, unknown>, ...MockComarkNode[]]
+
+        const renderMockNode = (node: MockComarkNode): ReturnType<typeof h> | string => {
+          if (typeof node === 'string') {
+            return node
+          }
+
+          const [tag, nodeProps, ...children] = node
+          const components = props.components as Record<string, Component>
+          const component = components[tag] ?? tag
+          const renderedChildren = children.map(renderMockNode)
+          return typeof component === 'string'
+            ? h(component, nodeProps, renderedChildren)
+            : h(component, nodeProps, () => renderedChildren)
+        }
+
+        const renderSkillLinkTree = (text: string) => {
+          const skillLinkPattern = /\[\$([a-z][a-z0-9:._/-]*)\]\(([^)]+\/SKILL\.md)\)/giu
+          const nodes: MockComarkNode[] = []
+          let lastIndex = 0
+          let match: RegExpExecArray | null
+
+          while ((match = skillLinkPattern.exec(text)) !== null) {
+            if (match.index > lastIndex) {
+              nodes.push(text.slice(lastIndex, match.index))
+            }
+
+            nodes.push(['a', { href: match[2] }, `$${match[1]}`])
+            lastIndex = match.index + match[0].length
+          }
+
+          if (lastIndex === 0) {
+            return null
+          }
+
+          if (lastIndex < text.length) {
+            nodes.push(text.slice(lastIndex))
+          }
+
+          const state = {
+            markdown: text,
+            tree: {
+              nodes: [['p', {}, ...nodes] as MockComarkNode],
+              frontmatter: {},
+              meta: {}
+            },
+            options: { plugins: props.plugins },
+            tokens: []
+          }
+
+          for (const plugin of props.plugins) {
+            if (
+              plugin
+              && typeof plugin === 'object'
+              && 'post' in plugin
+              && typeof plugin.post === 'function'
+            ) {
+              plugin.post(state)
+            }
+          }
+
+          return h('div', { class: 'mock-comark', 'data-streaming': String(props.streaming) }, [
+            ...state.tree.nodes.map(renderMockNode)
+          ])
+        }
+
         return () => {
           const text = props.markdown
           const components = props.components as Record<string, Component>
@@ -97,6 +163,11 @@ vi.mock('@comark/vue', () => {
               }),
               displayMatch[3]
             ])
+          }
+
+          const skillLinkTree = renderSkillLinkTree(text)
+          if (skillLinkTree) {
+            return skillLinkTree
           }
 
           const inlineMatch = text.match(/^(.*?)\$(.+?)\$(.*)$/)
@@ -128,6 +199,31 @@ vi.mock('@comark/vue', () => {
 
           return h('div', { class: 'mock-comark', 'data-streaming': String(props.streaming) }, text)
         }
+      }
+    })
+  }
+})
+
+vi.mock('../app/components/message-part/SkillReferenceBadge.vue', () => {
+  return {
+    default: defineComponent({
+      name: 'SkillReferenceBadge',
+      props: {
+        name: {
+          type: String,
+          required: true
+        },
+        path: {
+          type: String,
+          default: null
+        }
+      },
+      setup(props) {
+        return () => h('span', {
+          'data-test': 'skill-reference-badge',
+          'data-skill-name': props.name,
+          'data-skill-path': props.path ?? ''
+        }, `$${props.name}`)
       }
     })
   }
@@ -355,5 +451,38 @@ describe('message part text markdown rendering', () => {
       line: null,
       column: null
     })
+  })
+
+  it('renders submitted skill markdown links as skill reference badges through Comark', async () => {
+    const wrapper = await mountText(
+      'assistant',
+      'Use [$imagegen](/Users/demo/.codex/skills/.system/imagegen/SKILL.md) now.'
+    )
+
+    const badge = wrapper.get('[data-test="skill-reference-badge"]')
+    expect(badge.text()).toBe('$imagegen')
+    expect(badge.attributes('data-skill-name')).toBe('imagegen')
+    expect(badge.attributes('data-skill-path')).toBe('/Users/demo/.codex/skills/.system/imagegen/SKILL.md')
+    expect(wrapper.find('a[href="/Users/demo/.codex/skills/.system/imagegen/SKILL.md"]').exists()).toBe(false)
+  })
+
+  it('keeps ordinary markdown links as anchors when the skill badge plugin does not match', async () => {
+    const wrapper = await mountText('assistant', '[docs](https://example.com/docs)')
+
+    expect(wrapper.find('[data-test="skill-reference-badge"]').exists()).toBe(false)
+    expect(wrapper.get('a').attributes('href')).toBe('https://example.com/docs')
+    expect(wrapper.get('a').text()).toBe('docs')
+  })
+
+  it('renders multiple skill references without collapsing surrounding text', async () => {
+    const wrapper = await mountText(
+      'assistant',
+      'Use [$imagegen](/a/imagegen/SKILL.md) and [$browser-use](/b/browser-use/SKILL.md).'
+    )
+
+    const badges = wrapper.findAll('[data-test="skill-reference-badge"]')
+    expect(badges).toHaveLength(2)
+    expect(badges.map(badge => badge.text())).toEqual(['$imagegen', '$browser-use'])
+    expect(wrapper.text()).toContain('Use $imagegen and $browser-use.')
   })
 })

--- a/packages/client/test/message-part-text.test.ts
+++ b/packages/client/test/message-part-text.test.ts
@@ -87,7 +87,7 @@ vi.mock('@comark/vue', () => {
         }
 
         const renderSkillLinkTree = (text: string) => {
-          const skillLinkPattern = /\[\$([a-z][a-z0-9:._/-]*)\]\(([^)]+\/SKILL\.md)\)/giu
+          const skillLinkPattern = /\[\$([a-z0-9][a-z0-9:._/-]*)\]\(([^)]+\/SKILL\.md)\)/giu
           const nodes: MockComarkNode[] = []
           let lastIndex = 0
           let match: RegExpExecArray | null

--- a/packages/client/test/skill-reference-badge-transform.test.ts
+++ b/packages/client/test/skill-reference-badge-transform.test.ts
@@ -102,6 +102,68 @@ describe('skillReferenceBadgePlugin', () => {
     ])
   })
 
+  it('accepts case-insensitive and digit-prefixed skill tokens', async () => {
+    const tree = await parse('Use $ImageGen and $1tool.', {
+      plugins: [
+        skillReferenceBadgePlugin()
+      ]
+    })
+
+    expect(tree.nodes).toEqual([
+      ['p', {},
+        'Use ',
+        [SKILL_REFERENCE_BADGE_TAG, { name: 'ImageGen', raw: 'true' }],
+        ' and ',
+        [SKILL_REFERENCE_BADGE_TAG, { name: '1tool', raw: 'true' }],
+        '.'
+      ]
+    ])
+  })
+
+  it('removes auto-close markers directly after raw skill badges', () => {
+    const tree: ComarkTree = {
+      nodes: [
+        ['p', {},
+          [SKILL_REFERENCE_BADGE_TAG, { name: 'skill-name', raw: 'true' }],
+          '$ and more text'
+        ]
+      ],
+      frontmatter: {},
+      meta: {}
+    }
+
+    const result = transformSkillReferenceBadges(tree)
+
+    expect(result.nodes).toEqual([
+      ['p', {},
+        [SKILL_REFERENCE_BADGE_TAG, { name: 'skill-name', raw: 'true' }],
+        ' and more text'
+      ]
+    ])
+  })
+
+  it('removes trailing auto-close markers after raw skill content', () => {
+    const tree: ComarkTree = {
+      nodes: [
+        ['p', {},
+          [SKILL_REFERENCE_BADGE_TAG, { name: 'skill-name', raw: 'true' }],
+          ' additional text$ '
+        ]
+      ],
+      frontmatter: {},
+      meta: {}
+    }
+
+    const result = transformSkillReferenceBadges(tree)
+
+    expect(result.nodes).toEqual([
+      ['p', {},
+        [SKILL_REFERENCE_BADGE_TAG, { name: 'skill-name', raw: 'true' }],
+        ' additional text '
+      ]
+    ])
+  })
+
   it('does not treat ordinary inline LaTeX as a skill reference', async () => {
     const tree = await parse('Energy: $E = mc^2$.', {
       plugins: [

--- a/packages/client/test/skill-reference-badge-transform.test.ts
+++ b/packages/client/test/skill-reference-badge-transform.test.ts
@@ -1,0 +1,135 @@
+import type { ComarkTree } from '@comark/vue'
+import { parse } from '@comark/vue/parse'
+import { describe, expect, it } from 'vitest'
+
+import {
+  SKILL_REFERENCE_BADGE_TAG,
+  skillReferenceBadgePlugin,
+  transformSkillReferenceBadges
+} from '../app/utils/skill-reference-badge'
+
+describe('transformSkillReferenceBadges', () => {
+  it('replaces submitted skill markdown links with skill badge nodes', () => {
+    const tree: ComarkTree = {
+      nodes: [
+        ['p', {},
+          'Use ',
+          ['a', { href: '/Users/demo/.codex/skills/.system/imagegen/SKILL.md' }, '$imagegen'],
+          ' now.'
+        ]
+      ],
+      frontmatter: {},
+      meta: {}
+    }
+
+    const result = transformSkillReferenceBadges(tree)
+
+    expect(result.nodes).toEqual([
+      ['p', {},
+        'Use ',
+        [
+          SKILL_REFERENCE_BADGE_TAG,
+          {
+            name: 'imagegen',
+            path: '/Users/demo/.codex/skills/.system/imagegen/SKILL.md'
+          }
+        ],
+        ' now.'
+      ]
+    ])
+  })
+
+  it('decodes encoded local skill paths', () => {
+    const tree: ComarkTree = {
+      nodes: [
+        ['p', {},
+          ['a', { href: '/Users/demo/My%20Skills/%ED%85%8C%EC%8A%A4%ED%8A%B8/SKILL.md' }, '$skill-name']
+        ]
+      ],
+      frontmatter: {},
+      meta: {}
+    }
+
+    const result = transformSkillReferenceBadges(tree)
+
+    expect(result.nodes).toEqual([
+      ['p', {},
+        [
+          SKILL_REFERENCE_BADGE_TAG,
+          {
+            name: 'skill-name',
+            path: '/Users/demo/My Skills/테스트/SKILL.md'
+          }
+        ]
+      ]
+    ])
+  })
+
+  it('leaves non-skill links unchanged', () => {
+    const tree: ComarkTree = {
+      nodes: [
+        ['p', {},
+          ['a', { href: 'https://example.com' }, '$imagegen'],
+          ' ',
+          ['a', { href: '/Users/demo/.codex/skills/imagegen/SKILL.md' }, 'imagegen'],
+          ' ',
+          ['a', { href: '/Users/demo/.codex/skills/imagegen/README.md' }, '$imagegen']
+        ]
+      ],
+      frontmatter: {},
+      meta: {}
+    }
+
+    const result = transformSkillReferenceBadges(tree)
+
+    expect(result).toEqual(tree)
+  })
+})
+
+describe('skillReferenceBadgePlugin', () => {
+  it('parses raw skill references before math auto-close consumes them', async () => {
+    const tree = await parse('$skill-name additional text', {
+      plugins: [
+        skillReferenceBadgePlugin()
+      ]
+    })
+
+    expect(tree.nodes).toEqual([
+      ['p', {},
+        [SKILL_REFERENCE_BADGE_TAG, { name: 'skill-name', raw: 'true' }],
+        ' additional text'
+      ]
+    ])
+  })
+
+  it('does not treat ordinary inline LaTeX as a skill reference', async () => {
+    const tree = await parse('Energy: $E = mc^2$.', {
+      plugins: [
+        skillReferenceBadgePlugin()
+      ]
+    })
+
+    expect(tree.nodes).toEqual([
+      ['p', {}, 'Energy: $E = mc^2$.']
+    ])
+  })
+
+  it('does not replace code spans or fenced code', async () => {
+    const tree = await parse([
+      'Inline `$skill-name`.',
+      '',
+      '```text',
+      '$skill-name',
+      '```'
+    ].join('\n'), {
+      plugins: [
+        skillReferenceBadgePlugin()
+      ]
+    })
+
+    expect(tree.nodes).toEqual([
+      ['p', {}, 'Inline ', ['code', {}, '$skill-name'], '.'],
+      ['pre', { language: 'text' }, ['code', { class: 'language-text' }, '$skill-name']]
+    ])
+  })
+})

--- a/packages/client/test/skill-reference-badge.test.ts
+++ b/packages/client/test/skill-reference-badge.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const requestMock = vi.fn()
+
+vi.mock('../app/composables/useProjects', () => {
+  return {
+    useProjects: () => ({
+      getProject: (projectId?: string | null) => projectId
+        ? { projectPath: '/Users/demo/Project/codori' }
+        : null
+    })
+  }
+})
+
+vi.mock('../app/composables/useRpc', () => {
+  return {
+    useRpc: () => ({
+      getWorkspaceClient: () => ({
+        request: requestMock
+      })
+    })
+  }
+})
+
+import SkillReferenceBadge from '../app/components/message-part/SkillReferenceBadge.vue'
+
+const BadgeStub = defineComponent({
+  name: 'UBadge',
+  props: {
+    as: {
+      type: String,
+      default: 'span'
+    },
+    color: {
+      type: String,
+      default: undefined
+    },
+    variant: {
+      type: String,
+      default: undefined
+    },
+    size: {
+      type: String,
+      default: undefined
+    },
+    ui: {
+      type: Object,
+      default: () => ({})
+    },
+    title: {
+      type: String,
+      default: undefined
+    }
+  },
+  setup(props, { slots }) {
+    return () => h(props.as, {
+      class: 'badge-stub',
+      title: props.title,
+      'data-color': props.color,
+      'data-variant': props.variant,
+      'data-size': props.size,
+      'data-base': props.ui?.base ?? ''
+    }, slots.default?.())
+  }
+})
+
+describe('SkillReferenceBadge', () => {
+  beforeEach(() => {
+    requestMock.mockReset()
+  })
+
+  it('renders metadata display names when the skill catalog resolves', async () => {
+    requestMock.mockResolvedValue({
+      data: [{
+        cwd: '/Users/demo/Project/codori',
+        errors: [],
+        skills: [{
+          name: 'imagegen',
+          description: 'Generate images',
+          enabled: true,
+          path: '/Users/demo/.codex/skills/.system/imagegen/SKILL.md',
+          scope: 'system',
+          interface: {
+            displayName: 'Image Generator'
+          }
+        }]
+      }]
+    })
+
+    const wrapper = mount(SkillReferenceBadge, {
+      props: {
+        name: 'imagegen',
+        path: '/Users/demo/.codex/skills/.system/imagegen/SKILL.md',
+        workspace: { kind: 'project', id: 'demo' },
+        workspaceRootPath: '/Users/demo/Project/codori'
+      },
+      global: {
+        stubs: {
+          UBadge: BadgeStub
+        }
+      }
+    })
+
+    await flushPromises()
+
+    expect(wrapper.text()).toBe('Image Generator')
+    expect(wrapper.get('.badge-stub').attributes('data-color')).toBe('primary')
+    expect(wrapper.get('.badge-stub').attributes('data-variant')).toBe('soft')
+    expect(wrapper.get('.badge-stub').attributes('data-base')).toContain('bg-[#7c3aed]/15')
+    expect(wrapper.get('.badge-stub').attributes('title')).toBe('/Users/demo/.codex/skills/.system/imagegen/SKILL.md')
+  })
+
+  it('falls back to a skill marker and token name when metadata is unavailable', async () => {
+    requestMock.mockResolvedValue({
+      data: [{
+        cwd: '/Users/demo/Project/codori',
+        errors: [],
+        skills: []
+      }]
+    })
+
+    const wrapper = mount(SkillReferenceBadge, {
+      props: {
+        name: '$missing-skill',
+        workspace: { kind: 'project', id: 'demo' },
+        workspaceRootPath: '/Users/demo/Project/codori'
+      },
+      global: {
+        stubs: {
+          UBadge: BadgeStub
+        }
+      }
+    })
+
+    await flushPromises()
+
+    expect(wrapper.text()).toBe('🛠️missing-skill')
+  })
+})

--- a/packages/client/test/skill-reference-badge.test.ts
+++ b/packages/client/test/skill-reference-badge.test.ts
@@ -6,6 +6,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const requestMock = vi.fn()
 
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+
+  return {
+    promise,
+    resolve,
+    reject
+  }
+}
+
 vi.mock('../app/composables/useProjects', () => {
   return {
     useProjects: () => ({
@@ -139,5 +154,125 @@ describe('SkillReferenceBadge', () => {
     await flushPromises()
 
     expect(wrapper.text()).toBe('🛠️missing-skill')
+  })
+
+  it('retries catalog fetches after transient failures', async () => {
+    requestMock
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce({
+        data: [{
+          cwd: '/Users/demo/Project/retry',
+          errors: [],
+          skills: [{
+            name: 'retry-skill',
+            description: 'Retry skill',
+            enabled: true,
+            path: '/Users/demo/.codex/skills/retry-skill/SKILL.md',
+            scope: 'user',
+            interface: {
+              displayName: 'Retry Skill'
+            }
+          }]
+        }]
+      })
+
+    const firstWrapper = mount(SkillReferenceBadge, {
+      props: {
+        name: 'retry-skill',
+        workspace: { kind: 'project', id: 'retry' },
+        workspaceRootPath: '/Users/demo/Project/retry'
+      },
+      global: {
+        stubs: {
+          UBadge: BadgeStub
+        }
+      }
+    })
+
+    await flushPromises()
+    expect(firstWrapper.text()).toBe('🛠️retry-skill')
+    firstWrapper.unmount()
+
+    const secondWrapper = mount(SkillReferenceBadge, {
+      props: {
+        name: 'retry-skill',
+        workspace: { kind: 'project', id: 'retry' },
+        workspaceRootPath: '/Users/demo/Project/retry'
+      },
+      global: {
+        stubs: {
+          UBadge: BadgeStub
+        }
+      }
+    })
+
+    await flushPromises()
+
+    expect(requestMock).toHaveBeenCalledTimes(2)
+    expect(secondWrapper.text()).toBe('Retry Skill')
+  })
+
+  it('ignores stale catalog responses after workspace changes', async () => {
+    const firstRequest = createDeferred<unknown>()
+    const secondRequest = createDeferred<unknown>()
+    requestMock
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockReturnValueOnce(secondRequest.promise)
+
+    const wrapper = mount(SkillReferenceBadge, {
+      props: {
+        name: 'race-skill',
+        workspace: { kind: 'project', id: 'race' },
+        workspaceRootPath: '/Users/demo/Project/race-a'
+      },
+      global: {
+        stubs: {
+          UBadge: BadgeStub
+        }
+      }
+    })
+
+    await wrapper.setProps({
+      workspaceRootPath: '/Users/demo/Project/race-b'
+    })
+
+    secondRequest.resolve({
+      data: [{
+        cwd: '/Users/demo/Project/race-b',
+        errors: [],
+        skills: [{
+          name: 'race-skill',
+          description: 'Fresh skill',
+          enabled: true,
+          path: '/Users/demo/.codex/skills/race-skill/SKILL.md',
+          scope: 'user',
+          interface: {
+            displayName: 'Fresh Skill'
+          }
+        }]
+      }]
+    })
+    await flushPromises()
+    expect(wrapper.text()).toBe('Fresh Skill')
+
+    firstRequest.resolve({
+      data: [{
+        cwd: '/Users/demo/Project/race-a',
+        errors: [],
+        skills: [{
+          name: 'race-skill',
+          description: 'Stale skill',
+          enabled: true,
+          path: '/Users/demo/.codex/skills/race-skill/SKILL.md',
+          scope: 'user',
+          interface: {
+            displayName: 'Stale Skill'
+          }
+        }]
+      }]
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toBe('Fresh Skill')
   })
 })

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codori/server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": false,
   "description": "Codori server for Git project discovery, Codex runtime management, and bundled dashboard serving.",
   "type": "module",


### PR DESCRIPTION
## Summary
- Render submitted skill markdown links as compact skill badges.
- Intercept raw `$skill-name` references before inline math parsing consumes the text.
- Resolve badge labels from skill metadata when available, with a stable fallback label when metadata is unavailable.

## Validation
- `pnpm --filter @codori/client test -- skill-reference-badge message-part-text`
- `pnpm --filter @codori/client lint`
- `pnpm --filter @codori/client typecheck`

Note: typecheck exits successfully, while the existing Vue tooling warning about `vue-router/volar/sfc-route-blocks` is still printed.