### PR TITLE
fix: restore hydrated turn UI state

### DIFF
--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -33,7 +33,9 @@ import {
 import { isFocusWithinContainer } from '../utils/slash-prompt-focus'
 import {
   isConstrainedBrowserRequiringDeferredSync,
+  isActiveTurnStatus,
   resumeThreadStreamAfterReactivation,
+  resolveHydratedActiveTurn,
   shouldAttemptThreadReactivationSync,
   type ThreadReactivationReason
 } from '../utils/thread-reactivation'
@@ -1018,14 +1020,6 @@ let fileAutocompleteRequestSequence = 0
 const THREAD_REACTIVATION_SYNC_MIN_INTERVAL_MS = 8_000
 const THREAD_REACTIVATION_INACTIVE_GRACE_MS = 500
 
-const isActiveTurnStatus = (value: string | null | undefined) => {
-  if (!value) {
-    return false
-  }
-
-  return !/(completed|failed|error|cancelled|canceled|interrupted|stopped)/i.test(value)
-}
-
 const currentLiveStream = () =>
   session.liveStream?.threadId === activeThreadId.value
     ? session.liveStream
@@ -1166,6 +1160,17 @@ const replayBufferedNotifications = (liveStream: LiveStream) => {
 
     applyNotification(notification)
   }
+}
+
+const restoreHydratedLiveStreamTurn = (
+  liveStream: LiveStream,
+  activeTurnId: string
+) => {
+  setLiveStreamTurnId(liveStream, activeTurnId)
+
+  replayBufferedNotifications(liveStream)
+
+  return session.liveStream === liveStream ? liveStream.turnId : null
 }
 
 const clearLiveStream = (reason?: Error) => {
@@ -2464,9 +2469,6 @@ async function ensureProjectRuntime() {
   await startProject(workspaceId.value)
 }
 
-const findActiveTurn = (thread: Thread) =>
-  thread.turns.findLast(turn => isActiveTurnStatus(turn.status))
-
 const syncThreadSnapshot = (thread: Thread) => {
   activeThreadId.value = thread.id
   threadTitle.value = resolveThreadSummaryTitle(thread)
@@ -2525,24 +2527,28 @@ const hydrateThread = async (threadId: string) => {
       refreshWorkspaceGitBranchesInBackground('thread/resume')
       syncThreadSnapshot(response.thread)
       markAwaitingAssistantOutput(false)
-      const activeTurn = findActiveTurn(response.thread)
+      const activeTurn = resolveHydratedActiveTurn({
+        readThread: response.thread,
+        resumeThread: resumeResponse.thread
+      })
       const liveStream = session.liveStream
+      const activeTurnId = activeTurn?.id ?? null
 
-      if (liveStream) {
-        const bufferedTurnId = activeTurn?.id
-          ?? liveStream.bufferedNotifications
-            .map(notificationTurnId)
-            .find((turnId): turnId is string => Boolean(turnId))
-
-        if (bufferedTurnId) {
-          setLiveStreamTurnId(liveStream, bufferedTurnId)
+      if (!activeTurnId) {
+        if (session.liveStream === liveStream) {
+          clearLiveStream()
         }
-
-        replayBufferedNotifications(liveStream)
+        if (!error.value) {
+          status.value = 'ready'
+        }
+        return
       }
 
-      if (!activeTurn) {
-        clearLiveStream()
+      const restoredTurnId = liveStream
+        ? restoreHydratedLiveStreamTurn(liveStream, activeTurnId)
+        : activeTurnId
+
+      if (!restoredTurnId) {
         if (!error.value) {
           status.value = 'ready'
         }
@@ -2554,18 +2560,8 @@ const hydrateThread = async (threadId: string) => {
         return
       }
 
-      setLiveStreamTurnId(session.liveStream, activeTurn.id)
+      setLiveStreamTurnId(session.liveStream, restoredTurnId)
       status.value = 'streaming'
-
-      const pendingNotifications = session.liveStream.bufferedNotifications.splice(0, session.liveStream.bufferedNotifications.length)
-      for (const notification of pendingNotifications) {
-        const turnId = notificationTurnId(notification)
-        if (turnId && turnId !== activeTurn.id) {
-          continue
-        }
-
-        applyNotification(notification)
-      }
     } catch (caughtError) {
       clearLiveStream()
       const errorMessage = caughtError instanceof Error ? caughtError.message : String(caughtError)
@@ -2684,9 +2680,17 @@ const syncActiveThreadAfterReactivation = (reason: ThreadReactivationReason) => 
       markAwaitingAssistantOutput(false)
       lastWorkspaceDeactivatedAt = null
 
-      const activeTurn = findActiveTurn(readResponse.thread)
-      if (!activeTurn) {
-        clearLiveStream()
+      const activeTurn = resolveHydratedActiveTurn({
+        readThread: readResponse.thread,
+        resumeThread: resumeResponse.thread
+      })
+      const liveStream = await ensureObservedThreadSubscription()
+      const activeTurnId = activeTurn?.id ?? null
+
+      if (!activeTurnId) {
+        if (session.liveStream === liveStream) {
+          clearLiveStream()
+        }
         if (!error.value) {
           status.value = 'ready'
         }
@@ -2696,11 +2700,20 @@ const syncActiveThreadAfterReactivation = (reason: ThreadReactivationReason) => 
         return
       }
 
-      const liveStream = await ensureObservedThreadSubscription()
-      if (liveStream) {
-        setLiveStreamTurnId(liveStream, activeTurn.id)
-        replayBufferedNotifications(liveStream)
+      const restoredTurnId = liveStream
+        ? restoreHydratedLiveStreamTurn(liveStream, activeTurnId)
+        : activeTurnId
+
+      if (!restoredTurnId) {
+        if (!error.value) {
+          status.value = 'ready'
+        }
+        if (pinnedToBottom.value) {
+          void scheduleScrollToBottom('auto')
+        }
+        return
       }
+
       status.value = 'streaming'
       if (pinnedToBottom.value) {
         void scheduleScrollToBottom('auto')

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -2555,12 +2555,6 @@ const hydrateThread = async (threadId: string) => {
         return
       }
 
-      if (!session.liveStream) {
-        status.value = 'streaming'
-        return
-      }
-
-      setLiveStreamTurnId(session.liveStream, restoredTurnId)
       status.value = 'streaming'
     } catch (caughtError) {
       clearLiveStream()

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -31,6 +31,7 @@ import {
   shouldApplyNotificationWithoutTurnId
 } from '../utils/chat-turn-engagement'
 import { isFocusWithinContainer } from '../utils/slash-prompt-focus'
+import { isChatScrollNearBottom } from '../utils/chat-scroll'
 import {
   isConstrainedBrowserRequiringDeferredSync,
   isActiveTurnStatus,
@@ -469,6 +470,11 @@ const chatMessagesRootClass = computed(() =>
 )
 const chatSpacingOffset = computed(() =>
   Math.max(140, stickyFooterHeight.value + 24)
+)
+const showScrollToBottomLink = computed(() =>
+  !showWelcomeState.value
+  && displayMessages.value.length > 0
+  && !pinnedToBottom.value
 )
 const showWelcomeState = computed(() =>
   messages.value.length === 0
@@ -2377,7 +2383,7 @@ const updatePinnedState = () => {
     return
   }
 
-  pinnedToBottom.value = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight < 80
+  pinnedToBottom.value = isChatScrollNearBottom(viewport)
 }
 
 const scrollToBottom = (behavior: ScrollBehavior = 'auto') => {
@@ -2390,6 +2396,11 @@ const scrollToBottom = (behavior: ScrollBehavior = 'auto') => {
     top: viewport.scrollHeight,
     behavior
   })
+  pinnedToBottom.value = true
+}
+
+const jumpToChatBottom = () => {
+  scrollToBottom('smooth')
 }
 
 const ensureChatSession = async () => {
@@ -2435,7 +2446,7 @@ const scheduleScrollToBottom = async (behavior: ScrollBehavior = 'auto') => {
   }
 
   requestAnimationFrame(() => {
-    if (pinnedToBottom.value || isBusy.value) {
+    if (pinnedToBottom.value) {
       scrollToBottom(behavior)
     }
   })
@@ -3492,7 +3503,7 @@ const sendMessage = async () => {
       await pendingThreadHydration
     }
 
-    pinnedToBottom.value = true
+    updatePinnedState()
     error.value = null
     attachmentError.value = null
 
@@ -4330,7 +4341,7 @@ watch(
 </script>
 
 <template>
-  <section class="flex h-full min-h-0 flex-col bg-default">
+  <section class="relative flex h-full min-h-0 flex-col bg-default">
     <div
       ref="scrollViewport"
       class="min-h-0 flex-1 overflow-y-auto"
@@ -4458,6 +4469,25 @@ watch(
           />
         </template>
       </UChatMessages>
+    </div>
+
+    <div
+      v-if="showScrollToBottomLink"
+      class="pointer-events-none absolute inset-x-0 z-10 flex justify-center px-4 md:px-6"
+      :style="{ bottom: `${stickyFooterHeight + 12}px` }"
+    >
+      <UTooltip text="Jump to latest">
+        <UButton
+          type="button"
+          color="neutral"
+          variant="outline"
+          size="sm"
+          icon="i-lucide-arrow-down"
+          label="Jump to latest"
+          class="pointer-events-auto rounded-full border border-default bg-default/95 shadow-lg backdrop-blur"
+          @click="jumpToChatBottom"
+        />
+      </UTooltip>
     </div>
 
     <div

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -62,7 +62,11 @@ import {
   resolveThreadSummaryTitle,
   useThreadSummaries
 } from '../composables/useThreadSummaries'
-import { resolveChatMessagesStatus, shouldAwaitAssistantOutput } from '../utils/chat-messages-status'
+import {
+  hasVisibleAssistantOutputAfterLatestUserMessage,
+  resolveChatMessagesStatus,
+  shouldAwaitAssistantOutput
+} from '../utils/chat-messages-status'
 import {
   ITEM_PART,
   eventToMessage,
@@ -447,10 +451,20 @@ const composerPlaceholder = computed(() =>
         ? 'Ask Codex anything. @ to use plugins or use files'
         : 'Describe the change you want Codex to make'
 )
-const chatMessagesStatus = computed(() =>
-  resolveChatMessagesStatus(status.value, awaitingAssistantOutput.value)
-)
 const displayMessages = computed(() => groupTranscriptMessages(messages.value))
+const showAwaitingAssistantIndicator = computed(() =>
+  awaitingAssistantOutput.value
+  && !hasVisibleAssistantOutputAfterLatestUserMessage(displayMessages.value)
+)
+const chatMessagesStatus = computed(() =>
+  resolveChatMessagesStatus(status.value, showAwaitingAssistantIndicator.value)
+)
+const chatMessagesRootClass = computed(() =>
+  [
+    'min-h-full px-4 py-5 md:px-6',
+    showAwaitingAssistantIndicator.value ? '[&>article:last-of-type]:!min-h-0' : null
+  ].filter(Boolean).join(' ')
+)
 const chatSpacingOffset = computed(() =>
   Math.max(140, stickyFooterHeight.value + 24)
 )
@@ -4415,7 +4429,7 @@ watch(
           }
         }"
         :ui="{
-          root: 'min-h-full px-4 py-5 md:px-6',
+          root: chatMessagesRootClass,
           message: 'max-w-none',
           content: 'w-full max-w-5xl'
         }"
@@ -4431,7 +4445,7 @@ watch(
         </template>
         <template #indicator>
           <UChatShimmer
-            v-if="awaitingAssistantOutput"
+            v-if="showAwaitingAssistantIndicator"
             text="Thinking..."
             class="px-1 py-2"
           />

--- a/packages/client/app/utils/chat-messages-status.ts
+++ b/packages/client/app/utils/chat-messages-status.ts
@@ -1,8 +1,43 @@
 import type { ChatStatus } from '../composables/useChatSession'
+import {
+  ITEM_PART,
+  TOOL_GROUP_PART,
+  type ChatMessage
+} from '../../shared/codex-chat'
 
 export const shouldAwaitAssistantOutput = (
   submissionMethod: 'turn/start' | 'turn/steer'
 ) => submissionMethod === 'turn/start'
+
+const hasVisibleAssistantPart = (part: ChatMessage['parts'][number]) => {
+  switch (part.type) {
+    case 'text':
+    case 'plan':
+      return part.text.trim().length > 0
+    case 'reasoning':
+      return [...part.summary, ...part.content].some(text => text.trim().length > 0)
+    case 'attachment':
+    case ITEM_PART:
+    case TOOL_GROUP_PART:
+      return true
+    default:
+      return false
+  }
+}
+
+export const hasVisibleAssistantOutputAfterLatestUserMessage = (
+  messages: ChatMessage[]
+) => {
+  const latestUserMessageIndex = messages.findLastIndex(message => message.role === 'user')
+  const candidateMessages = latestUserMessageIndex === -1
+    ? messages
+    : messages.slice(latestUserMessageIndex + 1)
+
+  return candidateMessages.some(message =>
+    message.role === 'assistant'
+    && message.parts.some(hasVisibleAssistantPart)
+  )
+}
 
 export const resolveChatMessagesStatus = (
   status: ChatStatus,

--- a/packages/client/app/utils/chat-messages-status.ts
+++ b/packages/client/app/utils/chat-messages-status.ts
@@ -15,7 +15,8 @@ const hasVisibleAssistantPart = (part: ChatMessage['parts'][number]) => {
     case 'plan':
       return part.text.trim().length > 0
     case 'reasoning':
-      return [...part.summary, ...part.content].some(text => text.trim().length > 0)
+      return part.summary.some(text => text.trim().length > 0)
+        || part.content.some(text => text.trim().length > 0)
     case 'attachment':
     case ITEM_PART:
     case TOOL_GROUP_PART:
@@ -29,14 +30,22 @@ export const hasVisibleAssistantOutputAfterLatestUserMessage = (
   messages: ChatMessage[]
 ) => {
   const latestUserMessageIndex = messages.findLastIndex(message => message.role === 'user')
-  const candidateMessages = latestUserMessageIndex === -1
-    ? messages
-    : messages.slice(latestUserMessageIndex + 1)
 
-  return candidateMessages.some(message =>
-    message.role === 'assistant'
-    && message.parts.some(hasVisibleAssistantPart)
-  )
+  for (let index = latestUserMessageIndex + 1; index < messages.length; index += 1) {
+    const message = messages[index]
+    if (!message) {
+      continue
+    }
+
+    if (
+      message.role === 'assistant'
+      && message.parts.some(hasVisibleAssistantPart)
+    ) {
+      return true
+    }
+  }
+
+  return false
 }
 
 export const resolveChatMessagesStatus = (

--- a/packages/client/app/utils/chat-scroll.ts
+++ b/packages/client/app/utils/chat-scroll.ts
@@ -1,0 +1,11 @@
+export const CHAT_SCROLL_BOTTOM_THRESHOLD_PX = 20
+
+type ChatScrollMetrics = Pick<HTMLElement, 'clientHeight' | 'scrollHeight' | 'scrollTop'>
+
+export const chatScrollDistanceFromBottom = (metrics: ChatScrollMetrics) =>
+  Math.max(0, metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight)
+
+export const isChatScrollNearBottom = (
+  metrics: ChatScrollMetrics,
+  thresholdPx = CHAT_SCROLL_BOTTOM_THRESHOLD_PX
+) => chatScrollDistanceFromBottom(metrics) <= thresholdPx

--- a/packages/client/app/utils/thread-reactivation.ts
+++ b/packages/client/app/utils/thread-reactivation.ts
@@ -2,6 +2,8 @@ import type { ThreadReadParams } from '~~/shared/generated/codex-app-server/v2/T
 import type { ThreadReadResponse } from '~~/shared/generated/codex-app-server/v2/ThreadReadResponse'
 import type { ThreadResumeParams } from '~~/shared/generated/codex-app-server/v2/ThreadResumeParams'
 import type { ThreadResumeResponse } from '~~/shared/generated/codex-app-server/v2/ThreadResumeResponse'
+import type { Thread } from '~~/shared/generated/codex-app-server/v2/Thread'
+import type { Turn } from '~~/shared/generated/codex-app-server/v2/Turn'
 
 export type ThreadReactivationReason =
   | 'window/visible'
@@ -31,6 +33,9 @@ export type ThreadReactivationResumeResult = {
   resumeResponse: ThreadResumeResponse
   readResponse: ThreadReadResponse
 }
+
+type ThreadWithTurns = Pick<Thread, 'turns'>
+type ThreadActivationSnapshot = Pick<Thread, 'status' | 'turns'>
 
 const desktopRecoveryReasons = new Set<ThreadReactivationReason>([
   'window/online',
@@ -99,6 +104,42 @@ export const shouldAttemptThreadReactivationSync = (input: {
   }
 
   return input.browserRequiresDeferredSync && input.hadDocumentDeactivation
+}
+
+export const isActiveTurnStatus = (value: string | null | undefined) => {
+  return value === 'inProgress'
+}
+
+export const findActiveTurn = (thread: ThreadWithTurns): Turn | null =>
+  thread.turns.findLast(turn => isActiveTurnStatus(turn.status)) ?? null
+
+const findTurnById = (thread: ThreadWithTurns, turnId: string) =>
+  thread.turns.findLast(turn => turn.id === turnId) ?? null
+
+export const resolveHydratedActiveTurn = (input: {
+  readThread: ThreadActivationSnapshot
+  resumeThread?: ThreadWithTurns | null
+}) => {
+  if (input.readThread.status.type !== 'active') {
+    return null
+  }
+
+  const readActiveTurn = findActiveTurn(input.readThread)
+  if (readActiveTurn) {
+    return readActiveTurn
+  }
+
+  const resumeActiveTurn = input.resumeThread ? findActiveTurn(input.resumeThread) : null
+  if (!resumeActiveTurn) {
+    return null
+  }
+
+  const matchingReadTurn = findTurnById(input.readThread, resumeActiveTurn.id)
+  if (matchingReadTurn && !isActiveTurnStatus(matchingReadTurn.status)) {
+    return null
+  }
+
+  return resumeActiveTurn
 }
 
 export const resumeThreadStreamAfterReactivation = async (

--- a/packages/client/test/chat-scroll.test.ts
+++ b/packages/client/test/chat-scroll.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CHAT_SCROLL_BOTTOM_THRESHOLD_PX,
+  chatScrollDistanceFromBottom,
+  isChatScrollNearBottom
+} from '../app/utils/chat-scroll'
+
+describe('chat scroll state', () => {
+  it('treats scroll positions within 20px of the bottom as pinned', () => {
+    expect(isChatScrollNearBottom({
+      scrollHeight: 1000,
+      scrollTop: 480,
+      clientHeight: 500
+    })).toBe(true)
+    expect(chatScrollDistanceFromBottom({
+      scrollHeight: 1000,
+      scrollTop: 480,
+      clientHeight: 500
+    })).toBe(CHAT_SCROLL_BOTTOM_THRESHOLD_PX)
+  })
+
+  it('does not treat positions outside the threshold as pinned', () => {
+    expect(isChatScrollNearBottom({
+      scrollHeight: 1000,
+      scrollTop: 479,
+      clientHeight: 500
+    })).toBe(false)
+  })
+})

--- a/packages/client/test/chat-transcript.test.ts
+++ b/packages/client/test/chat-transcript.test.ts
@@ -15,7 +15,10 @@ import {
   type ChatMessage
 } from '../shared/codex-chat'
 import { mergeThreadSummary, renameThreadSummary } from '../app/composables/useThreadSummaries'
-import { resolveChatMessagesStatus } from '../app/utils/chat-messages-status'
+import {
+  hasVisibleAssistantOutputAfterLatestUserMessage,
+  resolveChatMessagesStatus
+} from '../app/utils/chat-messages-status'
 
 const makeTurn = (input: Pick<Turn, 'id' | 'items' | 'status' | 'error'> & Partial<Pick<Turn, 'startedAt' | 'completedAt' | 'durationMs'>>): Turn => ({
   id: input.id,
@@ -250,6 +253,68 @@ describe('chat transcript stability', () => {
     expect(resolveChatMessagesStatus('streaming', true)).toBe('submitted')
     expect(resolveChatMessagesStatus('streaming', false)).toBe('streaming')
     expect(resolveChatMessagesStatus('ready', true)).toBe('ready')
+  })
+
+  it('detects visible assistant output only after the latest user message', () => {
+    expect(hasVisibleAssistantOutputAfterLatestUserMessage([{
+      id: 'assistant-previous',
+      role: 'assistant',
+      parts: [{
+        type: 'text',
+        text: 'Previous reply',
+        state: 'done'
+      }]
+    }, {
+      id: 'user-current',
+      role: 'user',
+      pending: true,
+      parts: [{
+        type: 'text',
+        text: 'New request',
+        state: 'streaming'
+      }]
+    }])).toBe(false)
+
+    expect(hasVisibleAssistantOutputAfterLatestUserMessage([{
+      id: 'user-current',
+      role: 'user',
+      pending: true,
+      parts: [{
+        type: 'text',
+        text: 'New request',
+        state: 'streaming'
+      }]
+    }, {
+      id: 'assistant-empty',
+      role: 'assistant',
+      pending: true,
+      parts: [{
+        type: 'reasoning',
+        summary: [],
+        content: [],
+        state: 'streaming'
+      }]
+    }])).toBe(false)
+
+    expect(hasVisibleAssistantOutputAfterLatestUserMessage([{
+      id: 'user-current',
+      role: 'user',
+      pending: true,
+      parts: [{
+        type: 'text',
+        text: 'New request',
+        state: 'streaming'
+      }]
+    }, {
+      id: 'assistant-current',
+      role: 'assistant',
+      pending: true,
+      parts: [{
+        type: 'text',
+        text: 'Streaming reply',
+        state: 'streaming'
+      }]
+    }])).toBe(true)
   })
 
   it('updates cached thread summaries in place when a live title arrives', () => {

--- a/packages/client/test/thread-reactivation.test.ts
+++ b/packages/client/test/thread-reactivation.test.ts
@@ -2,12 +2,37 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  findActiveTurn,
   isConstrainedBrowserRequiringDeferredSync,
+  isActiveTurnStatus,
   resumeThreadStreamAfterReactivation,
+  resolveHydratedActiveTurn,
   shouldAttemptThreadReactivationSync
 } from '../app/utils/thread-reactivation'
 import type { ThreadReadResponse } from '../shared/generated/codex-app-server/v2/ThreadReadResponse'
 import type { ThreadResumeResponse } from '../shared/generated/codex-app-server/v2/ThreadResumeResponse'
+import type { Thread } from '../shared/generated/codex-app-server/v2/Thread'
+import type { Turn } from '../shared/generated/codex-app-server/v2/Turn'
+
+const makeTurn = (id: string, status: Turn['status']): Turn => ({
+  id,
+  status,
+  items: [],
+  error: null,
+  startedAt: null,
+  completedAt: null,
+  durationMs: null
+})
+
+const makeThreadSnapshot = (
+  turns: Turn[],
+  status: Thread['status']['type'] = 'active'
+): Pick<Thread, 'status' | 'turns'> => ({
+  status: status === 'active'
+    ? { type: 'active', activeFlags: [] }
+    : { type: status },
+  turns
+})
 
 describe('thread reactivation policy', () => {
   afterEach(() => {
@@ -112,6 +137,42 @@ describe('thread reactivation policy', () => {
       transportConnected: true,
       hadDocumentDeactivation: false
     })).toBe(false)
+  })
+
+  it('resolves active turn state from resume before the read snapshot', () => {
+    const readCompletedTurn = makeTurn('turn-read-completed', 'completed')
+    const resumeActiveTurn = makeTurn('turn-resume-active', 'inProgress')
+
+    expect(isActiveTurnStatus('inProgress')).toBe(true)
+    expect(isActiveTurnStatus('completed')).toBe(false)
+    expect(isActiveTurnStatus('running')).toBe(false)
+    expect(findActiveTurn({
+      turns: [readCompletedTurn, resumeActiveTurn]
+    })).toBe(resumeActiveTurn)
+    expect(resolveHydratedActiveTurn({
+      readThread: makeThreadSnapshot([readCompletedTurn]),
+      resumeThread: { turns: [resumeActiveTurn] }
+    })).toBe(resumeActiveTurn)
+  })
+
+  it('does not revive a resume turn that the read snapshot marks completed', () => {
+    const readCompletedTurn = makeTurn('turn-stale-active', 'completed')
+    const resumeActiveTurn = makeTurn('turn-stale-active', 'inProgress')
+
+    expect(resolveHydratedActiveTurn({
+      readThread: makeThreadSnapshot([readCompletedTurn]),
+      resumeThread: { turns: [resumeActiveTurn] }
+    })).toBeNull()
+  })
+
+  it('ignores resume active turns when the read snapshot is idle', () => {
+    const readCompletedTurn = makeTurn('turn-read-completed', 'completed')
+    const resumeActiveTurn = makeTurn('turn-resume-active', 'inProgress')
+
+    expect(resolveHydratedActiveTurn({
+      readThread: makeThreadSnapshot([readCompletedTurn], 'idle'),
+      resumeThread: { turns: [resumeActiveTurn] }
+    })).toBeNull()
   })
 
   it('rehydrates through thread/resume before thread/read after reconnecting', async () => {


### PR DESCRIPTION
## Summary
- Hide the bottom thinking indicator once assistant output is visible so streaming messages can use the chat height.
- Restore prompt/send-button state when opening or reloading a thread while a turn is still active.
- Gate hydrated active-turn restoration with the latest thread/read status so completed threads do not revive stale resume state.
- Add regression tests for transcript thinking state and hydrated active-turn resolution.

## Why
Direct thread hydration used the persisted read snapshot and live resume state inconsistently. That could leave active turns unrecognized on reconnect, while a stale resume or buffered turn id could also make completed threads look active. The new helper centralizes the active-turn decision and uses thread/read as the authoritative idle/completed gate.

## Validation
- pnpm --filter @codori/client test -- thread-reactivation smoke chat-transcript
- pnpm --filter @codori/client lint
- pnpm --filter @codori/client typecheck
- Built and ran the codori server locally for browser verification, then shut it down.