### PR TITLE
Add /goal slash command flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codori",
   "private": true,
-  "version": "0.3.5",
+  "version": "0.4.0",
   "packageManager": "pnpm@10.33.2",
   "scripts": {
     "build": "pnpm --filter @codori/client build && pnpm --filter @codori/server build",

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -185,6 +185,7 @@ import {
   resolveSubagentAccent,
   toSubagentAvatarText
 } from '~~/shared/subagent-panels'
+import { goalStatusLabel } from '~~/shared/thread-goal'
 const props = defineProps<{
   projectId?: string
   chatId?: string
@@ -2210,7 +2211,6 @@ const {
 } = reviewWorkflow
 
 const goalWorkflow = useChatGoalWorkflow({
-  projectId: workspaceId.value,
   activeThreadId,
   threadGoals,
   ensurePendingLiveStream,
@@ -4917,7 +4917,7 @@ watch(
               <span class="shrink-0 font-medium">Goal</span>
               <span class="truncate">{{ currentThreadGoal.objective }}</span>
               <span class="shrink-0 text-muted">
-                {{ currentThreadGoal.status === 'budgetLimited' ? 'limited' : currentThreadGoal.status }}
+                {{ goalStatusLabel(currentThreadGoal.status) }}
               </span>
             </button>
           </div>

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -9,6 +9,7 @@ import {
   watch
 } from 'vue'
 import LocalFileViewerModal from './LocalFileViewerModal.vue'
+import GoalDrawer from './GoalDrawer.vue'
 import MessageContent from './MessageContent.vue'
 import PlanTaskListPanel from './PlanTaskListPanel.vue'
 import PlanImplementationPromptDrawer from './PlanImplementationPromptDrawer.vue'
@@ -44,6 +45,7 @@ import {
   type ThreadReactivationReason
 } from '../utils/thread-reactivation'
 import { useChatAttachments, type DraftAttachment } from '../composables/useChatAttachments'
+import { useChatGoalWorkflow } from '../composables/useChatGoalWorkflow'
 import { useChatPlanWorkflow } from '../composables/useChatPlanWorkflow'
 import { useChatReviewWorkflow } from '../composables/useChatReviewWorkflow'
 import { useSubagentPanelsController } from '../composables/useSubagentPanelsController'
@@ -284,6 +286,7 @@ const { syncThreadSummary, updateThreadSummaryTitle } = useThreadSummaries(works
 const {
   messages,
   subagentPanels,
+  threadGoals,
   threadPlans,
   threadCollaborationModeMasks,
   collaborationModeMasks,
@@ -1596,6 +1599,10 @@ const resolveSlashCommandIcon = (command: SlashCommandDefinition) => {
     return 'i-lucide-search-check'
   }
 
+  if (command.name === 'goal') {
+    return 'i-lucide-flag'
+  }
+
   if (command.name === 'usage' || command.name === 'status') {
     return 'i-lucide-gauge'
   }
@@ -2023,6 +2030,59 @@ const handleSlashCommandSubmission = async (
       return {
         consumed: true
       }
+    case 'openGoal':
+      error.value = null
+      status.value = 'ready'
+      clearSlashCommandDraft()
+      await openGoalSummary()
+      await focusPromptAt(0)
+      return {
+        consumed: true
+      }
+    case 'setGoalObjective': {
+      const succeeded = await setGoalObjective(dispatchAction.objective)
+      if (succeeded) {
+        error.value = null
+        status.value = 'ready'
+        clearSlashCommandDraft()
+        await focusPromptAt(0)
+      }
+      return {
+        consumed: true
+      }
+    }
+    case 'setGoalStatus': {
+      const succeeded = await setGoalStatus(dispatchAction.status)
+      if (succeeded) {
+        error.value = null
+        status.value = 'ready'
+        clearSlashCommandDraft()
+        await focusPromptAt(0)
+      }
+      return {
+        consumed: true
+      }
+    }
+    case 'clearGoal': {
+      const succeeded = await clearGoal()
+      if (succeeded) {
+        error.value = null
+        status.value = 'ready'
+        clearSlashCommandDraft()
+        await focusPromptAt(0)
+      }
+      return {
+        consumed: true
+      }
+    }
+    case 'editGoal':
+      error.value = null
+      status.value = 'ready'
+      clearSlashCommandDraft()
+      await openGoalEditor()
+      return {
+        consumed: true
+      }
     case 'activatePlanMode':
       try {
         await setCurrentThreadCollaborationMode('plan')
@@ -2148,6 +2208,34 @@ const {
   handleReviewDrawerOpenChange,
   handleReviewDrawerBack
 } = reviewWorkflow
+
+const goalWorkflow = useChatGoalWorkflow({
+  projectId: workspaceId.value,
+  activeThreadId,
+  threadGoals,
+  ensurePendingLiveStream,
+  getClient: () => getRuntimeClient(),
+  setComposerError
+})
+
+const {
+  goalDrawerOpen,
+  goalDrawerMode,
+  goalDrawerLoading,
+  goalDrawerSubmitting,
+  goalDrawerError,
+  goalDraftObjective,
+  currentThreadGoal,
+  applyThreadGoalUpdatedNotification,
+  applyThreadGoalClearedNotification,
+  openGoalSummary,
+  setGoalObjective,
+  setGoalStatus,
+  clearGoal,
+  openGoalEditor,
+  saveGoalEdit,
+  handleGoalDrawerOpenChange
+} = goalWorkflow
 
 const planWorkflow = useChatPlanWorkflow({
   projectId: workspaceId.value,
@@ -2787,6 +2875,7 @@ const resetDraftThread = () => {
   autoRedirectThreadId.value = null
   messages.value = []
   subagentPanels.value = []
+  threadGoals.value = {}
   error.value = null
   tokenUsage.value = null
   latestPlanTurnId.value = null
@@ -3225,6 +3314,14 @@ const applyNotification = (notification: CodexRpcNotification) => {
       }
 
       updateThreadSummaryTitle(nextThreadId, nextTitle, notificationThreadUpdatedAt(notification))
+      return
+    }
+    case 'thread/goal/updated': {
+      applyThreadGoalUpdatedNotification(notification.params)
+      return
+    }
+    case 'thread/goal/cleared': {
+      applyThreadGoalClearedNotification(notification.params)
       return
     }
     case 'serverRequest/resolved': {
@@ -4804,6 +4901,27 @@ watch(
             <span>{{ currentCollaborationModeLabel }} mode</span>
           </div>
 
+          <div
+            v-if="currentThreadGoal"
+            class="mb-2 flex px-1 text-xs text-toned"
+          >
+            <button
+              type="button"
+              class="inline-flex max-w-full items-center gap-2 rounded-full border border-default bg-default/70 px-2.5 py-1 text-left transition hover:border-primary/30 hover:text-highlighted"
+              @click="void openGoalSummary()"
+            >
+              <UIcon
+                name="i-lucide-flag"
+                class="size-3.5 shrink-0 text-primary"
+              />
+              <span class="shrink-0 font-medium">Goal</span>
+              <span class="truncate">{{ currentThreadGoal.objective }}</span>
+              <span class="shrink-0 text-muted">
+                {{ currentThreadGoal.status === 'budgetLimited' ? 'limited' : currentThreadGoal.status }}
+              </span>
+            </button>
+          </div>
+
           <UChatPrompt
             ref="chatPromptRef"
             v-model="input"
@@ -5082,6 +5200,22 @@ watch(
     @choose-base-branch-mode="openBaseBranchPicker"
     @choose-base-branch="(branch) => startReview({ type: 'baseBranch', branch })"
     @back="handleReviewDrawerBack"
+  />
+
+  <GoalDrawer
+    v-model:draft-objective="goalDraftObjective"
+    :open="goalDrawerOpen"
+    :mode="goalDrawerMode"
+    :goal="currentThreadGoal"
+    :loading="goalDrawerLoading"
+    :submitting="goalDrawerSubmitting"
+    :error="goalDrawerError"
+    @update:open="handleGoalDrawerOpenChange"
+    @edit="openGoalEditor"
+    @save-objective="saveGoalEdit"
+    @pause="setGoalStatus('paused')"
+    @resume="setGoalStatus('active')"
+    @clear="clearGoal"
   />
 
   <UsageStatusModal

--- a/packages/client/app/components/GoalDrawer.vue
+++ b/packages/client/app/components/GoalDrawer.vue
@@ -99,10 +99,12 @@ watch(() => [props.open, props.mode] as const, async ([open, mode]) => {
   }
 
   await nextTick()
-  const element = objectiveTextarea.value instanceof HTMLTextAreaElement
-    ? objectiveTextarea.value
-    : objectiveTextarea.value?.$el?.querySelector?.('textarea')
-  element?.focus()
+  requestAnimationFrame(() => {
+    const element = objectiveTextarea.value instanceof HTMLTextAreaElement
+      ? objectiveTextarea.value
+      : objectiveTextarea.value?.$el?.querySelector?.('textarea')
+    element?.focus()
+  })
 })
 </script>
 

--- a/packages/client/app/components/GoalDrawer.vue
+++ b/packages/client/app/components/GoalDrawer.vue
@@ -1,0 +1,250 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue'
+import BottomDrawerShell from './BottomDrawerShell.vue'
+import {
+  formatGoalElapsedSeconds,
+  goalStatusLabel
+} from '~~/shared/thread-goal'
+import type { ThreadGoal } from '~~/shared/generated/codex-app-server/v2/ThreadGoal'
+
+const props = withDefaults(defineProps<{
+  open?: boolean
+  mode?: 'summary' | 'edit'
+  goal?: ThreadGoal | null
+  loading?: boolean
+  submitting?: boolean
+  error?: string | null
+  draftObjective?: string
+}>(), {
+  open: false,
+  mode: 'summary',
+  goal: null,
+  loading: false,
+  submitting: false,
+  error: null,
+  draftObjective: ''
+})
+
+const emit = defineEmits<{
+  'update:open': [open: boolean]
+  'update:draftObjective': [objective: string]
+  edit: []
+  saveObjective: [objective: string]
+  pause: []
+  resume: []
+  clear: []
+}>()
+
+const objectiveTextarea = ref<{ $el?: HTMLElement } | HTMLTextAreaElement | null>(null)
+
+const title = computed(() =>
+  props.mode === 'edit' ? 'Edit goal' : 'Thread goal'
+)
+
+const description = computed(() =>
+  props.mode === 'edit'
+    ? 'Update the persistent objective Codex should continue toward.'
+    : 'Inspect and control the persistent objective for this thread.'
+)
+
+const statusLabel = computed(() =>
+  props.goal ? goalStatusLabel(props.goal.status) : 'No goal'
+)
+
+const statusColor = computed(() => {
+  switch (props.goal?.status) {
+    case 'active':
+      return 'primary'
+    case 'paused':
+      return 'warning'
+    case 'budgetLimited':
+      return 'error'
+    case 'complete':
+      return 'success'
+    default:
+      return 'neutral'
+  }
+})
+
+const tokenBudgetLabel = computed(() => {
+  if (!props.goal) {
+    return null
+  }
+
+  const used = props.goal.tokensUsed.toLocaleString()
+  if (props.goal.tokenBudget == null) {
+    return `${used} used`
+  }
+
+  return `${used} / ${props.goal.tokenBudget.toLocaleString()}`
+})
+
+const elapsedLabel = computed(() =>
+  props.goal ? formatGoalElapsedSeconds(props.goal.timeUsedSeconds) : null
+)
+
+const trimmedDraftObjective = computed(() => props.draftObjective.trim())
+
+const submitEdit = () => {
+  if (!trimmedDraftObjective.value) {
+    return
+  }
+
+  emit('saveObjective', trimmedDraftObjective.value)
+}
+
+watch(() => [props.open, props.mode] as const, async ([open, mode]) => {
+  if (!open || mode !== 'edit') {
+    return
+  }
+
+  await nextTick()
+  const element = objectiveTextarea.value instanceof HTMLTextAreaElement
+    ? objectiveTextarea.value
+    : objectiveTextarea.value?.$el?.querySelector?.('textarea')
+  element?.focus()
+})
+</script>
+
+<template>
+  <BottomDrawerShell
+    :open="open"
+    :title="title"
+    :description="description"
+    body-class="px-4 pb-4 pt-2 md:px-5"
+    @update:open="emit('update:open', $event)"
+  >
+    <div class="space-y-3">
+      <UAlert
+        v-if="error"
+        color="error"
+        variant="soft"
+        icon="i-lucide-circle-alert"
+        :title="error"
+      />
+
+      <div
+        v-if="loading"
+        class="rounded-lg border border-default bg-elevated/30 px-4 py-5 text-sm text-muted"
+      >
+        Loading thread goal...
+      </div>
+
+      <form
+        v-else-if="mode === 'edit'"
+        class="space-y-3"
+        @submit.prevent="submitEdit"
+      >
+        <UTextarea
+          ref="objectiveTextarea"
+          :model-value="draftObjective"
+          :disabled="submitting"
+          :rows="4"
+          autoresize
+          placeholder="Describe the long-running goal for this thread"
+          class="w-full"
+          @update:model-value="emit('update:draftObjective', String($event ?? ''))"
+        />
+
+        <div class="flex flex-wrap justify-end gap-2">
+          <UButton
+            type="button"
+            color="neutral"
+            variant="ghost"
+            :disabled="submitting"
+            @click="emit('update:open', false)"
+          >
+            Cancel
+          </UButton>
+          <UButton
+            type="submit"
+            color="primary"
+            icon="i-lucide-save"
+            :loading="submitting"
+            :disabled="!trimmedDraftObjective"
+          >
+            Save goal
+          </UButton>
+        </div>
+      </form>
+
+      <div
+        v-else-if="goal"
+        class="space-y-3"
+      >
+        <div class="rounded-lg border border-default bg-elevated/30 px-4 py-3">
+          <div class="flex flex-wrap items-center justify-between gap-2">
+            <UBadge
+              :color="statusColor"
+              variant="soft"
+              class="rounded-full"
+            >
+              {{ statusLabel }}
+            </UBadge>
+            <div class="flex items-center gap-2 text-xs text-muted">
+              <span v-if="elapsedLabel">{{ elapsedLabel }}</span>
+              <span v-if="tokenBudgetLabel">{{ tokenBudgetLabel }} tokens</span>
+            </div>
+          </div>
+
+          <p class="mt-3 whitespace-pre-wrap text-sm leading-6 text-highlighted">
+            {{ goal.objective }}
+          </p>
+        </div>
+
+        <div class="flex flex-wrap gap-2">
+          <UButton
+            type="button"
+            color="neutral"
+            variant="outline"
+            icon="i-lucide-pencil"
+            :disabled="submitting"
+            @click="emit('edit')"
+          >
+            Edit
+          </UButton>
+          <UButton
+            v-if="goal.status === 'paused'"
+            type="button"
+            color="primary"
+            variant="soft"
+            icon="i-lucide-play"
+            :loading="submitting"
+            @click="emit('resume')"
+          >
+            Resume
+          </UButton>
+          <UButton
+            v-else-if="goal.status === 'active'"
+            type="button"
+            color="warning"
+            variant="soft"
+            icon="i-lucide-pause"
+            :loading="submitting"
+            @click="emit('pause')"
+          >
+            Pause
+          </UButton>
+          <UButton
+            type="button"
+            color="error"
+            variant="ghost"
+            icon="i-lucide-trash-2"
+            :loading="submitting"
+            @click="emit('clear')"
+          >
+            Clear
+          </UButton>
+        </div>
+      </div>
+
+      <div
+        v-else
+        class="space-y-3 rounded-lg border border-dashed border-default px-4 py-5 text-sm text-muted"
+      >
+        <p>No goal is currently set for this thread.</p>
+        <p>Use <span class="font-mono text-highlighted">/goal &lt;objective&gt;</span> to start a persistent goal.</p>
+      </div>
+    </div>
+  </BottomDrawerShell>
+</template>

--- a/packages/client/app/composables/useChatGoalWorkflow.ts
+++ b/packages/client/app/composables/useChatGoalWorkflow.ts
@@ -72,6 +72,20 @@ export const useChatGoalWorkflow = (options: UseChatGoalWorkflowOptions) => {
     return liveStream.threadId
   }
 
+  const getActiveGoalThreadId = () => options.activeThreadId.value
+
+  const requireActiveGoalThreadId = () => {
+    const threadId = getActiveGoalThreadId()
+    if (threadId) {
+      return threadId
+    }
+
+    const messageText = 'Start a session before changing a thread goal.'
+    goalDrawerError.value = messageText
+    options.setComposerError(messageText)
+    return null
+  }
+
   const getGoal = async (threadId: string) => {
     const response = await options.getClient(options.projectId).request<ThreadGoalGetResponse>('thread/goal/get', {
       threadId
@@ -92,7 +106,11 @@ export const useChatGoalWorkflow = (options: UseChatGoalWorkflowOptions) => {
     goalDrawerError.value = null
 
     try {
-      const threadId = await ensureGoalThreadId()
+      const threadId = getActiveGoalThreadId()
+      if (!threadId) {
+        return
+      }
+
       await getGoal(threadId)
     } catch (caughtError) {
       goalDrawerError.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
@@ -105,7 +123,7 @@ export const useChatGoalWorkflow = (options: UseChatGoalWorkflowOptions) => {
     const trimmedObjective = objective.trim()
     if (!trimmedObjective) {
       options.setComposerError('Goal objective must not be empty.')
-      return
+      return false
     }
 
     goalDrawerSubmitting.value = true
@@ -124,10 +142,12 @@ export const useChatGoalWorkflow = (options: UseChatGoalWorkflowOptions) => {
         goalDrawerMode.value = 'summary'
         goalDrawerOpen.value = true
       }
+      return true
     } catch (caughtError) {
       const messageText = caughtError instanceof Error ? caughtError.message : String(caughtError)
       goalDrawerError.value = messageText
       options.setComposerError(messageText)
+      return false
     } finally {
       goalDrawerSubmitting.value = false
     }
@@ -138,7 +158,11 @@ export const useChatGoalWorkflow = (options: UseChatGoalWorkflowOptions) => {
     goalDrawerError.value = null
 
     try {
-      const threadId = await ensureGoalThreadId()
+      const threadId = requireActiveGoalThreadId()
+      if (!threadId) {
+        return false
+      }
+
       const response = await options.getClient(options.projectId).request<ThreadGoalSetResponse>('thread/goal/set', {
         threadId,
         status
@@ -146,10 +170,12 @@ export const useChatGoalWorkflow = (options: UseChatGoalWorkflowOptions) => {
       setThreadGoalState(response.goal)
       goalDrawerMode.value = 'summary'
       goalDrawerOpen.value = true
+      return true
     } catch (caughtError) {
       const messageText = caughtError instanceof Error ? caughtError.message : String(caughtError)
       goalDrawerError.value = messageText
       options.setComposerError(messageText)
+      return false
     } finally {
       goalDrawerSubmitting.value = false
     }
@@ -160,17 +186,23 @@ export const useChatGoalWorkflow = (options: UseChatGoalWorkflowOptions) => {
     goalDrawerError.value = null
 
     try {
-      const threadId = await ensureGoalThreadId()
+      const threadId = requireActiveGoalThreadId()
+      if (!threadId) {
+        return false
+      }
+
       await options.getClient(options.projectId).request<ThreadGoalClearResponse>('thread/goal/clear', {
         threadId
       })
       clearThreadGoalState(threadId)
       goalDrawerMode.value = 'summary'
       goalDrawerOpen.value = true
+      return true
     } catch (caughtError) {
       const messageText = caughtError instanceof Error ? caughtError.message : String(caughtError)
       goalDrawerError.value = messageText
       options.setComposerError(messageText)
+      return false
     } finally {
       goalDrawerSubmitting.value = false
     }
@@ -183,7 +215,14 @@ export const useChatGoalWorkflow = (options: UseChatGoalWorkflowOptions) => {
     goalDrawerLoading.value = true
 
     try {
-      const threadId = await ensureGoalThreadId()
+      const threadId = getActiveGoalThreadId()
+      if (!threadId) {
+        goalDrawerMode.value = 'summary'
+        goalDrawerError.value = 'No goal is currently set for this thread.'
+        goalDraftObjective.value = ''
+        return
+      }
+
       const goal = currentThreadGoal.value ?? await getGoal(threadId)
       if (!goal) {
         goalDrawerMode.value = 'summary'
@@ -201,7 +240,7 @@ export const useChatGoalWorkflow = (options: UseChatGoalWorkflowOptions) => {
   }
 
   const saveGoalEdit = async (objective: string) => {
-    await setGoalObjective(objective, { openSummary: true })
+    return await setGoalObjective(objective, { openSummary: true })
   }
 
   const handleGoalDrawerOpenChange = (open: boolean) => {

--- a/packages/client/app/composables/useChatGoalWorkflow.ts
+++ b/packages/client/app/composables/useChatGoalWorkflow.ts
@@ -21,11 +21,10 @@ type GoalRpcClient = {
 }
 
 type UseChatGoalWorkflowOptions = {
-  projectId: string
   activeThreadId: Ref<string | null>
   threadGoals: Ref<Record<string, ThreadGoal>>
   ensurePendingLiveStream: () => Promise<LiveStream>
-  getClient: (projectId: string) => GoalRpcClient
+  getClient: () => GoalRpcClient
   setComposerError: (messageText: string) => void
 }
 
@@ -87,7 +86,7 @@ export const useChatGoalWorkflow = (options: UseChatGoalWorkflowOptions) => {
   }
 
   const getGoal = async (threadId: string) => {
-    const response = await options.getClient(options.projectId).request<ThreadGoalGetResponse>('thread/goal/get', {
+    const response = await options.getClient().request<ThreadGoalGetResponse>('thread/goal/get', {
       threadId
     })
     const goal = normalizeThreadGoal(response.goal)
@@ -119,7 +118,10 @@ export const useChatGoalWorkflow = (options: UseChatGoalWorkflowOptions) => {
     }
   }
 
-  const setGoalObjective = async (objective: string, input?: { openSummary?: boolean }) => {
+  const setGoalObjective = async (objective: string, input?: {
+    openSummary?: boolean
+    status?: ThreadGoalStatus
+  }) => {
     const trimmedObjective = objective.trim()
     if (!trimmedObjective) {
       options.setComposerError('Goal objective must not be empty.')
@@ -131,10 +133,10 @@ export const useChatGoalWorkflow = (options: UseChatGoalWorkflowOptions) => {
 
     try {
       const threadId = await ensureGoalThreadId()
-      const response = await options.getClient(options.projectId).request<ThreadGoalSetResponse>('thread/goal/set', {
+      const response = await options.getClient().request<ThreadGoalSetResponse>('thread/goal/set', {
         threadId,
         objective: trimmedObjective,
-        status: 'active'
+        status: input?.status ?? 'active'
       })
       setThreadGoalState(response.goal)
       goalDraftObjective.value = response.goal.objective
@@ -163,7 +165,7 @@ export const useChatGoalWorkflow = (options: UseChatGoalWorkflowOptions) => {
         return false
       }
 
-      const response = await options.getClient(options.projectId).request<ThreadGoalSetResponse>('thread/goal/set', {
+      const response = await options.getClient().request<ThreadGoalSetResponse>('thread/goal/set', {
         threadId,
         status
       })
@@ -191,7 +193,7 @@ export const useChatGoalWorkflow = (options: UseChatGoalWorkflowOptions) => {
         return false
       }
 
-      await options.getClient(options.projectId).request<ThreadGoalClearResponse>('thread/goal/clear', {
+      await options.getClient().request<ThreadGoalClearResponse>('thread/goal/clear', {
         threadId
       })
       clearThreadGoalState(threadId)
@@ -240,7 +242,10 @@ export const useChatGoalWorkflow = (options: UseChatGoalWorkflowOptions) => {
   }
 
   const saveGoalEdit = async (objective: string) => {
-    return await setGoalObjective(objective, { openSummary: true })
+    return await setGoalObjective(objective, {
+      openSummary: true,
+      status: currentThreadGoal.value?.status
+    })
   }
 
   const handleGoalDrawerOpenChange = (open: boolean) => {

--- a/packages/client/app/composables/useChatGoalWorkflow.ts
+++ b/packages/client/app/composables/useChatGoalWorkflow.ts
@@ -1,0 +1,234 @@
+import { computed, ref, type Ref } from 'vue'
+import {
+  applyThreadGoalCleared,
+  applyThreadGoalUpdated,
+  normalizeThreadGoal
+} from '~~/shared/thread-goal'
+import type { LiveStream } from './useChatSession'
+import type { ThreadGoal } from '~~/shared/generated/codex-app-server/v2/ThreadGoal'
+import type { ThreadGoalClearParams } from '~~/shared/generated/codex-app-server/v2/ThreadGoalClearParams'
+import type { ThreadGoalClearResponse } from '~~/shared/generated/codex-app-server/v2/ThreadGoalClearResponse'
+import type { ThreadGoalGetParams } from '~~/shared/generated/codex-app-server/v2/ThreadGoalGetParams'
+import type { ThreadGoalGetResponse } from '~~/shared/generated/codex-app-server/v2/ThreadGoalGetResponse'
+import type { ThreadGoalSetParams } from '~~/shared/generated/codex-app-server/v2/ThreadGoalSetParams'
+import type { ThreadGoalSetResponse } from '~~/shared/generated/codex-app-server/v2/ThreadGoalSetResponse'
+import type { ThreadGoalStatus } from '~~/shared/generated/codex-app-server/v2/ThreadGoalStatus'
+
+type GoalRpcClient = {
+  request<T>(method: 'thread/goal/get', params: ThreadGoalGetParams): Promise<T>
+  request<T>(method: 'thread/goal/set', params: ThreadGoalSetParams): Promise<T>
+  request<T>(method: 'thread/goal/clear', params: ThreadGoalClearParams): Promise<T>
+}
+
+type UseChatGoalWorkflowOptions = {
+  projectId: string
+  activeThreadId: Ref<string | null>
+  threadGoals: Ref<Record<string, ThreadGoal>>
+  ensurePendingLiveStream: () => Promise<LiveStream>
+  getClient: (projectId: string) => GoalRpcClient
+  setComposerError: (messageText: string) => void
+}
+
+export const useChatGoalWorkflow = (options: UseChatGoalWorkflowOptions) => {
+  const goalDrawerOpen = ref(false)
+  const goalDrawerMode = ref<'summary' | 'edit'>('summary')
+  const goalDrawerLoading = ref(false)
+  const goalDrawerSubmitting = ref(false)
+  const goalDrawerError = ref<string | null>(null)
+  const goalDraftObjective = ref('')
+
+  const currentThreadGoal = computed(() => {
+    const threadId = options.activeThreadId.value
+    return threadId ? options.threadGoals.value[threadId] ?? null : null
+  })
+
+  const setThreadGoalState = (goal: ThreadGoal) => {
+    options.threadGoals.value = {
+      ...options.threadGoals.value,
+      [goal.threadId]: goal
+    }
+  }
+
+  const clearThreadGoalState = (threadId: string) => {
+    if (!(threadId in options.threadGoals.value)) {
+      return
+    }
+
+    const nextGoals = { ...options.threadGoals.value }
+    delete nextGoals[threadId]
+    options.threadGoals.value = nextGoals
+  }
+
+  const applyThreadGoalUpdatedNotification = (params: unknown) => {
+    options.threadGoals.value = applyThreadGoalUpdated(options.threadGoals.value, params)
+  }
+
+  const applyThreadGoalClearedNotification = (params: unknown) => {
+    options.threadGoals.value = applyThreadGoalCleared(options.threadGoals.value, params)
+  }
+
+  const ensureGoalThreadId = async () => {
+    const liveStream = await options.ensurePendingLiveStream()
+    return liveStream.threadId
+  }
+
+  const getGoal = async (threadId: string) => {
+    const response = await options.getClient(options.projectId).request<ThreadGoalGetResponse>('thread/goal/get', {
+      threadId
+    })
+    const goal = normalizeThreadGoal(response.goal)
+    if (goal) {
+      setThreadGoalState(goal)
+    } else {
+      clearThreadGoalState(threadId)
+    }
+    return goal
+  }
+
+  const openGoalSummary = async () => {
+    goalDrawerMode.value = 'summary'
+    goalDrawerOpen.value = true
+    goalDrawerLoading.value = true
+    goalDrawerError.value = null
+
+    try {
+      const threadId = await ensureGoalThreadId()
+      await getGoal(threadId)
+    } catch (caughtError) {
+      goalDrawerError.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
+    } finally {
+      goalDrawerLoading.value = false
+    }
+  }
+
+  const setGoalObjective = async (objective: string, input?: { openSummary?: boolean }) => {
+    const trimmedObjective = objective.trim()
+    if (!trimmedObjective) {
+      options.setComposerError('Goal objective must not be empty.')
+      return
+    }
+
+    goalDrawerSubmitting.value = true
+    goalDrawerError.value = null
+
+    try {
+      const threadId = await ensureGoalThreadId()
+      const response = await options.getClient(options.projectId).request<ThreadGoalSetResponse>('thread/goal/set', {
+        threadId,
+        objective: trimmedObjective,
+        status: 'active'
+      })
+      setThreadGoalState(response.goal)
+      goalDraftObjective.value = response.goal.objective
+      if (input?.openSummary) {
+        goalDrawerMode.value = 'summary'
+        goalDrawerOpen.value = true
+      }
+    } catch (caughtError) {
+      const messageText = caughtError instanceof Error ? caughtError.message : String(caughtError)
+      goalDrawerError.value = messageText
+      options.setComposerError(messageText)
+    } finally {
+      goalDrawerSubmitting.value = false
+    }
+  }
+
+  const setGoalStatus = async (status: Extract<ThreadGoalStatus, 'active' | 'paused'>) => {
+    goalDrawerSubmitting.value = true
+    goalDrawerError.value = null
+
+    try {
+      const threadId = await ensureGoalThreadId()
+      const response = await options.getClient(options.projectId).request<ThreadGoalSetResponse>('thread/goal/set', {
+        threadId,
+        status
+      })
+      setThreadGoalState(response.goal)
+      goalDrawerMode.value = 'summary'
+      goalDrawerOpen.value = true
+    } catch (caughtError) {
+      const messageText = caughtError instanceof Error ? caughtError.message : String(caughtError)
+      goalDrawerError.value = messageText
+      options.setComposerError(messageText)
+    } finally {
+      goalDrawerSubmitting.value = false
+    }
+  }
+
+  const clearGoal = async () => {
+    goalDrawerSubmitting.value = true
+    goalDrawerError.value = null
+
+    try {
+      const threadId = await ensureGoalThreadId()
+      await options.getClient(options.projectId).request<ThreadGoalClearResponse>('thread/goal/clear', {
+        threadId
+      })
+      clearThreadGoalState(threadId)
+      goalDrawerMode.value = 'summary'
+      goalDrawerOpen.value = true
+    } catch (caughtError) {
+      const messageText = caughtError instanceof Error ? caughtError.message : String(caughtError)
+      goalDrawerError.value = messageText
+      options.setComposerError(messageText)
+    } finally {
+      goalDrawerSubmitting.value = false
+    }
+  }
+
+  const openGoalEditor = async () => {
+    goalDrawerOpen.value = true
+    goalDrawerMode.value = 'edit'
+    goalDrawerError.value = null
+    goalDrawerLoading.value = true
+
+    try {
+      const threadId = await ensureGoalThreadId()
+      const goal = currentThreadGoal.value ?? await getGoal(threadId)
+      if (!goal) {
+        goalDrawerMode.value = 'summary'
+        goalDrawerError.value = 'No goal is currently set for this thread.'
+        goalDraftObjective.value = ''
+        return
+      }
+
+      goalDraftObjective.value = goal.objective
+    } catch (caughtError) {
+      goalDrawerError.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
+    } finally {
+      goalDrawerLoading.value = false
+    }
+  }
+
+  const saveGoalEdit = async (objective: string) => {
+    await setGoalObjective(objective, { openSummary: true })
+  }
+
+  const handleGoalDrawerOpenChange = (open: boolean) => {
+    goalDrawerOpen.value = open
+    if (!open) {
+      goalDrawerMode.value = 'summary'
+      goalDrawerError.value = null
+      goalDraftObjective.value = ''
+    }
+  }
+
+  return {
+    goalDrawerOpen,
+    goalDrawerMode,
+    goalDrawerLoading,
+    goalDrawerSubmitting,
+    goalDrawerError,
+    goalDraftObjective,
+    currentThreadGoal,
+    applyThreadGoalUpdatedNotification,
+    applyThreadGoalClearedNotification,
+    openGoalSummary,
+    setGoalObjective,
+    setGoalStatus,
+    clearGoal,
+    openGoalEditor,
+    saveGoalEdit,
+    handleGoalDrawerOpenChange
+  }
+}

--- a/packages/client/app/composables/useChatSession.ts
+++ b/packages/client/app/composables/useChatSession.ts
@@ -3,6 +3,7 @@ import type { ChatMessage, SubagentAgentStatus, VisualSubagentPanel } from '~~/s
 import type { CollaborationModeMask } from '~~/shared/collaboration-mode'
 import type { ReasoningEffort } from '~~/shared/generated/codex-app-server/ReasoningEffort'
 import type { CodexRpcNotification } from '~~/shared/codex-rpc'
+import type { ThreadGoal } from '~~/shared/generated/codex-app-server/v2/ThreadGoal'
 import type { ThreadPlanState } from '~~/shared/turn-plan'
 import {
   FALLBACK_MODELS,
@@ -40,6 +41,7 @@ export type SubagentPanelState = VisualSubagentPanel & {
 export type ChatSession = {
   messages: Ref<ChatMessage[]>
   subagentPanels: Ref<SubagentPanelState[]>
+  threadGoals: Ref<Record<string, ThreadGoal>>
   threadPlans: Ref<Record<string, ThreadPlanState>>
   threadCollaborationModeMasks: Ref<Record<string, CollaborationModeMask>>
   collaborationModeMasks: Ref<CollaborationModeMask[]>
@@ -76,6 +78,7 @@ const createSession = (): ChatSession => {
   const session: ChatSession = {
     messages: ref([]) as Ref<ChatMessage[]>,
     subagentPanels: ref([]) as Ref<SubagentPanelState[]>,
+    threadGoals: ref({}) as Ref<Record<string, ThreadGoal>>,
     threadPlans: ref({}) as Ref<Record<string, ThreadPlanState>>,
     threadCollaborationModeMasks: ref({}) as Ref<Record<string, CollaborationModeMask>>,
     collaborationModeMasks: ref([]) as Ref<CollaborationModeMask[]>,

--- a/packages/client/app/utils/chat-turn-engagement.ts
+++ b/packages/client/app/utils/chat-turn-engagement.ts
@@ -64,6 +64,8 @@ export const shouldApplyThreadAgnosticNotification = (method: string) =>
 export const shouldApplyNotificationWithoutTurnId = (method: string) =>
   shouldApplyThreadAgnosticNotification(method)
   || method === 'thread/name/updated'
+  || method === 'thread/goal/updated'
+  || method === 'thread/goal/cleared'
 
 export const shouldAdvanceLiveStreamTurn = (input: {
   lockedTurnId?: string | null

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -47,7 +47,8 @@
     "ofetch": "^1.5.1",
     "shiki": "^4.0.2",
     "tailwindcss": "^4.2.4",
-    "vue": "^3.5.33"
+    "vue": "^3.5.33",
+    "vue-router": "^5.0.6"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.6",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codori/client",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "private": false,
   "description": "Codori Nuxt dashboard for project browsing, Codex chat, and thread resume.",
   "type": "module",

--- a/packages/client/shared/slash-command-dispatch.ts
+++ b/packages/client/shared/slash-command-dispatch.ts
@@ -15,6 +15,23 @@ export type SlashCommandDispatchAction =
       type: 'openUsageStatus'
     }
   | {
+      type: 'openGoal'
+    }
+  | {
+      type: 'setGoalObjective'
+      objective: string
+    }
+  | {
+      type: 'setGoalStatus'
+      status: 'active' | 'paused'
+    }
+  | {
+      type: 'clearGoal'
+    }
+  | {
+      type: 'editGoal'
+    }
+  | {
       type: 'activatePlanMode'
     }
   | {
@@ -68,6 +85,47 @@ export const resolveSlashCommandDispatch = (input: {
       return {
         type: 'openUsageStatus'
       }
+    case 'goal': {
+      if (attachmentsCount > 0) {
+        return {
+          type: 'error',
+          message: 'Slash commands do not support image attachments yet.'
+        }
+      }
+
+      if (slashCommand.isBare) {
+        return {
+          type: 'openGoal'
+        }
+      }
+
+      const normalizedArgs = slashCommand.args.trim().toLowerCase()
+      switch (normalizedArgs) {
+        case 'pause':
+          return {
+            type: 'setGoalStatus',
+            status: 'paused'
+          }
+        case 'resume':
+          return {
+            type: 'setGoalStatus',
+            status: 'active'
+          }
+        case 'clear':
+          return {
+            type: 'clearGoal'
+          }
+        case 'edit':
+          return {
+            type: 'editGoal'
+          }
+        default:
+          return {
+            type: 'setGoalObjective',
+            objective: slashCommand.args
+          }
+      }
+    }
     case 'plan':
       if (!planModeAvailable) {
         return {

--- a/packages/client/shared/slash-commands.ts
+++ b/packages/client/shared/slash-commands.ts
@@ -1,4 +1,4 @@
-export type SlashCommandName = 'plan' | 'review' | 'usage' | 'status'
+export type SlashCommandName = 'plan' | 'review' | 'goal' | 'usage' | 'status'
 
 export type SlashCommandDefinition = {
   name: SlashCommandName
@@ -32,6 +32,12 @@ export const SLASH_COMMANDS: SlashCommandDefinition[] = [{
   description: 'Review current changes or compare against a base branch.',
   supportsInlineArgs: false,
   completeOnSpace: true,
+  executeOnEnter: true
+}, {
+  name: 'goal',
+  description: 'Set, inspect, or manage the persistent goal for this thread.',
+  supportsInlineArgs: true,
+  completeOnSpace: false,
   executeOnEnter: true
 }, {
   name: 'usage',

--- a/packages/client/shared/thread-goal.ts
+++ b/packages/client/shared/thread-goal.ts
@@ -1,0 +1,144 @@
+import type { ThreadGoal } from './generated/codex-app-server/v2/ThreadGoal'
+import type { ThreadGoalClearedNotification } from './generated/codex-app-server/v2/ThreadGoalClearedNotification'
+import type { ThreadGoalStatus } from './generated/codex-app-server/v2/ThreadGoalStatus'
+import type { ThreadGoalUpdatedNotification } from './generated/codex-app-server/v2/ThreadGoalUpdatedNotification'
+
+const THREAD_GOAL_STATUSES = new Set<ThreadGoalStatus>([
+  'active',
+  'paused',
+  'budgetLimited',
+  'complete'
+])
+
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isThreadGoalStatus = (value: unknown): value is ThreadGoalStatus =>
+  typeof value === 'string' && THREAD_GOAL_STATUSES.has(value as ThreadGoalStatus)
+
+const finiteNumberOrZero = (value: unknown) =>
+  typeof value === 'number' && Number.isFinite(value) ? value : 0
+
+export const normalizeThreadGoal = (value: unknown): ThreadGoal | null => {
+  if (!isObjectRecord(value)) {
+    return null
+  }
+
+  const threadId = value.threadId
+  const objective = value.objective
+  const status = value.status
+  if (typeof threadId !== 'string' || typeof objective !== 'string' || !isThreadGoalStatus(status)) {
+    return null
+  }
+
+  return {
+    threadId,
+    objective,
+    status,
+    tokenBudget: typeof value.tokenBudget === 'number' && Number.isFinite(value.tokenBudget)
+      ? value.tokenBudget
+      : null,
+    tokensUsed: finiteNumberOrZero(value.tokensUsed),
+    timeUsedSeconds: finiteNumberOrZero(value.timeUsedSeconds),
+    createdAt: finiteNumberOrZero(value.createdAt),
+    updatedAt: finiteNumberOrZero(value.updatedAt)
+  }
+}
+
+export const normalizeThreadGoalUpdatedNotification = (
+  params: unknown
+): ThreadGoalUpdatedNotification | null => {
+  if (!isObjectRecord(params)) {
+    return null
+  }
+
+  const threadId = params.threadId
+  const turnId = params.turnId
+  const goal = normalizeThreadGoal(params.goal)
+  if (typeof threadId !== 'string' || !goal) {
+    return null
+  }
+
+  return {
+    threadId,
+    turnId: typeof turnId === 'string' ? turnId : null,
+    goal
+  }
+}
+
+export const normalizeThreadGoalClearedNotification = (
+  params: unknown
+): ThreadGoalClearedNotification | null => {
+  if (!isObjectRecord(params) || typeof params.threadId !== 'string') {
+    return null
+  }
+
+  return {
+    threadId: params.threadId
+  }
+}
+
+export const applyThreadGoalUpdated = (
+  goals: Record<string, ThreadGoal>,
+  params: unknown
+) => {
+  const notification = normalizeThreadGoalUpdatedNotification(params)
+  if (!notification) {
+    return goals
+  }
+
+  return {
+    ...goals,
+    [notification.threadId]: notification.goal
+  }
+}
+
+export const applyThreadGoalCleared = (
+  goals: Record<string, ThreadGoal>,
+  params: unknown
+) => {
+  const notification = normalizeThreadGoalClearedNotification(params)
+  if (!notification || !(notification.threadId in goals)) {
+    return goals
+  }
+
+  const nextGoals = { ...goals }
+  delete nextGoals[notification.threadId]
+  return nextGoals
+}
+
+export const goalStatusLabel = (status: ThreadGoalStatus) => {
+  switch (status) {
+    case 'active':
+      return 'Active'
+    case 'paused':
+      return 'Paused'
+    case 'budgetLimited':
+      return 'Budget limited'
+    case 'complete':
+      return 'Complete'
+  }
+}
+
+export const formatGoalElapsedSeconds = (seconds: number) => {
+  const totalSeconds = Math.max(0, Math.floor(seconds))
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`
+  }
+
+  const minutes = Math.floor(totalSeconds / 60)
+  if (minutes < 60) {
+    return `${minutes}m`
+  }
+
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+  if (hours < 24) {
+    return remainingMinutes ? `${hours}h ${remainingMinutes}m` : `${hours}h`
+  }
+
+  const days = Math.floor(hours / 24)
+  const remainingHours = hours % 24
+  return `${days}d ${remainingHours}h`
+}
+

--- a/packages/client/test/chat-goal-workflow.test.ts
+++ b/packages/client/test/chat-goal-workflow.test.ts
@@ -44,7 +44,6 @@ describe('chat goal workflow', () => {
     )
     const threadGoals = ref<Record<string, ThreadGoal>>({})
     const workflow = useChatGoalWorkflow({
-      projectId: 'codori',
       activeThreadId,
       threadGoals,
       ensurePendingLiveStream,
@@ -101,6 +100,28 @@ describe('chat goal workflow', () => {
       status: 'active'
     })
     expect(threadGoals.value['thread-1']?.objective).toBe('Ship issue #68')
+  })
+
+  it('preserves the current goal status when saving edited objective text', async () => {
+    const { threadGoals, workflow } = createWorkflow()
+    threadGoals.value = {
+      'thread-1': testGoal({ status: 'paused' })
+    }
+    request.mockResolvedValue({
+      goal: testGoal({
+        objective: 'Updated paused goal',
+        status: 'paused'
+      })
+    })
+
+    await workflow.saveGoalEdit('Updated paused goal')
+
+    expect(request).toHaveBeenCalledWith('thread/goal/set', {
+      threadId: 'thread-1',
+      objective: 'Updated paused goal',
+      status: 'paused'
+    })
+    expect(threadGoals.value['thread-1']?.status).toBe('paused')
   })
 
   it('updates goal status and clears goals through native RPCs', async () => {

--- a/packages/client/test/chat-goal-workflow.test.ts
+++ b/packages/client/test/chat-goal-workflow.test.ts
@@ -38,8 +38,10 @@ describe('chat goal workflow', () => {
     })
   })
 
-  const createWorkflow = () => {
-    const activeThreadId = ref<string | null>('thread-1')
+  const createWorkflow = (input: { activeThreadId?: string | null } = {}) => {
+    const activeThreadId = ref<string | null>(
+      Object.hasOwn(input, 'activeThreadId') ? input.activeThreadId ?? null : 'thread-1'
+    )
     const threadGoals = ref<Record<string, ThreadGoal>>({})
     const workflow = useChatGoalWorkflow({
       projectId: 'codori',
@@ -71,6 +73,18 @@ describe('chat goal workflow', () => {
     expect(threadGoals.value['thread-1']?.objective).toBe('Keep the goal visible')
     expect(workflow.goalDrawerOpen.value).toBe(true)
     expect(workflow.goalDrawerLoading.value).toBe(false)
+  })
+
+  it('opens an empty summary without starting a thread when no thread exists', async () => {
+    const { workflow } = createWorkflow({ activeThreadId: null })
+
+    await workflow.openGoalSummary()
+
+    expect(ensurePendingLiveStream).not.toHaveBeenCalled()
+    expect(request).not.toHaveBeenCalled()
+    expect(workflow.goalDrawerOpen.value).toBe(true)
+    expect(workflow.goalDrawerLoading.value).toBe(false)
+    expect(workflow.currentThreadGoal.value).toBeNull()
   })
 
   it('sets an active thread goal from inline /goal text', async () => {

--- a/packages/client/test/chat-goal-workflow.test.ts
+++ b/packages/client/test/chat-goal-workflow.test.ts
@@ -1,0 +1,142 @@
+import { ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useChatGoalWorkflow } from '../app/composables/useChatGoalWorkflow'
+import type { ThreadGoal } from '../shared/generated/codex-app-server/v2/ThreadGoal'
+
+const testGoal = (overrides: Partial<ThreadGoal> = {}): ThreadGoal => ({
+  threadId: 'thread-1',
+  objective: 'Ship goal support',
+  status: 'active',
+  tokenBudget: null,
+  tokensUsed: 0,
+  timeUsedSeconds: 0,
+  createdAt: 1,
+  updatedAt: 2,
+  ...overrides
+})
+
+describe('chat goal workflow', () => {
+  const request = vi.fn()
+  const ensurePendingLiveStream = vi.fn()
+  const setComposerError = vi.fn()
+
+  beforeEach(() => {
+    request.mockReset()
+    ensurePendingLiveStream.mockReset()
+    setComposerError.mockReset()
+    ensurePendingLiveStream.mockResolvedValue({
+      threadId: 'thread-1',
+      turnId: null,
+      lockedTurnId: null,
+      bufferedNotifications: [],
+      observedSubagentThreadIds: new Set(),
+      pendingUserMessageIds: [],
+      turnIdWaiters: [],
+      interruptRequested: false,
+      interruptAcknowledged: false,
+      unsubscribe: null
+    })
+  })
+
+  const createWorkflow = () => {
+    const activeThreadId = ref<string | null>('thread-1')
+    const threadGoals = ref<Record<string, ThreadGoal>>({})
+    const workflow = useChatGoalWorkflow({
+      projectId: 'codori',
+      activeThreadId,
+      threadGoals,
+      ensurePendingLiveStream,
+      getClient: () => ({ request }),
+      setComposerError
+    })
+
+    return {
+      activeThreadId,
+      threadGoals,
+      workflow
+    }
+  }
+
+  it('loads the current thread goal for bare /goal', async () => {
+    const { threadGoals, workflow } = createWorkflow()
+    request.mockResolvedValue({
+      goal: testGoal({ objective: 'Keep the goal visible' })
+    })
+
+    await workflow.openGoalSummary()
+
+    expect(request).toHaveBeenCalledWith('thread/goal/get', {
+      threadId: 'thread-1'
+    })
+    expect(threadGoals.value['thread-1']?.objective).toBe('Keep the goal visible')
+    expect(workflow.goalDrawerOpen.value).toBe(true)
+    expect(workflow.goalDrawerLoading.value).toBe(false)
+  })
+
+  it('sets an active thread goal from inline /goal text', async () => {
+    const { threadGoals, workflow } = createWorkflow()
+    request.mockResolvedValue({
+      goal: testGoal({ objective: 'Ship issue #68' })
+    })
+
+    await workflow.setGoalObjective(' Ship issue #68 ')
+
+    expect(request).toHaveBeenCalledWith('thread/goal/set', {
+      threadId: 'thread-1',
+      objective: 'Ship issue #68',
+      status: 'active'
+    })
+    expect(threadGoals.value['thread-1']?.objective).toBe('Ship issue #68')
+  })
+
+  it('updates goal status and clears goals through native RPCs', async () => {
+    const { threadGoals, workflow } = createWorkflow()
+    threadGoals.value = {
+      'thread-1': testGoal()
+    }
+    request.mockResolvedValueOnce({
+      goal: testGoal({ status: 'paused' })
+    })
+    request.mockResolvedValueOnce({
+      cleared: true
+    })
+
+    await workflow.setGoalStatus('paused')
+    await workflow.clearGoal()
+
+    expect(request).toHaveBeenNthCalledWith(1, 'thread/goal/set', {
+      threadId: 'thread-1',
+      status: 'paused'
+    })
+    expect(request).toHaveBeenNthCalledWith(2, 'thread/goal/clear', {
+      threadId: 'thread-1'
+    })
+    expect(threadGoals.value).toEqual({})
+  })
+
+  it('applies goal update and clear notifications to local state', () => {
+    const { threadGoals, workflow } = createWorkflow()
+
+    workflow.applyThreadGoalUpdatedNotification({
+      threadId: 'thread-1',
+      turnId: null,
+      goal: testGoal({ status: 'complete' })
+    })
+    expect(threadGoals.value['thread-1']?.status).toBe('complete')
+
+    workflow.applyThreadGoalClearedNotification({
+      threadId: 'thread-1'
+    })
+    expect(threadGoals.value).toEqual({})
+  })
+
+  it('surfaces unsupported goal errors without falling back to chat text', async () => {
+    const { workflow } = createWorkflow()
+    request.mockRejectedValue(new Error('goals feature is disabled'))
+
+    await workflow.setGoalObjective('Ship issue #68')
+
+    expect(setComposerError).toHaveBeenCalledWith('goals feature is disabled')
+    expect(workflow.goalDrawerError.value).toBe('goals feature is disabled')
+  })
+})

--- a/packages/client/test/goal-drawer.test.ts
+++ b/packages/client/test/goal-drawer.test.ts
@@ -1,0 +1,139 @@
+/* eslint-disable vue/one-component-per-file */
+// @vitest-environment jsdom
+
+import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import { describe, expect, it } from 'vitest'
+import GoalDrawer from '../app/components/GoalDrawer.vue'
+import type { ThreadGoal } from '../shared/generated/codex-app-server/v2/ThreadGoal'
+
+const testGoal = (overrides: Partial<ThreadGoal> = {}): ThreadGoal => ({
+  threadId: 'thread-1',
+  objective: 'Ship persistent goal support',
+  status: 'active',
+  tokenBudget: 1000,
+  tokensUsed: 125,
+  timeUsedSeconds: 90 * 60,
+  createdAt: 1,
+  updatedAt: 2,
+  ...overrides
+})
+
+const DrawerStub = defineComponent({
+  name: 'DrawerStub',
+  props: {
+    open: {
+      type: Boolean,
+      default: false
+    },
+    title: {
+      type: String,
+      default: ''
+    },
+    description: {
+      type: String,
+      default: ''
+    }
+  },
+  emits: ['update:open'],
+  setup(props, { slots }) {
+    return () => props.open
+      ? h('section', { class: 'drawer-stub' }, [
+          h('h2', props.title),
+          h('p', props.description),
+          slots.default?.()
+        ])
+      : null
+  }
+})
+
+const ButtonStub = defineComponent({
+  name: 'ButtonStub',
+  props: {
+    type: {
+      type: String,
+      default: 'button'
+    }
+  },
+  emits: ['click'],
+  setup(props, { slots, emit }) {
+    return () => h('button', {
+      type: props.type,
+      onClick: () => emit('click')
+    }, slots.default?.())
+  }
+})
+
+const TextareaStub = defineComponent({
+  name: 'TextareaStub',
+  props: {
+    modelValue: {
+      type: String,
+      default: ''
+    }
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () => h('textarea', {
+      value: props.modelValue,
+      onInput: (event: Event) => emit('update:modelValue', (event.target as HTMLTextAreaElement).value)
+    })
+  }
+})
+
+const mountDrawer = (props: Record<string, unknown>) =>
+  mount(GoalDrawer, {
+    props: {
+      open: true,
+      ...props
+    },
+    global: {
+      stubs: {
+        BottomDrawerShell: DrawerStub,
+        UAlert: true,
+        UBadge: true,
+        UButton: ButtonStub,
+        UIcon: true,
+        UTextarea: TextareaStub
+      }
+    }
+  })
+
+describe('goal drawer', () => {
+  it('renders active goal details and control actions', async () => {
+    const wrapper = mountDrawer({
+      goal: testGoal()
+    })
+
+    expect(wrapper.text()).toContain('Thread goal')
+    expect(wrapper.text()).toContain('Ship persistent goal support')
+    expect(wrapper.text()).toContain('1h 30m')
+    expect(wrapper.text()).toContain('125 / 1,000 tokens')
+
+    await wrapper.findAll('button').find(button => button.text() === 'Pause')?.trigger('click')
+    expect(wrapper.emitted('pause')).toHaveLength(1)
+  })
+
+  it('emits edited goal objectives', async () => {
+    const wrapper = mountDrawer({
+      mode: 'edit',
+      draftObjective: 'Old objective'
+    })
+
+    await wrapper.get('textarea').setValue('New objective')
+    expect(wrapper.emitted('update:draftObjective')?.[0]).toEqual(['New objective'])
+    await wrapper.setProps({ draftObjective: 'New objective' })
+
+    await wrapper.get('form').trigger('submit')
+    expect(wrapper.emitted('saveObjective')?.[0]).toEqual(['New objective'])
+  })
+
+  it('renders an empty state when no goal exists', () => {
+    const wrapper = mountDrawer({
+      goal: null
+    })
+
+    expect(wrapper.text()).toContain('No goal is currently set for this thread.')
+    expect(wrapper.text()).toContain('/goal <objective>')
+  })
+})

--- a/packages/client/test/slash-command-dispatch.test.ts
+++ b/packages/client/test/slash-command-dispatch.test.ts
@@ -46,4 +46,100 @@ describe('slash command dispatch', () => {
       message: 'Plan mode is unavailable in the current runtime.'
     })
   })
+
+  it('routes bare /goal to goal inspection', () => {
+    expect(resolveSlashCommandDispatch({
+      slashCommand: {
+        name: 'goal',
+        args: '',
+        isBare: true
+      },
+      attachmentsCount: 0,
+      planModeAvailable: true
+    })).toEqual({
+      type: 'openGoal'
+    })
+  })
+
+  it('routes inline /goal text to a goal objective update', () => {
+    expect(resolveSlashCommandDispatch({
+      slashCommand: {
+        name: 'goal',
+        args: 'Ship issue #68',
+        isBare: false
+      },
+      attachmentsCount: 0,
+      planModeAvailable: true
+    })).toEqual({
+      type: 'setGoalObjective',
+      objective: 'Ship issue #68'
+    })
+  })
+
+  it('routes /goal control commands to goal actions', () => {
+    expect(resolveSlashCommandDispatch({
+      slashCommand: {
+        name: 'goal',
+        args: 'pause',
+        isBare: false
+      },
+      attachmentsCount: 0,
+      planModeAvailable: true
+    })).toEqual({
+      type: 'setGoalStatus',
+      status: 'paused'
+    })
+
+    expect(resolveSlashCommandDispatch({
+      slashCommand: {
+        name: 'goal',
+        args: 'resume',
+        isBare: false
+      },
+      attachmentsCount: 0,
+      planModeAvailable: true
+    })).toEqual({
+      type: 'setGoalStatus',
+      status: 'active'
+    })
+
+    expect(resolveSlashCommandDispatch({
+      slashCommand: {
+        name: 'goal',
+        args: 'clear',
+        isBare: false
+      },
+      attachmentsCount: 0,
+      planModeAvailable: true
+    })).toEqual({
+      type: 'clearGoal'
+    })
+
+    expect(resolveSlashCommandDispatch({
+      slashCommand: {
+        name: 'goal',
+        args: 'edit',
+        isBare: false
+      },
+      attachmentsCount: 0,
+      planModeAvailable: true
+    })).toEqual({
+      type: 'editGoal'
+    })
+  })
+
+  it('rejects /goal commands with image attachments', () => {
+    expect(resolveSlashCommandDispatch({
+      slashCommand: {
+        name: 'goal',
+        args: 'Ship issue #68',
+        isBare: false
+      },
+      attachmentsCount: 1,
+      planModeAvailable: true
+    })).toEqual({
+      type: 'error',
+      message: 'Slash commands do not support image attachments yet.'
+    })
+  })
 })

--- a/packages/client/test/slash-commands.test.ts
+++ b/packages/client/test/slash-commands.test.ts
@@ -30,9 +30,10 @@ describe('slash command helpers', () => {
   })
 
   it('filters available commands by prefix and formats completion text', () => {
-    expect(filterSlashCommands(SLASH_COMMANDS, '')).toHaveLength(4)
+    expect(filterSlashCommands(SLASH_COMMANDS, '')).toHaveLength(5)
     expect(filterSlashCommands(SLASH_COMMANDS, 'pl').map(command => command.name)).toEqual(['plan'])
     expect(filterSlashCommands(SLASH_COMMANDS, 're').map(command => command.name)).toEqual(['review'])
+    expect(filterSlashCommands(SLASH_COMMANDS, 'go').map(command => command.name)).toEqual(['goal'])
     expect(filterSlashCommands(SLASH_COMMANDS, 'us').map(command => command.name)).toEqual(['usage'])
     expect(filterSlashCommands(SLASH_COMMANDS, 'st').map(command => command.name)).toEqual(['status'])
     expect(toSlashCommandCompletion(SLASH_COMMANDS[0]!)).toBe('/plan ')
@@ -61,6 +62,18 @@ describe('slash command helpers', () => {
     expect(parseSubmittedSlashCommand('/review compare this')).toEqual({
       name: 'review',
       args: 'compare this',
+      isBare: false
+    })
+
+    expect(parseSubmittedSlashCommand('/goal')).toEqual({
+      name: 'goal',
+      args: '',
+      isBare: true
+    })
+
+    expect(parseSubmittedSlashCommand('/goal ship issue #68')).toEqual({
+      name: 'goal',
+      args: 'ship issue #68',
       isBare: false
     })
 

--- a/packages/client/test/smoke.test.ts
+++ b/packages/client/test/smoke.test.ts
@@ -599,6 +599,8 @@ describe('client package', () => {
 
   it('applies thread-level notifications before an active turn id exists', () => {
     expect(shouldApplyNotificationWithoutTurnId('thread/name/updated')).toBe(true)
+    expect(shouldApplyNotificationWithoutTurnId('thread/goal/updated')).toBe(true)
+    expect(shouldApplyNotificationWithoutTurnId('thread/goal/cleared')).toBe(true)
     expect(shouldApplyNotificationWithoutTurnId('serverRequest/resolved')).toBe(true)
     expect(shouldApplyNotificationWithoutTurnId('item/agentMessage/delta')).toBe(false)
   })

--- a/packages/client/test/thread-goal.test.ts
+++ b/packages/client/test/thread-goal.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyThreadGoalCleared,
+  applyThreadGoalUpdated,
+  formatGoalElapsedSeconds,
+  goalStatusLabel,
+  normalizeThreadGoal
+} from '../shared/thread-goal'
+
+describe('thread goal helpers', () => {
+  it('normalizes app-server thread goal payloads', () => {
+    expect(normalizeThreadGoal({
+      threadId: 'thread-1',
+      objective: 'Ship goal support',
+      status: 'active',
+      tokenBudget: 1000,
+      tokensUsed: 125,
+      timeUsedSeconds: 65,
+      createdAt: 1,
+      updatedAt: 2
+    })).toEqual({
+      threadId: 'thread-1',
+      objective: 'Ship goal support',
+      status: 'active',
+      tokenBudget: 1000,
+      tokensUsed: 125,
+      timeUsedSeconds: 65,
+      createdAt: 1,
+      updatedAt: 2
+    })
+
+    expect(normalizeThreadGoal({
+      threadId: 'thread-1',
+      objective: 'Ship goal support',
+      status: 'unknown'
+    })).toBeNull()
+  })
+
+  it('applies goal update and clear notifications immutably', () => {
+    const goals = applyThreadGoalUpdated({}, {
+      threadId: 'thread-1',
+      turnId: null,
+      goal: {
+        threadId: 'thread-1',
+        objective: 'Ship goal support',
+        status: 'paused',
+        tokenBudget: null,
+        tokensUsed: 5,
+        timeUsedSeconds: 9,
+        createdAt: 1,
+        updatedAt: 2
+      }
+    })
+
+    expect(goals['thread-1']?.status).toBe('paused')
+    expect(applyThreadGoalCleared(goals, { threadId: 'thread-1' })).toEqual({})
+  })
+
+  it('formats status and elapsed labels', () => {
+    expect(goalStatusLabel('budgetLimited')).toBe('Budget limited')
+    expect(formatGoalElapsedSeconds(59)).toBe('59s')
+    expect(formatGoalElapsedSeconds(90)).toBe('1m')
+    expect(formatGoalElapsedSeconds(90 * 60)).toBe('1h 30m')
+    expect(formatGoalElapsedSeconds(26 * 60 * 60)).toBe('1d 2h')
+  })
+})

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codori/server",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "private": false,
   "description": "Codori server for Git project discovery, Codex runtime management, and bundled dashboard serving.",
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       vue:
         specifier: ^3.5.33
         version: 3.5.33(typescript@6.0.3)
+      vue-router:
+        specifier: ^5.0.6
+        version: 5.0.6(@vue/compiler-sfc@3.5.33)(vue@3.5.33(typescript@6.0.3))
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.6


### PR DESCRIPTION
## Summary
- Add `/goal` to the client slash-command registry and dispatch it to goal-specific actions instead of normal chat submission.
- Add per-thread goal workflow state backed by `thread/goal/get`, `thread/goal/set`, `thread/goal/clear`, plus `thread/goal/updated` and `thread/goal/cleared` notifications.
- Add a compact goal status indicator and drawer UI for summary, edit, pause/resume, and clear controls.
- Bump Codori packages to `0.4.0` for the new `/goal` feature release.

## Follow-up Commits
- `91b8645 fix: address goal review feedback` preserves paused goal status on edit, reuses centralized status labels, aligns `getClient` typing, and defers edit focus with `requestAnimationFrame`.
- `52f2a9d fix: declare vue-router for client typecheck` adds `vue-router@^5.0.6` as a direct client dependency so Nuxt-generated Volar plugin paths resolve cleanly.
- `76a75db chore: bump version to 0.4.0` bumps root, client, and server package versions for the feature release.

## Verification
- `pnpm --filter @codori/client exec vitest run test/goal-drawer.test.ts test/slash-commands.test.ts test/slash-command-dispatch.test.ts test/thread-goal.test.ts test/chat-goal-workflow.test.ts test/smoke.test.ts`
- `pnpm --filter @codori/client exec vitest run test/chat-goal-workflow.test.ts test/goal-drawer.test.ts test/thread-goal.test.ts test/smoke.test.ts`
- `pnpm --filter @codori/client test`
- `pnpm --filter @codori/client typecheck`
- `pnpm --filter @codori/client lint`
- `pnpm --filter @codori/client build`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `node packages/server/dist/cli.js --root /Users/comfuture/Project --host 127.0.0.1 --port 4310` then `curl -I http://127.0.0.1:4310/` and `curl -s http://127.0.0.1:4310/api/projects`

Notes: Browser plugin access to the local page was blocked by policy, so the final runtime check used the built server plus HTTP/API probes. The previous `vue-router/volar/sfc-route-blocks` typecheck warning is gone after adding `vue-router@^5.0.6`; only npm config warnings remain.

Closes #68