### PR TITLE
Improve chat transcript rendering and scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codori",
   "private": true,
-  "version": "0.3.4",
+  "version": "0.3.5",
   "packageManager": "pnpm@10.33.2",
   "scripts": {
     "build": "pnpm --filter @codori/client build && pnpm --filter @codori/server build",

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -31,7 +31,10 @@ import {
   shouldApplyNotificationWithoutTurnId
 } from '../utils/chat-turn-engagement'
 import { isFocusWithinContainer } from '../utils/slash-prompt-focus'
-import { isChatScrollNearBottom } from '../utils/chat-scroll'
+import {
+  resolveChatScrollPinnedState,
+  type ChatScrollMetrics
+} from '../utils/chat-scroll'
 import {
   isConstrainedBrowserRequiringDeferredSync,
   isActiveTurnStatus,
@@ -272,6 +275,7 @@ const skillAutocompleteListRef = ref<HTMLElement | null>(null)
 const mentionAutocompleteDropdownRef = ref<HTMLElement | null>(null)
 const mentionAutocompleteListRef = ref<HTMLElement | null>(null)
 const scrollViewport = ref<HTMLElement | null>(null)
+const transcriptContentRef = ref<HTMLElement | null>(null)
 const stickyFooterRef = ref<HTMLElement | null>(null)
 const stickyFooterHeight = ref(140)
 const pinnedToBottom = ref(true)
@@ -467,7 +471,7 @@ const chatMessagesStatus = computed(() =>
 const chatMessagesRootClass = computed(() =>
   [
     'min-h-full px-4 py-5 md:px-6',
-    showAwaitingAssistantIndicator.value ? '[&>article:last-of-type]:!min-h-0' : null
+    '[&>article:last-of-type]:!min-h-0'
   ].filter(Boolean).join(' ')
 )
 const chatSpacingOffset = computed(() =>
@@ -1017,6 +1021,9 @@ let releaseThreadReactivationListeners: (() => void) | null = null
 let runtimeSubscriptionKey: string | null = null
 const linkedChatThreadIds = new Set<string>()
 let footerResizeObserver: ResizeObserver | null = null
+let transcriptContentResizeObserver: ResizeObserver | null = null
+let scrollToBottomFrame: number | null = null
+let lastScrollMetrics: ChatScrollMetrics | null = null
 let lastWorkspaceDeactivatedAt: number | null = null
 let lastThreadReactivationSyncAt = 0
 let skipNextSkillMentionSync = false
@@ -2379,13 +2386,25 @@ const getFallbackItemData = (message: ChatMessage) => {
   return itemPart.data
 }
 
+const readChatScrollMetrics = (viewport: HTMLElement): ChatScrollMetrics => ({
+  clientHeight: viewport.clientHeight,
+  scrollHeight: viewport.scrollHeight,
+  scrollTop: viewport.scrollTop
+})
+
 const updatePinnedState = () => {
   const viewport = scrollViewport.value
   if (!viewport) {
     return
   }
 
-  pinnedToBottom.value = isChatScrollNearBottom(viewport)
+  const currentMetrics = readChatScrollMetrics(viewport)
+  pinnedToBottom.value = resolveChatScrollPinnedState({
+    current: currentMetrics,
+    previous: lastScrollMetrics,
+    wasPinned: pinnedToBottom.value
+  })
+  lastScrollMetrics = currentMetrics
 }
 
 const scrollToBottom = (behavior: ScrollBehavior = 'auto') => {
@@ -2399,6 +2418,7 @@ const scrollToBottom = (behavior: ScrollBehavior = 'auto') => {
     behavior
   })
   pinnedToBottom.value = true
+  lastScrollMetrics = readChatScrollMetrics(viewport)
 }
 
 const jumpToChatBottom = () => {
@@ -2447,11 +2467,23 @@ const scheduleScrollToBottom = async (behavior: ScrollBehavior = 'auto') => {
     return
   }
 
-  requestAnimationFrame(() => {
+  if (scrollToBottomFrame !== null) {
+    window.cancelAnimationFrame(scrollToBottomFrame)
+  }
+
+  scrollToBottomFrame = requestAnimationFrame(() => {
+    scrollToBottomFrame = null
     if (pinnedToBottom.value) {
       scrollToBottom(behavior)
     }
   })
+}
+
+const maintainBottomScrollIfPinned = () => {
+  updatePinnedState()
+  if (pinnedToBottom.value) {
+    void scheduleScrollToBottom('auto')
+  }
 }
 
 async function ensureProjectRuntime() {
@@ -3991,6 +4023,7 @@ onMounted(() => {
       const nextHeight = borderBoxSize ?? entry?.target.getBoundingClientRect().height
       if (typeof nextHeight === 'number' && Number.isFinite(nextHeight)) {
         stickyFooterHeight.value = Math.ceil(nextHeight)
+        maintainBottomScrollIfPinned()
       }
     })
 
@@ -4013,6 +4046,12 @@ onBeforeUnmount(() => {
   releaseThreadReactivationListeners = null
   footerResizeObserver?.disconnect()
   footerResizeObserver = null
+  transcriptContentResizeObserver?.disconnect()
+  transcriptContentResizeObserver = null
+  if (scrollToBottomFrame !== null) {
+    window.cancelAnimationFrame(scrollToBottomFrame)
+    scrollToBottomFrame = null
+  }
 })
 
 watch(() => props.threadId ?? null, (threadId) => {
@@ -4072,6 +4111,21 @@ watch(pendingThreadId, async (threadId) => {
   await router.push(toProjectThreadRoute(workspaceId.value, threadId))
   pendingThreadId.value = null
 })
+
+if (import.meta.client) {
+  watch(transcriptContentRef, (element) => {
+    transcriptContentResizeObserver?.disconnect()
+    transcriptContentResizeObserver = null
+
+    if (!element) {
+      return
+    }
+
+    transcriptContentResizeObserver = new ResizeObserver(maintainBottomScrollIfPinned)
+    transcriptContentResizeObserver.observe(element)
+    maintainBottomScrollIfPinned()
+  }, { flush: 'post' })
+}
 
 watch(messages, () => {
   void scheduleScrollToBottom(status.value === 'streaming' ? 'auto' : 'smooth')
@@ -4440,44 +4494,49 @@ watch(
         </div>
       </div>
 
-      <UChatMessages
+      <div
         v-else
-        :messages="displayMessages"
-        :status="chatMessagesStatus"
-        :should-auto-scroll="false"
-        :should-scroll-to-bottom="false"
-        :auto-scroll="false"
-        :spacing-offset="chatSpacingOffset"
-        :user="{
-          ui: {
-            root: 'scroll-mt-4',
-            container: 'gap-3 pb-8',
-            content: 'px-4 py-3 rounded-2xl min-h-12'
-          }
-        }"
-        :ui="{
-          root: chatMessagesRootClass,
-          message: 'max-w-none',
-          content: 'w-full max-w-5xl'
-        }"
-        compact
+        ref="transcriptContentRef"
+        class="min-h-full"
       >
-        <template #content="{ message }">
-          <MessageContent
-            :message="message as ChatMessage"
-            :project-id="workspaceKind === 'project' ? workspaceId : undefined"
-            :workspace="{ kind: workspaceKind, id: workspaceId }"
-            :workspace-root-path="selectedProject?.projectPath ?? null"
-          />
-        </template>
-        <template #indicator>
-          <UChatShimmer
-            v-if="showAwaitingAssistantIndicator"
-            text="Thinking..."
-            class="px-1 py-2"
-          />
-        </template>
-      </UChatMessages>
+        <UChatMessages
+          :messages="displayMessages"
+          :status="chatMessagesStatus"
+          :should-auto-scroll="false"
+          :should-scroll-to-bottom="false"
+          :auto-scroll="false"
+          :spacing-offset="chatSpacingOffset"
+          :user="{
+            ui: {
+              root: 'scroll-mt-4',
+              container: 'gap-3 pb-8',
+              content: 'px-4 py-3 rounded-2xl min-h-12'
+            }
+          }"
+          :ui="{
+            root: chatMessagesRootClass,
+            message: 'max-w-none',
+            content: 'w-full max-w-5xl'
+          }"
+          compact
+        >
+          <template #content="{ message }">
+            <MessageContent
+              :message="message as ChatMessage"
+              :project-id="workspaceKind === 'project' ? workspaceId : undefined"
+              :workspace="{ kind: workspaceKind, id: workspaceId }"
+              :workspace-root-path="selectedProject?.projectPath ?? null"
+            />
+          </template>
+          <template #indicator>
+            <UChatShimmer
+              v-if="showAwaitingAssistantIndicator"
+              text="Thinking..."
+              class="px-1 py-2"
+            />
+          </template>
+        </UChatMessages>
+      </div>
     </div>
 
     <div

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -76,8 +76,10 @@ import {
   findLatestCompletedPlanTurnId,
   findLatestPlanTurnId,
   groupTranscriptMessages,
+  hasAssistantTextMessageWithText,
   isSubagentActiveStatus,
   itemToMessages,
+  removeSyntheticReviewOutputMessages,
   replaceStreamingMessage,
   threadToMessages,
   upsertStreamingMessage,
@@ -3093,8 +3095,15 @@ const applyItemCompletedNotification = (notification: CodexRpcNotification) => {
   if (params.item.type === 'plan') {
     latestPlanTurnId.value = notificationTurnId(notification) ?? currentLiveStream()?.turnId ?? null
   }
+  if (params.item.type === 'agentMessage') {
+    messages.value = removeSyntheticReviewOutputMessages(messages.value, params.item.text)
+  }
   markAssistantOutputStartedForItem(params.item)
-  for (const nextMessage of itemToMessages(params.item)) {
+  for (const nextMessage of itemToMessages(params.item, {
+    includeReviewOutput: params.item.type === 'exitedReviewMode'
+      ? !hasAssistantTextMessageWithText(messages.value, params.item.review)
+      : undefined
+  })) {
     const confirmedMessage = {
       ...nextMessage,
       pending: false

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -79,10 +79,10 @@ import {
   findLatestCompletedPlanTurnId,
   findLatestPlanTurnId,
   groupTranscriptMessages,
-  hasAssistantTextMessageWithText,
+  hasAssistantTextMessageWithTextInLatestTurn,
   isSubagentActiveStatus,
   itemToMessages,
-  removeSyntheticReviewOutputMessages,
+  removeSyntheticReviewOutputMessagesInLatestTurn,
   replaceStreamingMessage,
   threadToMessages,
   upsertStreamingMessage,
@@ -3128,12 +3128,12 @@ const applyItemCompletedNotification = (notification: CodexRpcNotification) => {
     latestPlanTurnId.value = notificationTurnId(notification) ?? currentLiveStream()?.turnId ?? null
   }
   if (params.item.type === 'agentMessage') {
-    messages.value = removeSyntheticReviewOutputMessages(messages.value, params.item.text)
+    messages.value = removeSyntheticReviewOutputMessagesInLatestTurn(messages.value, params.item.text)
   }
   markAssistantOutputStartedForItem(params.item)
   for (const nextMessage of itemToMessages(params.item, {
     includeReviewOutput: params.item.type === 'exitedReviewMode'
-      ? !hasAssistantTextMessageWithText(messages.value, params.item.review)
+      ? !hasAssistantTextMessageWithTextInLatestTurn(messages.value, params.item.review)
       : undefined
   })) {
     const confirmedMessage = {

--- a/packages/client/app/components/message-item/AnsiOutput.vue
+++ b/packages/client/app/components/message-item/AnsiOutput.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { parseAnsiOutput } from '../../utils/ansi-output'
+
+const props = defineProps<{
+  text: string
+}>()
+
+const segments = computed(() => parseAnsiOutput(props.text))
+</script>
+
+<template>
+  <pre
+    data-ansi-output
+    class="overflow-x-auto rounded-xl border border-default/70 bg-elevated/40 px-3 py-3 text-xs leading-6 text-toned"
+  ><span
+    v-for="(segment, index) in segments"
+    :key="index"
+    data-ansi-output-segment
+    :style="segment.style"
+  >{{ segment.text }}</span></pre>
+</template>

--- a/packages/client/app/components/message-item/CommandExecution.vue
+++ b/packages/client/app/components/message-item/CommandExecution.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { CommandExecutionItem } from '~~/shared/codex-chat'
+import AnsiOutput from './AnsiOutput.vue'
 import { useChatToolState } from './use-chat-tool-state'
 
 const props = defineProps<{
@@ -44,10 +45,10 @@ const { open, isLoading, isStreaming } = useChatToolState(() => props.item.statu
     @update:open="open = $event"
   >
     <div class="space-y-3">
-      <pre
+      <AnsiOutput
         v-if="output"
-        class="overflow-x-auto rounded-xl border border-default/70 bg-elevated/40 px-3 py-3 text-xs leading-6 text-toned"
-      >{{ output }}</pre>
+        :text="output"
+      />
       <p
         v-else
         class="text-xs text-muted"

--- a/packages/client/app/components/message-item/CommandExecution.vue
+++ b/packages/client/app/components/message-item/CommandExecution.vue
@@ -19,9 +19,15 @@ const title = computed(() => {
 })
 
 const output = computed(() => props.item.aggregatedOutput?.trim() ?? '')
-const icon = computed(() =>
-  props.item.status === 'failed' ? 'i-lucide-triangle-alert' : 'i-lucide-terminal'
-)
+const exitSummary = computed(() => {
+  if (props.item.exitCode === null) {
+    return null
+  }
+
+  return props.item.status === 'failed'
+    ? `Run failed · exit code ${props.item.exitCode}`
+    : `Exit code ${props.item.exitCode}`
+})
 const { open, isLoading, isStreaming } = useChatToolState(() => props.item.status, props.item.status !== 'completed')
 </script>
 
@@ -29,7 +35,7 @@ const { open, isLoading, isStreaming } = useChatToolState(() => props.item.statu
   <UChatTool
     :text="title"
     :suffix="item.command"
-    :icon="icon"
+    icon="i-lucide-terminal"
     :loading="isLoading"
     :streaming="isStreaming"
     variant="card"
@@ -49,18 +55,11 @@ const { open, isLoading, isStreaming } = useChatToolState(() => props.item.statu
         Waiting for output.
       </p>
       <p
-        v-if="item.exitCode !== null"
+        v-if="exitSummary"
         class="text-xs font-medium text-muted"
       >
-        Exit code {{ item.exitCode }}
+        {{ exitSummary }}
       </p>
-      <UAlert
-        v-if="item.status === 'failed' && item.exitCode !== null"
-        color="error"
-        variant="soft"
-        icon="i-lucide-triangle-alert"
-        :title="`Command failed with exit code ${item.exitCode}`"
-      />
     </div>
   </UChatTool>
 </template>

--- a/packages/client/app/components/message-item/ContextCompaction.vue
+++ b/packages/client/app/components/message-item/ContextCompaction.vue
@@ -1,9 +1,18 @@
+<script setup lang="ts">
+defineProps<{
+  pending?: boolean
+}>()
+</script>
+
 <template>
-  <div class="flex items-center gap-2 rounded-full border border-default/70 bg-elevated/30 px-3 py-2 text-xs text-muted">
-    <UIcon
-      name="i-lucide-package-open"
-      class="size-3.5"
-    />
-    Thread context was compacted.
-  </div>
+  <USeparator
+    :label="pending ? '.. compacting thread ..' : '...compacted thread...'"
+    color="neutral"
+    type="dashed"
+    :ui="{
+      root: 'py-2',
+      border: 'border-muted',
+      label: 'text-xs font-medium text-muted'
+    }"
+  />
 </template>

--- a/packages/client/app/components/message-part/Item.ts
+++ b/packages/client/app/components/message-part/Item.ts
@@ -60,7 +60,9 @@ export default defineComponent({
             status: itemData.status
           })
         case 'context_compaction':
-          return h(MessageItemContextCompaction)
+          return h(MessageItemContextCompaction, {
+            pending: props.messagePending
+          })
         default:
           return null
       }

--- a/packages/client/app/utils/ansi-output.ts
+++ b/packages/client/app/utils/ansi-output.ts
@@ -1,0 +1,342 @@
+export type AnsiOutputStyle = {
+  color?: string
+  backgroundColor?: string
+  fontWeight?: string
+  fontStyle?: string
+  textDecorationLine?: string
+  opacity?: string
+}
+
+export type AnsiOutputSegment = {
+  text: string
+  style: AnsiOutputStyle
+}
+
+type AnsiState = {
+  foregroundColor?: string
+  backgroundColor?: string
+  bold: boolean
+  dim: boolean
+  italic: boolean
+  underline: boolean
+  inverse: boolean
+  strike: boolean
+}
+
+const ESCAPE_SEQUENCE = '\\u001B'
+const BELL_SEQUENCE = '\\u0007'
+
+const CSI_PATTERN = new RegExp(`${ESCAPE_SEQUENCE}\\[([0-?]*)([ -/]*)([@-~])`, 'gu')
+const OSC_PATTERN = new RegExp(`${ESCAPE_SEQUENCE}\\][^${BELL_SEQUENCE}${ESCAPE_SEQUENCE}]*(?:${BELL_SEQUENCE}|${ESCAPE_SEQUENCE}\\\\)`, 'gu')
+const UNSUPPORTED_ANSI_PATTERN = new RegExp(`${ESCAPE_SEQUENCE}(?:[@-Z\\\\-_]|\\[[0-?]*[ -/]*[@-~])`, 'gu')
+
+const standardForegroundColors = [
+  '#111827',
+  '#dc2626',
+  '#16a34a',
+  '#ca8a04',
+  '#2563eb',
+  '#c026d3',
+  '#0891b2',
+  '#e5e7eb'
+]
+
+const brightForegroundColors = [
+  '#6b7280',
+  '#ef4444',
+  '#22c55e',
+  '#eab308',
+  '#3b82f6',
+  '#d946ef',
+  '#06b6d4',
+  '#f9fafb'
+]
+
+const standardBackgroundColors = [
+  '#111827',
+  '#7f1d1d',
+  '#14532d',
+  '#713f12',
+  '#1e3a8a',
+  '#701a75',
+  '#164e63',
+  '#f3f4f6'
+]
+
+const brightBackgroundColors = [
+  '#374151',
+  '#991b1b',
+  '#166534',
+  '#854d0e',
+  '#1d4ed8',
+  '#86198f',
+  '#0e7490',
+  '#ffffff'
+]
+
+const createInitialState = (): AnsiState => ({
+  foregroundColor: undefined,
+  backgroundColor: undefined,
+  bold: false,
+  dim: false,
+  italic: false,
+  underline: false,
+  inverse: false,
+  strike: false
+})
+
+const styleFromState = (state: AnsiState): AnsiOutputStyle => {
+  const textDecorationLine = [
+    state.underline ? 'underline' : null,
+    state.strike ? 'line-through' : null
+  ].filter((value): value is string => Boolean(value)).join(' ')
+
+  return {
+    ...(state.inverse && state.backgroundColor ? { color: state.backgroundColor } : {}),
+    ...(!state.inverse && state.foregroundColor ? { color: state.foregroundColor } : {}),
+    ...(state.inverse && state.foregroundColor ? { backgroundColor: state.foregroundColor } : {}),
+    ...(!state.inverse && state.backgroundColor ? { backgroundColor: state.backgroundColor } : {}),
+    ...(state.bold ? { fontWeight: '700' } : {}),
+    ...(state.italic ? { fontStyle: 'italic' } : {}),
+    ...(textDecorationLine ? { textDecorationLine } : {}),
+    ...(state.dim ? { opacity: '0.72' } : {})
+  }
+}
+
+const styleKey = (style: AnsiOutputStyle) =>
+  [
+    style.color ?? '',
+    style.backgroundColor ?? '',
+    style.fontWeight ?? '',
+    style.fontStyle ?? '',
+    style.textDecorationLine ?? '',
+    style.opacity ?? ''
+  ].join('|')
+
+const stripUnsupportedAnsi = (text: string) =>
+  text.replace(OSC_PATTERN, '').replace(UNSUPPORTED_ANSI_PATTERN, '')
+
+const appendSegment = (
+  segments: AnsiOutputSegment[],
+  text: string,
+  state: AnsiState
+) => {
+  const cleanText = stripUnsupportedAnsi(text)
+  if (!cleanText) {
+    return
+  }
+
+  const style = styleFromState(state)
+  const previous = segments[segments.length - 1]
+  if (previous && styleKey(previous.style) === styleKey(style)) {
+    previous.text += cleanText
+    return
+  }
+
+  segments.push({
+    text: cleanText,
+    style
+  })
+}
+
+const parseSgrCodes = (params: string) => {
+  if (!params) {
+    return [0]
+  }
+
+  return params
+    .replace(/:/gu, ';')
+    .split(';')
+    .map(param => param === '' ? 0 : Number(param))
+    .filter(code => Number.isFinite(code))
+}
+
+const rgbColor = (red: number, green: number, blue: number) =>
+  `rgb(${red}, ${green}, ${blue})`
+
+const paletteColor = (palette: readonly string[], index: number) =>
+  palette[index] ?? null
+
+const ansi256Color = (value: number) => {
+  if (value < 0 || value > 255) {
+    return null
+  }
+
+  if (value < 8) {
+    return paletteColor(standardForegroundColors, value)
+  }
+
+  if (value < 16) {
+    return paletteColor(brightForegroundColors, value - 8)
+  }
+
+  if (value >= 232) {
+    const level = 8 + ((value - 232) * 10)
+    return rgbColor(level, level, level)
+  }
+
+  const offset = value - 16
+  const red = Math.floor(offset / 36)
+  const green = Math.floor((offset % 36) / 6)
+  const blue = offset % 6
+  const channel = (component: number) => component === 0 ? 0 : 55 + (component * 40)
+  return rgbColor(channel(red), channel(green), channel(blue))
+}
+
+const readExtendedColor = (codes: number[], index: number) => {
+  const mode = codes[index + 1]
+  if (mode === 5) {
+    const value = codes[index + 2]
+    if (value == null) {
+      return {
+        color: null,
+        nextIndex: index
+      }
+    }
+
+    return {
+      color: ansi256Color(value),
+      nextIndex: index + 2
+    }
+  }
+
+  if (mode === 2) {
+    const red = codes[index + 2]
+    const green = codes[index + 3]
+    const blue = codes[index + 4]
+    if (
+      red != null && red >= 0 && red <= 255
+      && green != null && green >= 0 && green <= 255
+      && blue != null && blue >= 0 && blue <= 255
+    ) {
+      return {
+        color: rgbColor(red, green, blue),
+        nextIndex: index + 4
+      }
+    }
+  }
+
+  return {
+    color: null,
+    nextIndex: index
+  }
+}
+
+const applySgrCodes = (state: AnsiState, codes: number[]) => {
+  for (let index = 0; index < codes.length; index += 1) {
+    const code = codes[index]
+    if (code == null) {
+      continue
+    }
+
+    if (code === 0) {
+      Object.assign(state, createInitialState())
+      continue
+    }
+
+    if (code === 1) {
+      state.bold = true
+      continue
+    }
+    if (code === 2) {
+      state.dim = true
+      continue
+    }
+    if (code === 3) {
+      state.italic = true
+      continue
+    }
+    if (code === 4) {
+      state.underline = true
+      continue
+    }
+    if (code === 7) {
+      state.inverse = true
+      continue
+    }
+    if (code === 9) {
+      state.strike = true
+      continue
+    }
+    if (code === 22) {
+      state.bold = false
+      state.dim = false
+      continue
+    }
+    if (code === 23) {
+      state.italic = false
+      continue
+    }
+    if (code === 24) {
+      state.underline = false
+      continue
+    }
+    if (code === 27) {
+      state.inverse = false
+      continue
+    }
+    if (code === 29) {
+      state.strike = false
+      continue
+    }
+    if (code === 39) {
+      state.foregroundColor = undefined
+      continue
+    }
+    if (code === 49) {
+      state.backgroundColor = undefined
+      continue
+    }
+    if (code >= 30 && code <= 37) {
+      state.foregroundColor = paletteColor(standardForegroundColors, code - 30) ?? state.foregroundColor
+      continue
+    }
+    if (code >= 90 && code <= 97) {
+      state.foregroundColor = paletteColor(brightForegroundColors, code - 90) ?? state.foregroundColor
+      continue
+    }
+    if (code >= 40 && code <= 47) {
+      state.backgroundColor = paletteColor(standardBackgroundColors, code - 40) ?? state.backgroundColor
+      continue
+    }
+    if (code >= 100 && code <= 107) {
+      state.backgroundColor = paletteColor(brightBackgroundColors, code - 100) ?? state.backgroundColor
+      continue
+    }
+    if (code === 38 || code === 48) {
+      const { color, nextIndex } = readExtendedColor(codes, index)
+      if (color) {
+        if (code === 38) {
+          state.foregroundColor = color
+        } else {
+          state.backgroundColor = color
+        }
+      }
+      index = nextIndex
+    }
+  }
+}
+
+export const parseAnsiOutput = (output: string): AnsiOutputSegment[] => {
+  const segments: AnsiOutputSegment[] = []
+  const state = createInitialState()
+  const text = output.replace(OSC_PATTERN, '')
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  while ((match = CSI_PATTERN.exec(text)) !== null) {
+    appendSegment(segments, text.slice(lastIndex, match.index), state)
+
+    const params = match[1] ?? ''
+    const intermediate = match[2] ?? ''
+    const command = match[3] ?? ''
+    if (command === 'm' && !intermediate) {
+      applySgrCodes(state, parseSgrCodes(params))
+    }
+
+    lastIndex = match.index + match[0].length
+  }
+
+  appendSegment(segments, text.slice(lastIndex), state)
+  return segments
+}

--- a/packages/client/app/utils/chat-scroll.ts
+++ b/packages/client/app/utils/chat-scroll.ts
@@ -1,6 +1,7 @@
 export const CHAT_SCROLL_BOTTOM_THRESHOLD_PX = 20
+export const CHAT_SCROLL_TOP_TOLERANCE_PX = 1
 
-type ChatScrollMetrics = Pick<HTMLElement, 'clientHeight' | 'scrollHeight' | 'scrollTop'>
+export type ChatScrollMetrics = Pick<HTMLElement, 'clientHeight' | 'scrollHeight' | 'scrollTop'>
 
 export const chatScrollDistanceFromBottom = (metrics: ChatScrollMetrics) =>
   Math.max(0, metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight)
@@ -9,3 +10,44 @@ export const isChatScrollNearBottom = (
   metrics: ChatScrollMetrics,
   thresholdPx = CHAT_SCROLL_BOTTOM_THRESHOLD_PX
 ) => chatScrollDistanceFromBottom(metrics) <= thresholdPx
+
+type ResolveChatScrollPinnedStateInput = {
+  current: ChatScrollMetrics
+  previous: ChatScrollMetrics | null
+  wasPinned: boolean
+  thresholdPx?: number
+  scrollTopTolerancePx?: number
+}
+
+const maxScrollTop = (metrics: ChatScrollMetrics) =>
+  Math.max(0, metrics.scrollHeight - metrics.clientHeight)
+
+export const resolveChatScrollPinnedState = ({
+  current,
+  previous,
+  wasPinned,
+  thresholdPx = CHAT_SCROLL_BOTTOM_THRESHOLD_PX,
+  scrollTopTolerancePx = CHAT_SCROLL_TOP_TOLERANCE_PX
+}: ResolveChatScrollPinnedStateInput) => {
+  if (isChatScrollNearBottom(current, thresholdPx)) {
+    return true
+  }
+
+  if (!previous) {
+    return wasPinned
+  }
+
+  if (!wasPinned) {
+    return false
+  }
+
+  const layoutChanged = current.scrollHeight !== previous.scrollHeight
+    || current.clientHeight !== previous.clientHeight
+  if (!layoutChanged) {
+    return false
+  }
+
+  const scrollTopMovedUp = current.scrollTop < previous.scrollTop - scrollTopTolerancePx
+  const scrollableRangeShrank = maxScrollTop(current) < maxScrollTop(previous)
+  return !scrollTopMovedUp || scrollableRangeShrank
+}

--- a/packages/client/app/utils/skill-reference-badge.ts
+++ b/packages/client/app/utils/skill-reference-badge.ts
@@ -79,6 +79,21 @@ const decodeSkillHref = (href: unknown) => {
   }
 }
 
+const isRawSkillReferenceNode = (node: ComarkNode): node is ComarkElement => {
+  return isElementNode(node)
+    && node[0] === SKILL_REFERENCE_BADGE_TAG
+    && node[1].raw === 'true'
+}
+
+const getRawSkillReferenceNodeName = (node: ComarkNode) => {
+  if (!isRawSkillReferenceNode(node)) {
+    return null
+  }
+
+  const name = node[1].name
+  return typeof name === 'string' && name ? name : null
+}
+
 const getSkillLinkReference = (node: ComarkElement) => {
   if (node[0] !== 'a') {
     return null
@@ -90,12 +105,27 @@ const getSkillLinkReference = (node: ComarkElement) => {
     return null
   }
 
-  const children = node.slice(2)
-  if (children.length !== 1 || typeof children[0] !== 'string') {
+  const children = node.slice(2) as ComarkNode[]
+  if (children.length !== 1) {
     return null
   }
 
-  const match = SKILL_LINK_LABEL_PATTERN.exec(children[0].trim())
+  const [label] = children
+  if (label == null) {
+    return null
+  }
+
+  if (typeof label !== 'string') {
+    const rawSkillName = getRawSkillReferenceNodeName(label)
+    return rawSkillName
+      ? {
+          name: rawSkillName,
+          path: href
+        }
+      : null
+  }
+
+  const match = SKILL_LINK_LABEL_PATTERN.exec(label.trim())
   if (!match?.[1]) {
     return null
   }
@@ -104,12 +134,6 @@ const getSkillLinkReference = (node: ComarkElement) => {
     name: match[1],
     path: href
   }
-}
-
-const isRawSkillReferenceNode = (node: ComarkNode) => {
-  return isElementNode(node)
-    && node[0] === SKILL_REFERENCE_BADGE_TAG
-    && node[1].raw === 'true'
 }
 
 const removeRawSkillAutoCloseMarkers = (children: ComarkNode[]) => {
@@ -197,6 +221,7 @@ const skillReferenceBadgeMarkdownItPlugin = (md: MarkdownItParser) => {
       return false
     }
 
+    state.pos += match.length
     if (silent) {
       return true
     }
@@ -206,7 +231,6 @@ const skillReferenceBadgeMarkdownItPlugin = (md: MarkdownItParser) => {
     token.attrSet('raw', 'true')
     token.markup = '$'
     token.content = match.name
-    state.pos += match.length
     return true
   })
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codori/client",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": false,
   "description": "Codori Nuxt dashboard for project browsing, Codex chat, and thread resume.",
   "type": "module",

--- a/packages/client/shared/codex-chat.ts
+++ b/packages/client/shared/codex-chat.ts
@@ -105,7 +105,7 @@ export type ItemData =
       item: Extract<ThreadItem, { type: 'contextCompaction' }>
     }
 
-export type GroupableToolKind = Exclude<ItemData['kind'], 'subagent_activity'>
+export type GroupableToolKind = Exclude<ItemData['kind'], 'subagent_activity' | 'context_compaction'>
 
 export type ToolCallGroupData = {
   id: string
@@ -166,8 +166,7 @@ const groupableToolKinds: GroupableToolKind[] = [
   'file_change',
   'mcp_tool_call',
   'dynamic_tool_call',
-  'web_search',
-  'context_compaction'
+  'web_search'
 ]
 
 const groupableToolKindLabels: Record<GroupableToolKind, { singular: string, plural: string }> = {
@@ -175,8 +174,7 @@ const groupableToolKindLabels: Record<GroupableToolKind, { singular: string, plu
   file_change: { singular: 'edit', plural: 'edits' },
   mcp_tool_call: { singular: 'MCP tool', plural: 'MCP tools' },
   dynamic_tool_call: { singular: 'internal tool', plural: 'internal tools' },
-  web_search: { singular: 'web search', plural: 'web searches' },
-  context_compaction: { singular: 'compaction', plural: 'compactions' }
+  web_search: { singular: 'web search', plural: 'web searches' }
 }
 
 const pluralize = (count: number, labels: { singular: string, plural: string }) =>
@@ -216,8 +214,6 @@ const isSuccessfullyCompletedToolMessage = (message: ChatMessage) => {
       return part.data.item.status === 'completed'
     case 'web_search':
       return part.data.status === 'completed'
-    case 'context_compaction':
-      return true
     default:
       return false
   }

--- a/packages/client/shared/codex-chat.ts
+++ b/packages/client/shared/codex-chat.ts
@@ -376,6 +376,29 @@ export const hasAssistantTextMessageWithText = (messages: ChatMessage[], text: s
   )
 }
 
+const isTurnBoundaryMessage = (message: ChatMessage) =>
+  message.role === 'user'
+  || (
+    message.role === 'system'
+    && message.parts.some(part =>
+      part.type === EVENT_PART
+      && part.data.kind === 'turn.started'
+    )
+  )
+
+const findLatestTurnBoundaryIndex = (messages: ChatMessage[]) => {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (isTurnBoundaryMessage(messages[index]!)) {
+      return index
+    }
+  }
+
+  return -1
+}
+
+export const hasAssistantTextMessageWithTextInLatestTurn = (messages: ChatMessage[], text: string) =>
+  hasAssistantTextMessageWithText(messages.slice(findLatestTurnBoundaryIndex(messages) + 1), text)
+
 const isSyntheticReviewOutputMessage = (message: ChatMessage, text: string) =>
   message.id.endsWith('-review-output')
   && message.role === 'assistant'
@@ -386,6 +409,14 @@ const isSyntheticReviewOutputMessage = (message: ChatMessage, text: string) =>
 
 export const removeSyntheticReviewOutputMessages = (messages: ChatMessage[], text: string) =>
   messages.filter(message => !isSyntheticReviewOutputMessage(message, text))
+
+export const removeSyntheticReviewOutputMessagesInLatestTurn = (messages: ChatMessage[], text: string) => {
+  const latestTurnBoundaryIndex = findLatestTurnBoundaryIndex(messages)
+  return messages.filter((message, index) =>
+    index <= latestTurnBoundaryIndex
+    || !isSyntheticReviewOutputMessage(message, text)
+  )
+}
 
 const userInputToParts = (input: UserInput): ChatPart[] => {
   if (input.type === 'text') {

--- a/packages/client/shared/codex-chat.ts
+++ b/packages/client/shared/codex-chat.ts
@@ -161,6 +161,12 @@ export type ChatMessage = {
   parts: ChatPart[]
 }
 
+type ItemToMessagesOptions = {
+  webSearchPending?: boolean
+  webSearchStatus?: WebSearchStatus
+  includeReviewOutput?: boolean
+}
+
 const groupableToolKinds: GroupableToolKind[] = [
   'command_execution',
   'file_change',
@@ -349,6 +355,38 @@ const attachmentMediaTypeFromUrl = (url: string) => {
   return match?.[1] || 'image/*'
 }
 
+const normalizeReviewOutputText = (text: string) =>
+  text.replace(/\r\n?/gu, '\n').trim()
+
+const hasSameReviewOutputText = (left: string, right: string) =>
+  normalizeReviewOutputText(left) === normalizeReviewOutputText(right)
+
+export const hasAssistantTextMessageWithText = (messages: ChatMessage[], text: string) => {
+  const normalizedText = normalizeReviewOutputText(text)
+  if (!normalizedText) {
+    return false
+  }
+
+  return messages.some(message =>
+    message.role === 'assistant'
+    && message.parts.some(part =>
+      part.type === 'text'
+      && normalizeReviewOutputText(part.text) === normalizedText
+    )
+  )
+}
+
+const isSyntheticReviewOutputMessage = (message: ChatMessage, text: string) =>
+  message.id.endsWith('-review-output')
+  && message.role === 'assistant'
+  && message.parts.some(part =>
+    part.type === 'text'
+    && hasSameReviewOutputText(part.text, text)
+  )
+
+export const removeSyntheticReviewOutputMessages = (messages: ChatMessage[], text: string) =>
+  messages.filter(message => !isSyntheticReviewOutputMessage(message, text))
+
 const userInputToParts = (input: UserInput): ChatPart[] => {
   if (input.type === 'text') {
     if (!input.text.trim()) {
@@ -414,10 +452,7 @@ const shouldHideReviewBootstrapUserMessage = (
 
 export const itemToMessages = (
   item: ThreadItem,
-  options: {
-    webSearchPending?: boolean
-    webSearchStatus?: WebSearchStatus
-  } = {}
+  options: ItemToMessagesOptions = {}
 ): ChatMessage[] => {
   switch (item.type) {
     case 'userMessage':
@@ -562,7 +597,7 @@ export const itemToMessages = (
         }]
       }]
     case 'exitedReviewMode': {
-      return [{
+      const messages: ChatMessage[] = [{
         id: `${item.id}-review-completed`,
         role: 'system',
         parts: [{
@@ -571,20 +606,32 @@ export const itemToMessages = (
             kind: 'review.completed'
           }
         }]
-      }, {
-        id: `${item.id}-review-output`,
-        role: 'assistant',
-        parts: [{
-          type: 'text',
-          text: item.review,
-          state: 'done'
-        }]
       }]
+
+      if (options.includeReviewOutput !== false) {
+        messages.push({
+          id: `${item.id}-review-output`,
+          role: 'assistant',
+          parts: [{
+            type: 'text',
+            text: item.review,
+            state: 'done'
+          }]
+        })
+      }
+
+      return messages
     }
     default:
       return []
   }
 }
+
+const turnHasAgentMessageWithReviewOutput = (turn: Turn, reviewOutput: string) =>
+  turn.items.some(item =>
+    item.type === 'agentMessage'
+    && hasSameReviewOutputText(item.text, reviewOutput)
+  )
 
 export const threadToMessages = (thread: Thread) =>
   thread.turns.flatMap((turn) =>
@@ -594,6 +641,9 @@ export const threadToMessages = (thread: Thread) =>
       }
 
       return itemToMessages(item, {
+        includeReviewOutput: item.type === 'exitedReviewMode'
+          ? !turnHasAgentMessageWithReviewOutput(turn, item.review)
+          : undefined,
         webSearchPending: item.type === 'webSearch' && turn.status === 'inProgress',
         webSearchStatus: item.type === 'webSearch'
           ? (turn.status === 'failed'

--- a/packages/client/test/ansi-output.test.ts
+++ b/packages/client/test/ansi-output.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseAnsiOutput } from '../app/utils/ansi-output'
+
+describe('parseAnsiOutput', () => {
+  it('renders SGR text colors and resets without leaking escape codes', () => {
+    const segments = parseAnsiOutput('ok \x1B[31mred\x1B[0m done')
+
+    expect(segments).toEqual([
+      {
+        text: 'ok ',
+        style: {}
+      },
+      {
+        text: 'red',
+        style: {
+          color: '#dc2626'
+        }
+      },
+      {
+        text: ' done',
+        style: {}
+      }
+    ])
+  })
+
+  it('supports bold, background color, and 24-bit colors', () => {
+    const segments = parseAnsiOutput('\x1B[1;42mgreen bg\x1B[22;48;2;12;34;56m rgb bg')
+
+    expect(segments).toEqual([
+      {
+        text: 'green bg',
+        style: {
+          backgroundColor: '#14532d',
+          fontWeight: '700'
+        }
+      },
+      {
+        text: ' rgb bg',
+        style: {
+          backgroundColor: 'rgb(12, 34, 56)'
+        }
+      }
+    ])
+  })
+
+  it('strips unsupported ANSI control sequences', () => {
+    const segments = parseAnsiOutput('before\x1B[2Kafter\x1B]0;title\x07')
+
+    expect(segments).toEqual([
+      {
+        text: 'beforeafter',
+        style: {}
+      }
+    ])
+  })
+})

--- a/packages/client/test/chat-scroll.test.ts
+++ b/packages/client/test/chat-scroll.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   CHAT_SCROLL_BOTTOM_THRESHOLD_PX,
   chatScrollDistanceFromBottom,
-  isChatScrollNearBottom
+  isChatScrollNearBottom,
+  resolveChatScrollPinnedState
 } from '../app/utils/chat-scroll'
 
 describe('chat scroll state', () => {
@@ -24,6 +25,98 @@ describe('chat scroll state', () => {
       scrollHeight: 1000,
       scrollTop: 479,
       clientHeight: 500
+    })).toBe(false)
+  })
+
+  it('preserves the existing pin state before the first scroll measurement', () => {
+    expect(resolveChatScrollPinnedState({
+      wasPinned: true,
+      previous: null,
+      current: {
+        scrollHeight: 1000,
+        scrollTop: 0,
+        clientHeight: 500
+      }
+    })).toBe(true)
+  })
+
+  it('keeps the transcript pinned when content grows after reaching the bottom', () => {
+    expect(resolveChatScrollPinnedState({
+      wasPinned: true,
+      previous: {
+        scrollHeight: 1000,
+        scrollTop: 500,
+        clientHeight: 500
+      },
+      current: {
+        scrollHeight: 1120,
+        scrollTop: 500,
+        clientHeight: 500
+      }
+    })).toBe(true)
+  })
+
+  it('keeps the transcript pinned when the viewport shrinks after reaching the bottom', () => {
+    expect(resolveChatScrollPinnedState({
+      wasPinned: true,
+      previous: {
+        scrollHeight: 1000,
+        scrollTop: 500,
+        clientHeight: 500
+      },
+      current: {
+        scrollHeight: 1000,
+        scrollTop: 500,
+        clientHeight: 440
+      }
+    })).toBe(true)
+  })
+
+  it('keeps the transcript pinned when collapsing content clamps scrollTop upward', () => {
+    expect(resolveChatScrollPinnedState({
+      wasPinned: true,
+      previous: {
+        scrollHeight: 1200,
+        scrollTop: 700,
+        clientHeight: 500
+      },
+      current: {
+        scrollHeight: 1000,
+        scrollTop: 500,
+        clientHeight: 500
+      }
+    })).toBe(true)
+  })
+
+  it('does not stay pinned when the user scrolls upward', () => {
+    expect(resolveChatScrollPinnedState({
+      wasPinned: true,
+      previous: {
+        scrollHeight: 1000,
+        scrollTop: 500,
+        clientHeight: 500
+      },
+      current: {
+        scrollHeight: 1000,
+        scrollTop: 450,
+        clientHeight: 500
+      }
+    })).toBe(false)
+  })
+
+  it('does not pin layout changes when the transcript was already unpinned', () => {
+    expect(resolveChatScrollPinnedState({
+      wasPinned: false,
+      previous: {
+        scrollHeight: 1000,
+        scrollTop: 300,
+        clientHeight: 500
+      },
+      current: {
+        scrollHeight: 1120,
+        scrollTop: 300,
+        clientHeight: 500
+      }
     })).toBe(false)
   })
 })

--- a/packages/client/test/chat-transcript.test.ts
+++ b/packages/client/test/chat-transcript.test.ts
@@ -9,8 +9,10 @@ import {
   findLatestPlanTurnId,
   groupTranscriptMessages,
   hasAssistantTextMessageWithText,
+  hasAssistantTextMessageWithTextInLatestTurn,
   itemToMessages,
   removeSyntheticReviewOutputMessages,
+  removeSyntheticReviewOutputMessagesInLatestTurn,
   threadToMessages,
   replaceStreamingMessage,
   upsertStreamingMessage,
@@ -549,6 +551,85 @@ describe('chat transcript stability', () => {
       realReviewOutput
     ], 'Final review output')).toEqual([
       realReviewOutput
+    ])
+  })
+
+  it('scopes live review output dedupe to the latest turn', () => {
+    const previousReviewOutput: ChatMessage = {
+      id: 'agent-previous',
+      role: 'assistant',
+      parts: [{
+        type: 'text',
+        text: 'Looks good',
+        state: 'done'
+      }]
+    }
+    const latestUserMessage: ChatMessage = {
+      id: 'user-latest',
+      role: 'user',
+      parts: [{
+        type: 'text',
+        text: 'Review again',
+        state: 'done'
+      }]
+    }
+    const currentReviewOutput: ChatMessage = {
+      id: 'agent-current',
+      role: 'assistant',
+      parts: [{
+        type: 'text',
+        text: 'Looks good',
+        state: 'done'
+      }]
+    }
+
+    expect(hasAssistantTextMessageWithTextInLatestTurn([
+      previousReviewOutput,
+      latestUserMessage
+    ], 'Looks good')).toBe(false)
+    expect(hasAssistantTextMessageWithTextInLatestTurn([
+      previousReviewOutput,
+      latestUserMessage,
+      currentReviewOutput
+    ], 'Looks good')).toBe(true)
+  })
+
+  it('only removes matching synthetic review output from the latest turn', () => {
+    const previousSyntheticReviewOutput: ChatMessage = {
+      id: 'review-previous-review-output',
+      role: 'assistant',
+      parts: [{
+        type: 'text',
+        text: 'Looks good',
+        state: 'done'
+      }]
+    }
+    const latestUserMessage: ChatMessage = {
+      id: 'user-latest',
+      role: 'user',
+      parts: [{
+        type: 'text',
+        text: 'Review again',
+        state: 'done'
+      }]
+    }
+    const currentSyntheticReviewOutput: ChatMessage = {
+      id: 'review-current-review-output',
+      role: 'assistant',
+      parts: [{
+        type: 'text',
+        text: 'Looks good',
+        state: 'done'
+      }]
+    }
+
+    expect(removeSyntheticReviewOutputMessagesInLatestTurn([
+      previousSyntheticReviewOutput,
+      latestUserMessage,
+      currentSyntheticReviewOutput
+    ], 'Looks good')).toEqual([
+      previousSyntheticReviewOutput,
+      latestUserMessage
     ])
   })
 

--- a/packages/client/test/chat-transcript.test.ts
+++ b/packages/client/test/chat-transcript.test.ts
@@ -592,6 +592,55 @@ describe('chat transcript stability', () => {
     expect(grouped[1]).toBe(assistant)
   })
 
+  it('keeps context compaction separate from adjacent grouped tool items', () => {
+    const compaction = itemToMessages({
+      type: 'contextCompaction',
+      id: 'compact-1'
+    })
+    const command = itemToMessages({
+      type: 'commandExecution',
+      id: 'cmd-1',
+      command: 'pnpm test',
+      cwd: '/tmp',
+      processId: null,
+      source: 'agent',
+      status: 'completed',
+      commandActions: [],
+      aggregatedOutput: 'Tests passed',
+      exitCode: 0,
+      durationMs: 42
+    })
+    const search = itemToMessages({
+      type: 'webSearch',
+      id: 'search-1',
+      query: 'openai codex compaction',
+      action: null
+    })
+    const assistant: ChatMessage = {
+      id: 'assistant-1',
+      role: 'assistant',
+      parts: [{
+        type: 'text',
+        text: 'Done',
+        state: 'done'
+      }]
+    }
+
+    const grouped = groupTranscriptMessages([...compaction, ...command, ...search, assistant])
+
+    expect(grouped).toHaveLength(3)
+    expect(grouped[0]).toEqual(compaction[0])
+    expect(grouped[1]?.parts[0]).toMatchObject({
+      type: TOOL_GROUP_PART,
+      data: {
+        summary: '2 tool calls',
+        details: '1 command, 1 web search',
+        messages: [...command, ...search]
+      }
+    })
+    expect(grouped[2]).toBe(assistant)
+  })
+
   it('keeps the active streaming tool tail ungrouped', () => {
     const running = itemToMessages({
       type: 'mcpToolCall',

--- a/packages/client/test/chat-transcript.test.ts
+++ b/packages/client/test/chat-transcript.test.ts
@@ -8,7 +8,9 @@ import {
   findLatestCompletedPlanTurnId,
   findLatestPlanTurnId,
   groupTranscriptMessages,
+  hasAssistantTextMessageWithText,
   itemToMessages,
+  removeSyntheticReviewOutputMessages,
   threadToMessages,
   replaceStreamingMessage,
   upsertStreamingMessage,
@@ -478,6 +480,76 @@ describe('chat transcript stability', () => {
         state: 'done'
       }]
     }])
+  })
+
+  it('does not duplicate review output when the server also sends an assistant message', () => {
+    expect(threadToMessages(makeThread({
+      id: 'thread-1',
+      preview: '',
+      cwd: '/tmp',
+      createdAt: 0,
+      updatedAt: 0,
+      name: null,
+      turns: [makeTurn({
+        id: 'turn-1',
+        status: 'completed',
+        error: null,
+        items: [{
+          type: 'exitedReviewMode',
+          id: 'review-1',
+          review: 'Final review output'
+        }, asAgentMessageItem({
+          id: 'agent-review-1',
+          text: 'Final review output'
+        })]
+      })]
+    }))).toEqual<ChatMessage[]>([{
+      id: 'review-1-review-completed',
+      role: 'system',
+      parts: [{
+        type: 'data-thread-event',
+        data: {
+          kind: 'review.completed'
+        }
+      }]
+    }, {
+      id: 'agent-review-1',
+      role: 'assistant',
+      parts: [{
+        type: 'text',
+        text: 'Final review output',
+        state: 'done'
+      }]
+    }])
+  })
+
+  it('removes synthetic review output once the real assistant review message arrives', () => {
+    const syntheticReviewOutput: ChatMessage = {
+      id: 'review-1-review-output',
+      role: 'assistant',
+      parts: [{
+        type: 'text',
+        text: 'Final review output',
+        state: 'done'
+      }]
+    }
+    const realReviewOutput: ChatMessage = {
+      id: 'agent-review-1',
+      role: 'assistant',
+      parts: [{
+        type: 'text',
+        text: 'Final review output',
+        state: 'done'
+      }]
+    }
+
+    expect(hasAssistantTextMessageWithText([syntheticReviewOutput], 'Final review output')).toBe(true)
+    expect(removeSyntheticReviewOutputMessages([
+      syntheticReviewOutput,
+      realReviewOutput
+    ], 'Final review output')).toEqual([
+      realReviewOutput
+    ])
   })
 
   it('keeps hydrated web-search items pending for in-progress turns', () => {

--- a/packages/client/test/command-execution-message-item.test.ts
+++ b/packages/client/test/command-execution-message-item.test.ts
@@ -88,4 +88,30 @@ describe('CommandExecution', () => {
     expect(wrapper.text()).toContain('Exit code 0')
     expect(wrapper.text()).not.toContain('Run failed · exit code 0')
   })
+
+  it('renders ANSI-styled output without exposing escape codes', () => {
+    const wrapper = mount(CommandExecution, {
+      props: {
+        item: makeCommandItem({
+          aggregatedOutput: 'plain \x1B[31;1mred bold\x1B[0m done'
+        })
+      },
+      global: {
+        stubs: {
+          UChatTool: ChatToolStub
+        }
+      }
+    })
+
+    const segments = wrapper.findAll('[data-ansi-output-segment]')
+    expect(wrapper.text()).toContain('plain red bold done')
+    expect(wrapper.text()).not.toContain('\x1B[31;1m')
+    expect(segments.map(segment => segment.element.textContent)).toEqual([
+      'plain ',
+      'red bold',
+      ' done'
+    ])
+    expect(segments[1]?.attributes('style')).toContain('color: rgb(220, 38, 38)')
+    expect(segments[1]?.attributes('style')).toContain('font-weight: 700')
+  })
 })

--- a/packages/client/test/command-execution-message-item.test.ts
+++ b/packages/client/test/command-execution-message-item.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import { describe, expect, it } from 'vitest'
+import type { CommandExecutionItem } from '../shared/codex-chat'
+
+import CommandExecution from '../app/components/message-item/CommandExecution.vue'
+
+const ChatToolStub = defineComponent({
+  name: 'UChatTool',
+  props: {
+    text: {
+      type: String,
+      default: ''
+    },
+    suffix: {
+      type: String,
+      default: ''
+    },
+    icon: {
+      type: String,
+      default: ''
+    }
+  },
+  template: `
+    <section data-testid="command-tool">
+      <header>
+        <span data-testid="title">{{ text }}</span>
+        <span data-testid="suffix">{{ suffix }}</span>
+        <span data-testid="icon">{{ icon }}</span>
+      </header>
+      <slot />
+    </section>
+  `
+})
+
+const makeCommandItem = (overrides: Partial<CommandExecutionItem> = {}): CommandExecutionItem => ({
+  type: 'commandExecution',
+  id: 'cmd-1',
+  command: 'rg missing-pattern',
+  cwd: '/tmp',
+  processId: null,
+  source: 'agent',
+  status: 'completed',
+  commandActions: [],
+  aggregatedOutput: '',
+  exitCode: 0,
+  durationMs: 12,
+  ...overrides
+})
+
+describe('CommandExecution', () => {
+  it('shows failed commands as muted metadata instead of a large alert', () => {
+    const wrapper = mount(CommandExecution, {
+      props: {
+        item: makeCommandItem({
+          status: 'failed',
+          exitCode: 1
+        })
+      },
+      global: {
+        stubs: {
+          UChatTool: ChatToolStub
+        }
+      }
+    })
+
+    expect(wrapper.get('[data-testid="title"]').text()).toBe('Run failed')
+    expect(wrapper.get('[data-testid="icon"]').text()).toBe('i-lucide-terminal')
+    expect(wrapper.text()).toContain('Run failed · exit code 1')
+    expect(wrapper.text()).not.toContain('Command failed with exit code 1')
+    expect(wrapper.findComponent({ name: 'UAlert' }).exists()).toBe(false)
+  })
+
+  it('keeps successful exit codes neutral', () => {
+    const wrapper = mount(CommandExecution, {
+      props: {
+        item: makeCommandItem()
+      },
+      global: {
+        stubs: {
+          UChatTool: ChatToolStub
+        }
+      }
+    })
+
+    expect(wrapper.text()).toContain('Exit code 0')
+    expect(wrapper.text()).not.toContain('Run failed · exit code 0')
+  })
+})

--- a/packages/client/test/context-compaction-message-item.test.ts
+++ b/packages/client/test/context-compaction-message-item.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { describe, expect, it } from 'vitest'
+
+import ContextCompaction from '../app/components/message-item/ContextCompaction.vue'
+import MessagePartItem from '../app/components/message-part/Item'
+import {
+  ITEM_PART,
+  type ChatPart
+} from '../shared/codex-chat'
+
+const SeparatorStub = defineComponent({
+  name: 'USeparator',
+  props: {
+    label: {
+      type: String,
+      default: ''
+    },
+    color: {
+      type: String,
+      default: undefined
+    },
+    type: {
+      type: String,
+      default: undefined
+    }
+  },
+  setup(props) {
+    return () => h('div', {
+      class: 'separator-stub',
+      'data-label': props.label,
+      'data-color': props.color,
+      'data-type': props.type
+    }, props.label)
+  }
+})
+
+describe('ContextCompaction', () => {
+  it('shows a compacting separator while the item is pending', () => {
+    const wrapper = mount(ContextCompaction, {
+      props: {
+        pending: true
+      },
+      global: {
+        stubs: {
+          USeparator: SeparatorStub
+        }
+      }
+    })
+
+    expect(wrapper.text()).toBe('.. compacting thread ..')
+    expect(wrapper.get('.separator-stub').attributes('data-type')).toBe('dashed')
+  })
+
+  it('shows a compacted separator after completion', () => {
+    const wrapper = mount(ContextCompaction, {
+      global: {
+        stubs: {
+          USeparator: SeparatorStub
+        }
+      }
+    })
+
+    expect(wrapper.text()).toBe('...compacted thread...')
+    expect(wrapper.get('.separator-stub').attributes('data-color')).toBe('neutral')
+  })
+
+  it('uses the parent message pending state for context compaction items', () => {
+    const part: Extract<ChatPart, { type: typeof ITEM_PART }> = {
+      type: ITEM_PART,
+      data: {
+        kind: 'context_compaction',
+        item: {
+          type: 'contextCompaction',
+          id: 'compact-1'
+        }
+      }
+    }
+    const wrapper = mount(MessagePartItem, {
+      props: {
+        part,
+        messagePending: true
+      },
+      global: {
+        stubs: {
+          USeparator: SeparatorStub
+        }
+      }
+    })
+
+    expect(wrapper.text()).toBe('.. compacting thread ..')
+  })
+})

--- a/packages/client/test/skill-reference-badge-transform.test.ts
+++ b/packages/client/test/skill-reference-badge-transform.test.ts
@@ -87,6 +87,28 @@ describe('transformSkillReferenceBadges', () => {
 })
 
 describe('skillReferenceBadgePlugin', () => {
+  it('parses submitted skill markdown links before raw skill matching can break link labels', async () => {
+    const tree = await parse('Use [$imagegen](/Users/demo/.codex/skills/.system/imagegen/SKILL.md) now.', {
+      plugins: [
+        skillReferenceBadgePlugin()
+      ]
+    })
+
+    expect(tree.nodes).toEqual([
+      ['p', {},
+        'Use ',
+        [
+          SKILL_REFERENCE_BADGE_TAG,
+          {
+            name: 'imagegen',
+            path: '/Users/demo/.codex/skills/.system/imagegen/SKILL.md'
+          }
+        ],
+        ' now.'
+      ]
+    ])
+  })
+
   it('parses raw skill references before math auto-close consumes them', async () => {
     const tree = await parse('$skill-name additional text', {
       plugins: [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codori/server",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": false,
   "description": "Codori server for Git project discovery, Codex runtime management, and bundled dashboard serving.",
   "type": "module",


### PR DESCRIPTION
## Summary
- Separate compaction transcript events from grouped tool-call rendering and show the compacting/compacted states with the Nuxt UI separator treatment.
- Fix chat transcript rendering for skill references, muted command failures, ANSI-styled command output, and duplicated review output.
- Preserve pinned chat scrolling across tool/task layout changes while still showing Jump to latest when the user has intentionally scrolled away.
- Scope live review-output deduplication to the latest turn so repeated text from older turns cannot hide the current review result.
- Bump the root, client, and server package patch versions from 0.3.4 to 0.3.5.

## Why
These changes make chat transcript updates less noisy and more stable while long-running tool output, compaction, review, and task UI are changing the message layout. The version bump prepares the package set for the next patch release.

## Validation
- `pnpm --filter @codori/client test -- chat-transcript.test.ts`
- `pnpm --filter @codori/client test -- chat-scroll.test.ts`
- `pnpm --filter @codori/client lint`
- `pnpm --filter @codori/client typecheck`
- `pnpm --filter @codori/client build`
- `pnpm install --lockfile-only`
- `pnpm -r --if-present typecheck`
- `git diff --check`

## Notes
- `typecheck` still prints the existing Volar `vue-router/volar/sfc-route-blocks` resolve warning but exits 0.
- Local visual verification was blocked because the in-app browser rejected the local page and the Nuxt dev server request hit `Vite Node IPC socket path not configured`.
- While addressing review feedback, `lint` initially failed only because an ignored `packages/client/--host/.nuxt` artifact from an earlier local dev-server attempt was present; after removing that generated artifact, `pnpm --filter @codori/client lint` passed.
