### PR TITLE
Restore live stream reactivation recovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codori",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "packageManager": "pnpm@10.33.2",
   "scripts": {
     "build": "pnpm --filter @codori/client build && pnpm --filter @codori/server build",

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -31,6 +31,12 @@ import {
   shouldApplyNotificationWithoutTurnId
 } from '../utils/chat-turn-engagement'
 import { isFocusWithinContainer } from '../utils/slash-prompt-focus'
+import {
+  isConstrainedBrowserRequiringDeferredSync,
+  resumeThreadStreamAfterReactivation,
+  shouldAttemptThreadReactivationSync,
+  type ThreadReactivationReason
+} from '../utils/thread-reactivation'
 import { useChatAttachments, type DraftAttachment } from '../composables/useChatAttachments'
 import { useChatPlanWorkflow } from '../composables/useChatPlanWorkflow'
 import { useChatReviewWorkflow } from '../composables/useChatReviewWorkflow'
@@ -85,6 +91,7 @@ import type { ModelListResponse } from '~~/shared/generated/codex-app-server/v2/
 import type { ThreadReadResponse } from '~~/shared/generated/codex-app-server/v2/ThreadReadResponse'
 import type { Thread } from '~~/shared/generated/codex-app-server/v2/Thread'
 import type { ThreadItem } from '~~/shared/generated/codex-app-server/v2/ThreadItem'
+import type { ThreadResumeParams } from '~~/shared/generated/codex-app-server/v2/ThreadResumeParams'
 import type { ThreadResumeResponse } from '~~/shared/generated/codex-app-server/v2/ThreadResumeResponse'
 import type { ThreadStartResponse } from '~~/shared/generated/codex-app-server/v2/ThreadStartResponse'
 import type { TurnStartResponse } from '~~/shared/generated/codex-app-server/v2/TurnStartResponse'
@@ -903,6 +910,13 @@ const syncPromptSelectionFromThread = (
 ) => {
   normalizePromptSelection(model ?? null, effort ?? null)
 }
+
+const buildThreadResumeParams = (threadId: string): ThreadResumeParams => ({
+  threadId,
+  cwd: selectedProject.value?.projectPath ?? null,
+  approvalPolicy: 'never',
+  persistExtendedHistory: true
+})
 
 const loadPromptControls = async () => {
   if (promptControlsLoaded.value) {
@@ -2480,12 +2494,7 @@ const hydrateThread = async (threadId: string) => {
         setSessionLiveStream(nextLiveStream)
       }
 
-      const resumeResponse = await client.request<ThreadResumeResponse>('thread/resume', {
-        threadId,
-        cwd: selectedProject.value?.projectPath ?? null,
-        approvalPolicy: 'never',
-        persistExtendedHistory: true
-      })
+      const resumeResponse = await client.request<ThreadResumeResponse>('thread/resume', buildThreadResumeParams(threadId))
       const response = await client.request<ThreadReadResponse>('thread/read', {
         threadId,
         includeTurns: true
@@ -2581,7 +2590,11 @@ const hasPotentiallyMissedThreadOutput = () =>
     )
   )
 
-const shouldSyncThreadAfterReactivation = (now: number) => {
+const shouldSyncThreadAfterReactivation = (
+  now: number,
+  reason: ThreadReactivationReason,
+  transportConnected: boolean
+) => {
   if (sendMessageLocked.value || pendingThreadHydration || session.pendingLiveStream) {
     return false
   }
@@ -2598,47 +2611,66 @@ const shouldSyncThreadAfterReactivation = (now: number) => {
     return false
   }
 
-  if (lastWorkspaceDeactivatedAt === null) {
+  const deactivatedAt = lastWorkspaceDeactivatedAt
+  const hadDocumentDeactivation = deactivatedAt !== null
+  if (!shouldAttemptThreadReactivationSync({
+    reason,
+    browserRequiresDeferredSync: isConstrainedBrowserRequiringDeferredSync(),
+    transportConnected,
+    hadDocumentDeactivation
+  })) {
+    return false
+  }
+
+  if (!transportConnected) {
     return true
   }
 
-  return now - lastWorkspaceDeactivatedAt >= THREAD_REACTIVATION_INACTIVE_GRACE_MS
+  return !hadDocumentDeactivation
+    || now - deactivatedAt >= THREAD_REACTIVATION_INACTIVE_GRACE_MS
 }
 
-const syncActiveThreadAfterReactivation = (reason: string) => {
+const syncActiveThreadAfterReactivation = (reason: ThreadReactivationReason) => {
   if (pendingThreadReactivationSync) {
     return pendingThreadReactivationSync
   }
 
-  const now = Date.now()
-  if (!shouldSyncThreadAfterReactivation(now)) {
-    return null
-  }
-
-  lastThreadReactivationSyncAt = now
   const threadId = activeThreadId.value
   if (!threadId) {
     return null
   }
 
+  const client = getRuntimeClient()
+  const now = Date.now()
+  if (!shouldSyncThreadAfterReactivation(now, reason, client.isConnected())) {
+    return null
+  }
+
+  lastThreadReactivationSyncAt = now
+
   const syncPromise = (async () => {
     try {
       await ensureProjectRuntime()
-      const client = getRuntimeClient()
-      await client.reconnect()
+      await ensureObservedThreadSubscription()
 
-      const response = await client.request<ThreadReadResponse>('thread/read', {
-        threadId,
-        includeTurns: true
-      })
+      const { resumeResponse, readResponse } = await resumeThreadStreamAfterReactivation(
+        client,
+        buildThreadResumeParams(threadId)
+      )
       if (activeThreadId.value !== threadId) {
         return
       }
 
-      syncThreadSnapshot(response.thread)
+      syncPromptSelectionFromThread(
+        resumeResponse.model ?? null,
+        (resumeResponse.reasoningEffort as ReasoningEffort | null | undefined) ?? null
+      )
+      refreshWorkspaceGitBranchesInBackground('thread/resume')
+      syncThreadSnapshot(readResponse.thread)
       markAwaitingAssistantOutput(false)
+      lastWorkspaceDeactivatedAt = null
 
-      const activeTurn = findActiveTurn(response.thread)
+      const activeTurn = findActiveTurn(readResponse.thread)
       if (!activeTurn) {
         clearLiveStream()
         if (!error.value) {
@@ -3878,6 +3910,12 @@ onMounted(() => {
     const handleThreadWorkspaceFocus = () => {
       void syncActiveThreadAfterReactivation('window/focus')
     }
+    const handleThreadWorkspaceResume = () => {
+      void syncActiveThreadAfterReactivation('document/resume')
+    }
+    const handleThreadWorkspacePageShow = () => {
+      void syncActiveThreadAfterReactivation('window/pageshow')
+    }
     const handleThreadWorkspaceInteraction = () => {
       void syncActiveThreadAfterReactivation('window/interaction')
     }
@@ -3887,9 +3925,9 @@ onMounted(() => {
 
     document.addEventListener('visibilitychange', handleThreadWorkspaceVisible)
     document.addEventListener('freeze', markThreadWorkspaceDeactivated)
-    document.addEventListener('resume', handleThreadWorkspaceFocus)
+    document.addEventListener('resume', handleThreadWorkspaceResume)
     window.addEventListener('pagehide', markThreadWorkspaceDeactivated)
-    window.addEventListener('pageshow', handleThreadWorkspaceFocus)
+    window.addEventListener('pageshow', handleThreadWorkspacePageShow)
     window.addEventListener('focus', handleThreadWorkspaceFocus)
     window.addEventListener('online', handleThreadWorkspaceOnline)
     window.addEventListener('pointerdown', handleThreadWorkspaceInteraction, { passive: true })
@@ -3897,9 +3935,9 @@ onMounted(() => {
     releaseThreadReactivationListeners = () => {
       document.removeEventListener('visibilitychange', handleThreadWorkspaceVisible)
       document.removeEventListener('freeze', markThreadWorkspaceDeactivated)
-      document.removeEventListener('resume', handleThreadWorkspaceFocus)
+      document.removeEventListener('resume', handleThreadWorkspaceResume)
       window.removeEventListener('pagehide', markThreadWorkspaceDeactivated)
-      window.removeEventListener('pageshow', handleThreadWorkspaceFocus)
+      window.removeEventListener('pageshow', handleThreadWorkspacePageShow)
       window.removeEventListener('focus', handleThreadWorkspaceFocus)
       window.removeEventListener('online', handleThreadWorkspaceOnline)
       window.removeEventListener('pointerdown', handleThreadWorkspaceInteraction)

--- a/packages/client/app/utils/thread-reactivation.ts
+++ b/packages/client/app/utils/thread-reactivation.ts
@@ -1,0 +1,111 @@
+import type { ThreadReadParams } from '~~/shared/generated/codex-app-server/v2/ThreadReadParams'
+import type { ThreadReadResponse } from '~~/shared/generated/codex-app-server/v2/ThreadReadResponse'
+import type { ThreadResumeParams } from '~~/shared/generated/codex-app-server/v2/ThreadResumeParams'
+import type { ThreadResumeResponse } from '~~/shared/generated/codex-app-server/v2/ThreadResumeResponse'
+
+export type ThreadReactivationReason =
+  | 'window/visible'
+  | 'window/focus'
+  | 'window/interaction'
+  | 'window/online'
+  | 'window/pageshow'
+  | 'document/resume'
+
+type BrowserRuntime = {
+  userAgent?: string
+  platform?: string
+  maxTouchPoints?: number
+  userAgentData?: {
+    mobile?: boolean
+    platform?: string
+  }
+}
+
+type ThreadReactivationResumeClient = {
+  reconnect(): Promise<void>
+  request<T>(method: 'thread/resume', params: ThreadResumeParams): Promise<T>
+  request<T>(method: 'thread/read', params: ThreadReadParams): Promise<T>
+}
+
+export type ThreadReactivationResumeResult = {
+  resumeResponse: ThreadResumeResponse
+  readResponse: ThreadReadResponse
+}
+
+const desktopRecoveryReasons = new Set<ThreadReactivationReason>([
+  'window/online',
+  'window/pageshow',
+  'document/resume'
+])
+
+const resolveBrowserRuntime = (): BrowserRuntime | null => {
+  if (typeof navigator === 'undefined') {
+    return null
+  }
+
+  const runtime = navigator as BrowserRuntime
+  return {
+    userAgent: runtime.userAgent,
+    platform: runtime.platform,
+    maxTouchPoints: runtime.maxTouchPoints,
+    userAgentData: runtime.userAgentData
+  }
+}
+
+export const isConstrainedBrowserRequiringDeferredSync = (
+  runtime: BrowserRuntime | null = resolveBrowserRuntime()
+) => {
+  if (!runtime) {
+    return false
+  }
+
+  const userAgent = runtime.userAgent?.toLowerCase() ?? ''
+  const platform = runtime.platform?.toLowerCase() ?? ''
+  const uaDataPlatform = runtime.userAgentData?.platform?.toLowerCase() ?? ''
+  const maxTouchPoints = runtime.maxTouchPoints ?? 0
+
+  const hasMobileUserAgent = /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini|windows phone/.test(userAgent)
+  const isMobileClientHint = runtime.userAgentData?.mobile === true
+  const isAndroidClientHint = uaDataPlatform === 'android'
+  const isIPadOSDesktopMode = platform === 'macintel' && maxTouchPoints > 1
+
+  return hasMobileUserAgent
+    || isMobileClientHint
+    || isAndroidClientHint
+    || isIPadOSDesktopMode
+}
+
+export const shouldAttemptThreadReactivationSync = (input: {
+  reason: ThreadReactivationReason
+  browserRequiresDeferredSync: boolean
+  transportConnected: boolean
+  hadDocumentDeactivation: boolean
+}) => {
+  if (!input.transportConnected) {
+    return true
+  }
+
+  if (desktopRecoveryReasons.has(input.reason)) {
+    return true
+  }
+
+  return input.browserRequiresDeferredSync && input.hadDocumentDeactivation
+}
+
+export const resumeThreadStreamAfterReactivation = async (
+  client: ThreadReactivationResumeClient,
+  resumeParams: ThreadResumeParams
+): Promise<ThreadReactivationResumeResult> => {
+  await client.reconnect()
+
+  const resumeResponse = await client.request<ThreadResumeResponse>('thread/resume', resumeParams)
+  const readResponse = await client.request<ThreadReadResponse>('thread/read', {
+    threadId: resumeParams.threadId,
+    includeTurns: true
+  })
+
+  return {
+    resumeResponse,
+    readResponse
+  }
+}

--- a/packages/client/app/utils/thread-reactivation.ts
+++ b/packages/client/app/utils/thread-reactivation.ts
@@ -38,6 +38,11 @@ const desktopRecoveryReasons = new Set<ThreadReactivationReason>([
   'document/resume'
 ])
 
+const desktopDeactivationRecoveryReasons = new Set<ThreadReactivationReason>([
+  'window/visible',
+  'window/focus'
+])
+
 const resolveBrowserRuntime = (): BrowserRuntime | null => {
   if (typeof navigator === 'undefined') {
     return null
@@ -86,6 +91,10 @@ export const shouldAttemptThreadReactivationSync = (input: {
   }
 
   if (desktopRecoveryReasons.has(input.reason)) {
+    return true
+  }
+
+  if (input.hadDocumentDeactivation && desktopDeactivationRecoveryReasons.has(input.reason)) {
     return true
   }
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codori/client",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": false,
   "description": "Codori Nuxt dashboard for project browsing, Codex chat, and thread resume.",
   "type": "module",

--- a/packages/client/shared/codex-rpc.ts
+++ b/packages/client/shared/codex-rpc.ts
@@ -304,6 +304,10 @@ export class CodexRpcClient {
     }
   }
 
+  isConnected() {
+    return this.initialized && this.socket?.readyState === WebSocket.OPEN
+  }
+
   async connect() {
     if (this.initialized && this.socket?.readyState === WebSocket.OPEN) {
       return

--- a/packages/client/test/thread-reactivation.test.ts
+++ b/packages/client/test/thread-reactivation.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  isConstrainedBrowserRequiringDeferredSync,
+  resumeThreadStreamAfterReactivation,
+  shouldAttemptThreadReactivationSync
+} from '../app/utils/thread-reactivation'
+import type { ThreadReadResponse } from '../shared/generated/codex-app-server/v2/ThreadReadResponse'
+import type { ThreadResumeResponse } from '../shared/generated/codex-app-server/v2/ThreadResumeResponse'
+
+describe('thread reactivation policy', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('keeps desktop browsers in continuous streaming mode by default', () => {
+    expect(isConstrainedBrowserRequiringDeferredSync({
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+      platform: 'MacIntel',
+      maxTouchPoints: 0
+    })).toBe(false)
+
+    expect(isConstrainedBrowserRequiringDeferredSync({
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      platform: 'Win32',
+      maxTouchPoints: 0
+    })).toBe(false)
+  })
+
+  it('uses deferred reactivation sync for constrained mobile browsers', () => {
+    expect(isConstrainedBrowserRequiringDeferredSync({
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+      platform: 'iPhone',
+      maxTouchPoints: 5
+    })).toBe(true)
+
+    expect(isConstrainedBrowserRequiringDeferredSync({
+      userAgent: 'Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+      platform: 'Linux armv8l',
+      maxTouchPoints: 5
+    })).toBe(true)
+  })
+
+  it('recognizes iPadOS Safari desktop-mode user agents as constrained', () => {
+    expect(isConstrainedBrowserRequiringDeferredSync({
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+      platform: 'MacIntel',
+      maxTouchPoints: 5
+    })).toBe(true)
+  })
+
+  it('does not resync desktop streams on ordinary focus or interaction while transport is connected', () => {
+    expect(shouldAttemptThreadReactivationSync({
+      reason: 'window/focus',
+      browserRequiresDeferredSync: false,
+      transportConnected: true,
+      hadDocumentDeactivation: true
+    })).toBe(false)
+
+    expect(shouldAttemptThreadReactivationSync({
+      reason: 'window/interaction',
+      browserRequiresDeferredSync: false,
+      transportConnected: true,
+      hadDocumentDeactivation: true
+    })).toBe(false)
+  })
+
+  it('keeps desktop recovery available when the transport was dropped', () => {
+    expect(shouldAttemptThreadReactivationSync({
+      reason: 'window/focus',
+      browserRequiresDeferredSync: false,
+      transportConnected: false,
+      hadDocumentDeactivation: false
+    })).toBe(true)
+  })
+
+  it('uses deferred sync for constrained browsers only after a deactivation signal', () => {
+    expect(shouldAttemptThreadReactivationSync({
+      reason: 'window/visible',
+      browserRequiresDeferredSync: true,
+      transportConnected: true,
+      hadDocumentDeactivation: true
+    })).toBe(true)
+
+    expect(shouldAttemptThreadReactivationSync({
+      reason: 'window/focus',
+      browserRequiresDeferredSync: true,
+      transportConnected: true,
+      hadDocumentDeactivation: false
+    })).toBe(false)
+  })
+
+  it('rehydrates through thread/resume before thread/read after reconnecting', async () => {
+    const resumeResponse = { thread: { id: 'thread-1' } } as unknown as ThreadResumeResponse
+    const readResponse = { thread: { id: 'thread-1', turns: [] } } as unknown as ThreadReadResponse
+    const calls: string[] = []
+    const client = {
+      reconnect: vi.fn(async () => {
+        calls.push('reconnect')
+      }),
+      request: vi.fn(async (method: string) => {
+        calls.push(method)
+        return method === 'thread/resume' ? resumeResponse : readResponse
+      })
+    }
+
+    await expect(resumeThreadStreamAfterReactivation(client, {
+      threadId: 'thread-1',
+      cwd: '/tmp/project',
+      approvalPolicy: 'never',
+      persistExtendedHistory: true
+    })).resolves.toEqual({
+      resumeResponse,
+      readResponse
+    })
+
+    expect(calls).toEqual([
+      'reconnect',
+      'thread/resume',
+      'thread/read'
+    ])
+    expect(client.request).toHaveBeenNthCalledWith(1, 'thread/resume', {
+      threadId: 'thread-1',
+      cwd: '/tmp/project',
+      approvalPolicy: 'never',
+      persistExtendedHistory: true
+    })
+    expect(client.request).toHaveBeenNthCalledWith(2, 'thread/read', {
+      threadId: 'thread-1',
+      includeTurns: true
+    })
+  })
+})

--- a/packages/client/test/thread-reactivation.test.ts
+++ b/packages/client/test/thread-reactivation.test.ts
@@ -55,8 +55,31 @@ describe('thread reactivation policy', () => {
       reason: 'window/focus',
       browserRequiresDeferredSync: false,
       transportConnected: true,
-      hadDocumentDeactivation: true
+      hadDocumentDeactivation: false
     })).toBe(false)
+
+    expect(shouldAttemptThreadReactivationSync({
+      reason: 'window/interaction',
+      browserRequiresDeferredSync: false,
+      transportConnected: true,
+      hadDocumentDeactivation: false
+    })).toBe(false)
+  })
+
+  it('recovers desktop streams after deactivation even when the transport appears connected', () => {
+    expect(shouldAttemptThreadReactivationSync({
+      reason: 'window/visible',
+      browserRequiresDeferredSync: false,
+      transportConnected: true,
+      hadDocumentDeactivation: true
+    })).toBe(true)
+
+    expect(shouldAttemptThreadReactivationSync({
+      reason: 'window/focus',
+      browserRequiresDeferredSync: false,
+      transportConnected: true,
+      hadDocumentDeactivation: true
+    })).toBe(true)
 
     expect(shouldAttemptThreadReactivationSync({
       reason: 'window/interaction',

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codori/server",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": false,
   "description": "Codori server for Git project discovery, Codex runtime management, and bundled dashboard serving.",
   "type": "module",


### PR DESCRIPTION
## Summary
- Add an explicit browser reactivation policy so connected desktop browsers keep applying live stream updates on ordinary focus and interaction events.
- Keep recovery available for dropped desktop transports, page lifecycle recovery, and constrained mobile/iPadOS browsers.
- Rehydrate reactivated active turns with reconnect -> thread/resume -> thread/read, then restore the live turn subscription so following deltas continue streaming.
- Address PR review by recovering desktop streams on window visible/focus after a document deactivation even when the WebSocket still appears open.
- Bump root, client, and server package patch versions from 0.3.2 to 0.3.3.

## Review Context
- Supersedes the implementation approach in PR #62.
- Avoids the two unresolved review risks there: removing desktop dropped-transport recovery, and missing iPadOS Safari desktop-mode user agents.
- The local transport is WebSocket JSON-RPC in this codebase even though the issue text refers to SSE.

## Commits
- 3662f0d fix: add thread reactivation recovery policy
- fcf1e48 fix: restore live thread reactivation streaming
- a123067 fix: recover desktop streams after deactivation
- 70951e8 chore: bump package versions to 0.3.3

## Validation
- pnpm --filter @codori/client exec vitest run test/thread-reactivation.test.ts test/codex-rpc.test.ts
- pnpm --filter @codori/client lint
- pnpm --filter @codori/client typecheck
- pnpm --filter @codori/client test
- pnpm --filter @codori/client build
- pnpm install --lockfile-only --ignore-scripts

Typecheck/build still print existing Nuxt/Volar and sourcemap/chunk-size warnings, but both commands exit successfully. The lockfile-only install did not change pnpm-lock.yaml for the workspace package version bump.
