### PR TITLE
Add image previews to local file viewer

### DIFF
--- a/packages/client/app/components/LocalFileViewerModal.vue
+++ b/packages/client/app/components/LocalFileViewerModal.vue
@@ -40,28 +40,46 @@ const relativePathLabel = computed(() => {
   return file.value.relativePath || file.value.name
 })
 
+const textFile = computed(() =>
+  file.value?.kind === 'text' ? file.value : null
+)
+
+const imageFile = computed(() =>
+  file.value?.kind === 'image' ? file.value : null
+)
+
 const lineCount = computed(() => {
-  if (!file.value) {
+  if (!textFile.value) {
     return 0
   }
 
-  return file.value.text.split('\n').length
+  return textFile.value.text.split('\n').length
 })
 
 const inferredLanguage = computed(() =>
-  file.value ? inferLocalFileLanguage(file.value.path, file.value.text) : null
+  textFile.value ? inferLocalFileLanguage(textFile.value.path, textFile.value.text) : null
 )
 
 const languageLabel = computed(() =>
   resolveLocalFileLanguageLabel(inferredLanguage.value)
 )
 
+const mediaTypeLabel = computed(() =>
+  imageFile.value?.mediaType ?? null
+)
+
+const imagePreviewSrc = computed(() =>
+  imageFile.value
+    ? `data:${imageFile.value.mediaType};base64,${imageFile.value.base64}`
+    : ''
+)
+
 const highlightedMarkdown = computed(() => {
-  if (!file.value) {
+  if (!textFile.value) {
     return ''
   }
 
-  return buildHighlightedFileMarkdown(file.value.text, inferredLanguage.value)
+  return buildHighlightedFileMarkdown(textFile.value.text, inferredLanguage.value)
 })
 
 const lineNumberWidth = computed(() =>
@@ -85,13 +103,18 @@ const isSameWorkspace = (left: WorkspaceLocalFileScope | null, right: WorkspaceL
   left?.kind === right?.kind && left?.id === right?.id
 
 const syncRenderedCodeLines = async () => {
-  if (!lineContainer.value) {
+  if (!textFile.value) {
     return
   }
 
   await nextTick()
+  await nextTick()
   requestAnimationFrame(() => {
-    const renderedLines = Array.from(lineContainer.value?.querySelectorAll<HTMLElement>('.line') ?? [])
+    if (!lineContainer.value || !textFile.value) {
+      return
+    }
+
+    const renderedLines = Array.from(lineContainer.value.querySelectorAll<HTMLElement>('.line'))
     for (const [index, line] of renderedLines.entries()) {
       const lineNumber = index + 1
       line.dataset.fileLine = String(lineNumber)
@@ -153,13 +176,13 @@ watch(
 )
 
 watch(() => state.value.line, () => {
-  if (file.value) {
+  if (textFile.value) {
     void syncRenderedCodeLines()
   }
 })
 
 watch(highlightedMarkdown, () => {
-  if (file.value) {
+  if (textFile.value) {
     void syncRenderedCodeLines()
   }
 }, { flush: 'post' })
@@ -188,10 +211,11 @@ watch(highlightedMarkdown, () => {
             </div>
             <div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted">
               <span v-if="file">{{ formatLocalFileSize(file.size) }}</span>
-              <span v-if="file">{{ lineCount }} lines</span>
+              <span v-if="textFile">{{ lineCount }} lines</span>
               <span v-if="updatedAtLabel">{{ updatedAtLabel }}</span>
+              <span v-if="mediaTypeLabel">{{ mediaTypeLabel }}</span>
               <span v-if="languageLabel">{{ languageLabel }}</span>
-              <span v-if="state.line">Line {{ state.line }}</span>
+              <span v-if="textFile && state.line">Line {{ state.line }}</span>
             </div>
           </div>
 
@@ -226,7 +250,20 @@ watch(highlightedMarkdown, () => {
         </div>
 
         <div
-          v-else-if="file"
+          v-else-if="imageFile"
+          class="local-file-viewer-image min-h-0 flex-1 overflow-auto bg-elevated/15"
+        >
+          <div class="flex min-h-full items-center justify-center p-6">
+            <img
+              class="max-h-full max-w-full object-contain"
+              :src="imagePreviewSrc"
+              :alt="imageFile.name"
+            >
+          </div>
+        </div>
+
+        <div
+          v-else-if="textFile"
           ref="lineContainer"
           class="local-file-viewer-code min-h-0 flex-1 overflow-auto bg-elevated/15"
           :style="{ '--lfv-line-number-width': lineNumberWidth }"

--- a/packages/client/app/components/LocalFileViewerModal.vue
+++ b/packages/client/app/components/LocalFileViewerModal.vue
@@ -108,7 +108,6 @@ const syncRenderedCodeLines = async () => {
   }
 
   await nextTick()
-  await nextTick()
   requestAnimationFrame(() => {
     if (!lineContainer.value || !textFile.value) {
       return

--- a/packages/client/shared/local-files.ts
+++ b/packages/client/shared/local-files.ts
@@ -7,15 +7,27 @@ export type LocalFileLinkTarget = {
   column: number | null
 }
 
+type LocalFileResponseBase = {
+  path: string
+  relativePath: string
+  name: string
+  size: number
+  updatedAt: number
+}
+
+export type LocalFileTextResponse = LocalFileResponseBase & {
+  kind: 'text'
+  text: string
+}
+
+export type LocalFileImageResponse = LocalFileResponseBase & {
+  kind: 'image'
+  mediaType: string
+  base64: string
+}
+
 export type ProjectLocalFileResponse = {
-  file: {
-    path: string
-    relativePath: string
-    name: string
-    size: number
-    updatedAt: number
-    text: string
-  }
+  file: LocalFileTextResponse | LocalFileImageResponse
 }
 
 export type WorkspaceLocalFileScope =

--- a/packages/client/test/local-file-viewer-modal.test.ts
+++ b/packages/client/test/local-file-viewer-modal.test.ts
@@ -1,0 +1,191 @@
+/* eslint-disable vue/one-component-per-file */
+// @vitest-environment jsdom
+
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent, h, nextTick } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import LocalFileViewerModal from '../app/components/LocalFileViewerModal.vue'
+import { useLocalFileViewer } from '../app/composables/useLocalFileViewer'
+
+const fetchMock = vi.fn()
+
+vi.mock('@comark/vue/plugins/highlight', () => ({
+  default: () => ({ name: 'highlight' })
+}))
+
+vi.mock('@comark/vue', () => ({
+  Comark: defineComponent({
+    name: 'MockComark',
+    props: {
+      markdown: {
+        type: String,
+        required: true
+      }
+    },
+    setup(props) {
+      return () => {
+        const lines = props.markdown
+          .split('\n')
+          .slice(1, -1)
+        return h('pre', { class: 'shiki' }, [
+          h('code', lines.map(line => h('span', { class: 'line' }, line)))
+        ])
+      }
+    }
+  })
+}))
+
+const ModalStub = defineComponent({
+  name: 'ModalStub',
+  props: {
+    open: {
+      type: Boolean,
+      default: false
+    }
+  },
+  setup(props, { slots }) {
+    return () => props.open
+      ? h('div', { class: 'modal-stub' }, slots.body?.())
+      : null
+  }
+})
+
+const ButtonStub = defineComponent({
+  name: 'ButtonStub',
+  props: {
+    ariaLabel: {
+      type: String,
+      default: ''
+    }
+  },
+  emits: ['click'],
+  setup(props, { emit }) {
+    return () => h('button', {
+      'aria-label': props.ariaLabel,
+      onClick: (event: MouseEvent) => emit('click', event)
+    })
+  }
+})
+
+const AlertStub = defineComponent({
+  name: 'AlertStub',
+  props: {
+    title: {
+      type: String,
+      default: ''
+    }
+  },
+  setup(props) {
+    return () => h('div', { class: 'alert-stub' }, props.title)
+  }
+})
+
+const openViewer = (input: { path: string, line?: number | null }) => {
+  const { openViewer: openLocalFileViewer } = useLocalFileViewer()
+  openLocalFileViewer({
+    workspace: { kind: 'project', id: 'demo' },
+    path: input.path,
+    line: input.line ?? null
+  })
+}
+
+const mountModal = () =>
+  mount(LocalFileViewerModal, {
+    global: {
+      stubs: {
+        UModal: ModalStub,
+        UButton: ButtonStub,
+        UAlert: AlertStub
+      }
+    }
+  })
+
+describe('LocalFileViewerModal', () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    const { state } = useLocalFileViewer()
+    state.value = {
+      open: false,
+      workspace: null,
+      projectId: null,
+      path: null,
+      line: null,
+      column: null
+    }
+    vi.stubGlobal('$fetch', fetchMock)
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      setTimeout(() => callback(0), 0)
+      return 1
+    })
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  it('keeps text previews in the highlighted source viewer with target-line metadata', async () => {
+    openViewer({
+      path: '/Users/demo/Project/codori/src/viewer.ts',
+      line: 2
+    })
+    fetchMock.mockResolvedValue({
+      file: {
+        kind: 'text',
+        path: '/Users/demo/Project/codori/src/viewer.ts',
+        relativePath: 'src/viewer.ts',
+        name: 'viewer.ts',
+        size: 35,
+        updatedAt: Date.UTC(2026, 4, 9, 6, 0),
+        text: 'const first = 1\nconst second = 2\n'
+      }
+    })
+
+    const wrapper = mountModal()
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+    await nextTick()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    const requestedUrl = new URL(String(fetchMock.mock.calls[0]?.[0]), 'http://localhost')
+    expect(requestedUrl.pathname).toBe('/api/projects/demo/local-file')
+    expect(requestedUrl.searchParams.get('path')).toBe('/Users/demo/Project/codori/src/viewer.ts')
+    expect(wrapper.find('.local-file-viewer-code').exists()).toBe(true)
+    expect(wrapper.find('img').exists()).toBe(false)
+    expect(wrapper.text()).toContain('src/viewer.ts')
+    expect(wrapper.text()).toContain('3 lines')
+    expect(wrapper.text()).toContain('TypeScript')
+    expect(wrapper.text()).toContain('Line 2')
+    expect(wrapper.get('[data-file-line="2"]').classes()).toContain('is-target-line')
+  })
+
+  it('renders image previews without the markdown source viewer metadata', async () => {
+    openViewer({
+      path: '/Users/demo/Project/codori/assets/pixel.png'
+    })
+    fetchMock.mockResolvedValue({
+      file: {
+        kind: 'image',
+        path: '/Users/demo/Project/codori/assets/pixel.png',
+        relativePath: 'assets/pixel.png',
+        name: 'pixel.png',
+        size: 68,
+        updatedAt: Date.UTC(2026, 4, 9, 6, 0),
+        mediaType: 'image/png',
+        base64: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ'
+      }
+    })
+
+    const wrapper = mountModal()
+    await flushPromises()
+    await nextTick()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    const image = wrapper.get('img')
+    expect(wrapper.find('.local-file-viewer-image').exists()).toBe(true)
+    expect(wrapper.find('.local-file-viewer-code').exists()).toBe(false)
+    expect(image.attributes('src')).toBe('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ')
+    expect(image.attributes('alt')).toBe('pixel.png')
+    expect(wrapper.text()).toContain('assets/pixel.png')
+    expect(wrapper.text()).toContain('image/png')
+    expect(wrapper.text()).not.toContain('lines')
+    expect(wrapper.text()).not.toContain('Line')
+  })
+})

--- a/packages/client/test/mocks/nuxt-imports.ts
+++ b/packages/client/test/mocks/nuxt-imports.ts
@@ -1,0 +1,29 @@
+import { ref, type Ref } from 'vue'
+
+const stateByKey = new Map<string, Ref<unknown>>()
+
+export const useRuntimeConfig = () => ({
+  public: {
+    serverBase: '',
+    serverWsBase: ''
+  }
+})
+
+export const useState = <T>(key: string, init?: () => T): Ref<T> => {
+  if (!stateByKey.has(key)) {
+    stateByKey.set(key, ref(init?.() ?? null))
+  }
+
+  return stateByKey.get(key) as Ref<T>
+}
+
+export const useRoute = () => ({
+  params: {},
+  query: {},
+  path: '/'
+})
+
+export const useRouter = () => ({
+  push: async () => {},
+  replace: async () => {}
+})

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [vue()],
   resolve: {
     alias: {
+      '#imports': fileURLToPath(new URL('./test/mocks/nuxt-imports.ts', import.meta.url)),
       '~~': fileURLToPath(new URL('.', import.meta.url))
     }
   },

--- a/packages/server/src/http-server.ts
+++ b/packages/server/src/http-server.ts
@@ -23,7 +23,7 @@ import {
 } from './attachment-store.js'
 import { CodoriError } from './errors.js'
 import { createGitBranch, listGitBranches, switchGitBranch } from './git.js'
-import { LocalFileViewError, readProjectLocalFile } from './local-file-viewer.js'
+import { LocalFileViewError, readProjectLocalFile, type LocalFileReadResult } from './local-file-viewer.js'
 import { createRuntimeManager } from './process-manager.js'
 import {
   createServiceUpdateController,
@@ -117,14 +117,7 @@ type ProjectGitBranchMutationRequest = {
 }
 
 type ProjectLocalFileResponse = {
-  file: {
-    path: string
-    relativePath: string
-    name: string
-    size: number
-    updatedAt: number
-    text: string
-  }
+  file: LocalFileReadResult
 }
 
 export type HttpServerOptions = {

--- a/packages/server/src/local-file-viewer.ts
+++ b/packages/server/src/local-file-viewer.ts
@@ -1,17 +1,30 @@
 import { basename, resolve } from 'node:path'
 import { readFile, realpath, stat } from 'node:fs/promises'
+import { lookup as lookupMimeType } from 'mime-types'
 import { isPathInsideDirectory } from './attachment-store.js'
 
 export const MAX_LOCAL_FILE_VIEW_BYTES = 1024 * 1024
 
-export type LocalFileReadResult = {
+type LocalFileReadResultBase = {
   path: string
   relativePath: string
   name: string
   size: number
   updatedAt: number
+}
+
+export type LocalFileTextReadResult = LocalFileReadResultBase & {
+  kind: 'text'
   text: string
 }
+
+export type LocalFileImageReadResult = LocalFileReadResultBase & {
+  kind: 'image'
+  mediaType: string
+  base64: string
+}
+
+export type LocalFileReadResult = LocalFileTextReadResult | LocalFileImageReadResult
 
 export class LocalFileViewError extends Error {
   readonly code: 'FORBIDDEN' | 'NOT_FOUND' | 'NOT_A_FILE' | 'TOO_LARGE' | 'BINARY'
@@ -34,6 +47,26 @@ const hasBinaryContent = (buffer: Buffer) => {
   }
 
   return false
+}
+
+const SUPPORTED_IMAGE_MEDIA_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'image/svg+xml'
+])
+
+const getSupportedImageMediaType = (filePath: string) => {
+  const inferred = lookupMimeType(filePath)
+  if (typeof inferred !== 'string') {
+    return null
+  }
+
+  const mediaType = inferred.toLowerCase()
+  return SUPPORTED_IMAGE_MEDIA_TYPES.has(mediaType)
+    ? mediaType
+    : null
 }
 
 export const readProjectLocalFile = async (
@@ -71,16 +104,31 @@ export const readProjectLocalFile = async (
   }
 
   const buffer = await readFile(resolvedTargetPath)
+  const baseFile = {
+    path: resolvedTargetPath,
+    relativePath: resolvedTargetPath.slice(resolvedProjectRoot.length).replace(/^[/\\]+/, ''),
+    name: basename(resolvedTargetPath),
+    size: fileStat.size,
+    updatedAt: fileStat.mtimeMs
+  }
+
+  const imageMediaType = getSupportedImageMediaType(resolvedTargetPath)
+  if (imageMediaType) {
+    return {
+      ...baseFile,
+      kind: 'image',
+      mediaType: imageMediaType,
+      base64: buffer.toString('base64')
+    }
+  }
+
   if (hasBinaryContent(buffer)) {
     throw new LocalFileViewError('BINARY', 'Binary files are not supported by the local file viewer.')
   }
 
   return {
-    path: resolvedTargetPath,
-    relativePath: resolvedTargetPath.slice(resolvedProjectRoot.length).replace(/^[/\\]+/, ''),
-    name: basename(resolvedTargetPath),
-    size: fileStat.size,
-    updatedAt: fileStat.mtimeMs,
+    ...baseFile,
+    kind: 'text',
     text: buffer.toString('utf8')
   }
 }

--- a/packages/server/src/local-file-viewer.ts
+++ b/packages/server/src/local-file-viewer.ts
@@ -1,4 +1,4 @@
-import { basename, resolve } from 'node:path'
+import { basename, relative, resolve } from 'node:path'
 import { readFile, realpath, stat } from 'node:fs/promises'
 import { lookup as lookupMimeType } from 'mime-types'
 import { isPathInsideDirectory } from './attachment-store.js'
@@ -27,7 +27,7 @@ export type LocalFileImageReadResult = LocalFileReadResultBase & {
 export type LocalFileReadResult = LocalFileTextReadResult | LocalFileImageReadResult
 
 export class LocalFileViewError extends Error {
-  readonly code: 'FORBIDDEN' | 'NOT_FOUND' | 'NOT_A_FILE' | 'TOO_LARGE' | 'BINARY'
+  readonly code: 'FORBIDDEN' | 'NOT_FOUND' | 'NOT_A_FILE' | 'TOO_LARGE' | 'BINARY' | 'UNSUPPORTED_MEDIA_TYPE'
 
   constructor(
     code: LocalFileViewError['code'],
@@ -69,6 +69,37 @@ const getSupportedImageMediaType = (filePath: string) => {
     : null
 }
 
+const startsWithBytes = (buffer: Buffer, signature: number[]) =>
+  signature.every((byte, index) => buffer[index] === byte)
+
+const hasValidSvgContent = (buffer: Buffer) => {
+  if (hasBinaryContent(buffer)) {
+    return false
+  }
+
+  const text = buffer.toString('utf8').replace(/^\uFEFF/u, '').trimStart()
+  return /^<svg(?:\s|>)/iu.test(text) || /^<\?xml[\s\S]*?<svg(?:\s|>)/iu.test(text)
+}
+
+const hasValidImageContent = (buffer: Buffer, mediaType: string) => {
+  switch (mediaType) {
+    case 'image/png':
+      return startsWithBytes(buffer, [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+    case 'image/jpeg':
+      return startsWithBytes(buffer, [0xFF, 0xD8, 0xFF])
+    case 'image/gif':
+      return buffer.subarray(0, 6).toString('ascii') === 'GIF87a'
+        || buffer.subarray(0, 6).toString('ascii') === 'GIF89a'
+    case 'image/webp':
+      return buffer.subarray(0, 4).toString('ascii') === 'RIFF'
+        && buffer.subarray(8, 12).toString('ascii') === 'WEBP'
+    case 'image/svg+xml':
+      return hasValidSvgContent(buffer)
+    default:
+      return false
+  }
+}
+
 export const readProjectLocalFile = async (
   projectRoot: string,
   requestedPath: string
@@ -106,7 +137,7 @@ export const readProjectLocalFile = async (
   const buffer = await readFile(resolvedTargetPath)
   const baseFile = {
     path: resolvedTargetPath,
-    relativePath: resolvedTargetPath.slice(resolvedProjectRoot.length).replace(/^[/\\]+/, ''),
+    relativePath: relative(resolvedProjectRoot, resolvedTargetPath),
     name: basename(resolvedTargetPath),
     size: fileStat.size,
     updatedAt: fileStat.mtimeMs
@@ -114,6 +145,13 @@ export const readProjectLocalFile = async (
 
   const imageMediaType = getSupportedImageMediaType(resolvedTargetPath)
   if (imageMediaType) {
+    if (!hasValidImageContent(buffer, imageMediaType)) {
+      throw new LocalFileViewError(
+        'UNSUPPORTED_MEDIA_TYPE',
+        'Local image preview is only available for valid PNG, JPEG, GIF, WebP, or SVG files.'
+      )
+    }
+
     return {
       ...baseFile,
       kind: 'image',

--- a/packages/server/test/http-server.test.ts
+++ b/packages/server/test/http-server.test.ts
@@ -1166,6 +1166,64 @@ describe('createHttpServer', () => {
     })
   })
 
+  it('rejects local image previews when file contents are not a valid image', async () => {
+    const projectPath = mkdtempSync(join(os.tmpdir(), 'codori-local-file-'))
+    tempDirs.push(projectPath)
+    const filePath = join(projectPath, 'assets', 'not-an-image.png')
+    mkdirSync(join(projectPath, 'assets'), { recursive: true })
+    writeFileSync(filePath, Buffer.from([0x00, 0x01, 0x02, 0x03]))
+
+    const app = await createHttpServer(createManager({
+      getProjectStatus: () => ({
+        ...createProjectRecord(),
+        projectPath
+      })
+    }))
+    startedApps.push(app)
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/projects/demo/local-file?path=${encodeURIComponent(filePath)}`
+    })
+
+    expect(response.statusCode).toBe(415)
+    expect(response.json()).toEqual({
+      error: {
+        code: 'UNSUPPORTED_MEDIA_TYPE',
+        message: 'Local image preview is only available for valid PNG, JPEG, GIF, WebP, or SVG files.'
+      }
+    })
+  })
+
+  it('rejects local image previews when text files are renamed with image extensions', async () => {
+    const projectPath = mkdtempSync(join(os.tmpdir(), 'codori-local-file-'))
+    tempDirs.push(projectPath)
+    const filePath = join(projectPath, 'assets', 'not-an-image.png')
+    mkdirSync(join(projectPath, 'assets'), { recursive: true })
+    writeFileSync(filePath, '<html>not an image</html>\n', 'utf8')
+
+    const app = await createHttpServer(createManager({
+      getProjectStatus: () => ({
+        ...createProjectRecord(),
+        projectPath
+      })
+    }))
+    startedApps.push(app)
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/projects/demo/local-file?path=${encodeURIComponent(filePath)}`
+    })
+
+    expect(response.statusCode).toBe(415)
+    expect(response.json()).toEqual({
+      error: {
+        code: 'UNSUPPORTED_MEDIA_TYPE',
+        message: 'Local image preview is only available for valid PNG, JPEG, GIF, WebP, or SVG files.'
+      }
+    })
+  })
+
   it('returns an inline image preview payload for chat local image files', async () => {
     const chatPath = mkdtempSync(join(os.tmpdir(), 'codori-local-chat-file-'))
     tempDirs.push(chatPath)

--- a/packages/server/test/http-server.test.ts
+++ b/packages/server/test/http-server.test.ts
@@ -1116,12 +1116,91 @@ describe('createHttpServer', () => {
     expect(response.statusCode).toBe(200)
     expect(response.json()).toEqual({
       file: {
+        kind: 'text',
         path: expect.stringMatching(/src\/viewer\.ts$/),
         relativePath: 'src/viewer.ts',
         name: 'viewer.ts',
         size: 'export const viewer = true\n'.length,
         updatedAt: expect.any(Number),
         text: 'export const viewer = true\n'
+      }
+    })
+  })
+
+  it('returns an inline image preview payload for project local image files', async () => {
+    const projectPath = mkdtempSync(join(os.tmpdir(), 'codori-local-file-'))
+    tempDirs.push(projectPath)
+    const filePath = join(projectPath, 'assets', 'pixel.png')
+    const imageBuffer = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+      'base64'
+    )
+    mkdirSync(join(projectPath, 'assets'), { recursive: true })
+    writeFileSync(filePath, imageBuffer)
+
+    const app = await createHttpServer(createManager({
+      getProjectStatus: () => ({
+        ...createProjectRecord(),
+        projectPath
+      })
+    }))
+    startedApps.push(app)
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/projects/demo/local-file?path=${encodeURIComponent(filePath)}`
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({
+      file: {
+        kind: 'image',
+        path: expect.stringMatching(/assets\/pixel\.png$/),
+        relativePath: 'assets/pixel.png',
+        name: 'pixel.png',
+        size: imageBuffer.length,
+        updatedAt: expect.any(Number),
+        mediaType: 'image/png',
+        base64: imageBuffer.toString('base64')
+      }
+    })
+  })
+
+  it('returns an inline image preview payload for chat local image files', async () => {
+    const chatPath = mkdtempSync(join(os.tmpdir(), 'codori-local-chat-file-'))
+    tempDirs.push(chatPath)
+    const filePath = join(chatPath, 'screenshots', 'preview.png')
+    const imageBuffer = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+      'base64'
+    )
+    mkdirSync(join(chatPath, 'screenshots'), { recursive: true })
+    writeFileSync(filePath, imageBuffer)
+
+    const app = await createHttpServer(createManager({
+      getChatStatus: () => ({
+        ...createChatRecord(),
+        chatPath
+      })
+    }))
+    startedApps.push(app)
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/chats/chat-test/local-file?path=${encodeURIComponent(filePath)}`
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({
+      file: {
+        kind: 'image',
+        path: expect.stringMatching(/screenshots\/preview\.png$/),
+        relativePath: 'screenshots/preview.png',
+        name: 'preview.png',
+        size: imageBuffer.length,
+        updatedAt: expect.any(Number),
+        mediaType: 'image/png',
+        base64: imageBuffer.toString('base64')
       }
     })
   })


### PR DESCRIPTION
## Summary
- extend the local-file preview response with text/image discriminated metadata
- allow supported image local files to return inline preview payloads while preserving workspace-root checks
- validate image contents before returning previews and keep invalid renamed files rejected
- render image previews in the existing modal and keep text highlighting/line targeting intact

## Commits
- cdc4444 feat: support image local file previews in server
- 6cb9be4 feat: render local image previews in client
- d28ba57 fix: harden local image preview handling

## Validation
- pnpm test
- pnpm lint
- pnpm typecheck
- pnpm build

Closes #66