### PR TITLE
Share Codex app-server runtime across workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Codori ignores common heavy directories during recursive scanning such as `node_
 - If a PID/runtime file points to a live shared process, Codori reuses it instead of spawning another app-server.
 - Codori records `startedAt` and `lastActivityAt` for the shared runtime under `~/.codori/run/`.
 - The shared runtime is stopped automatically after the configured inactivity timeout when no workspace has an active proxied WebSocket session.
-- Stopping the final active workspace stops the shared runtime immediately unless a proxied WebSocket session is still open.
+- Stopping the final active workspace stops the shared runtime immediately unless a proxied WebSocket session is still open; if one is open, Codori stops the runtime when that final session closes.
 - Workspaces with an active proxied WebSocket session keep the shared runtime from being reaped as idle.
 - If a PID/runtime file is stale, Codori cleans it up and starts a fresh runtime.
 - Runtime metadata is stored under `~/.codori/run/`.

--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ CODORI_SERVER_WS_BASE=wss://my-codori-host.your-tailnet.ts.net \
 pnpm --filter @codori/client dev
 ```
 
+Run a local Codori server with the freshly built client bundle:
+
+```bash
+pnpm run:local
+```
+
+This rebuilds the client and server first, then serves Codori on `http://127.0.0.1:4310` with the repository parent directory as the project root.
+
 Build the workspace:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It is designed for people who keep many Git repositories under one parent direct
 
 - discover projects
 - open the right project in a browser dashboard
-- start exactly one Codex app-server per project when needed
+- start a shared Codex app-server runtime only when needed
 - continue previous Codex threads in that same project context
 
 Codori is intentionally small. It manages project runtimes and gives you a UI. It does not try to become your VPN, ingress proxy, auth platform, or deployment layer.
@@ -19,14 +19,14 @@ Codori follows a few hard constraints:
 
 - Project-first: one root directory, many Git repositories, one control plane.
 - Thin management layer: Codori manages Codex app-server processes but does not replace them.
-- Safe runtime model: one project gets at most one active app-server, tracked by PID/runtime files.
+- Safe runtime model: one Codori server gets one shared app-server process, tracked by PID/runtime files, while each project or chat stays a logical workspace.
 - Bring-your-own network: private access is your responsibility.
 - Keep the surface area focused: Codori solves project discovery, runtime control, and Codex access without trying to absorb adjacent infrastructure concerns.
 
 ## Requirements
 
 - Node.js 22+
-- `codex` installed on the host that will run project app-servers
+- `codex` installed on the host that will run the shared app-server
 
 ## Usage
 
@@ -35,7 +35,7 @@ The normal flow is simple:
 1. Run the Codori server on the machine that already has your projects and local tooling.
 2. Open the Codori UI from that same server origin locally or through your own private network path.
 3. Pick a project from the sidebar and start coding.
-4. Let Codori start the project runtime only when chat or thread access actually needs it.
+4. Let Codori start the shared runtime only when chat or thread access actually needs it.
 
 Start the Codori management server:
 
@@ -255,15 +255,17 @@ Codori ignores common heavy directories during recursive scanning such as `node_
 
 ## Runtime Model
 
-- Each project gets at most one active Codex app-server.
-- If a PID/runtime file points to a live process, Codori reuses it instead of spawning another runtime.
-- Codori records `startedAt` and `lastActivityAt` for each runtime under `~/.codori/run/`.
-- Idle runtimes are stopped automatically after the configured inactivity timeout.
-- Runtimes with an active proxied WebSocket session are never reaped as idle.
+- Each Codori server instance starts at most one active Codex app-server process.
+- Projects and projectless chats are logical workspaces. Codori keeps their activity and WebSocket session counts separate while proxying them to the shared app-server.
+- If a PID/runtime file points to a live shared process, Codori reuses it instead of spawning another app-server.
+- Codori records `startedAt` and `lastActivityAt` for the shared runtime under `~/.codori/run/`.
+- The shared runtime is stopped automatically after the configured inactivity timeout when no workspace has an active proxied WebSocket session.
+- Stopping the final active workspace stops the shared runtime immediately unless a proxied WebSocket session is still open.
+- Workspaces with an active proxied WebSocket session keep the shared runtime from being reaped as idle.
 - If a PID/runtime file is stale, Codori cleans it up and starts a fresh runtime.
 - Runtime metadata is stored under `~/.codori/run/`.
 
-This keeps the browser UI stateless with respect to process ownership while still making runtime state explicit on disk.
+This keeps the browser UI stateless with respect to process ownership while preserving workspace context through explicit Codex app-server `cwd` parameters.
 
 ## Client UI
 
@@ -274,17 +276,17 @@ The client dashboard provides:
 - a new thread action
 - a previous threads panel for resume
 
-When you open a stopped project and start chatting, Codori starts its app-server first and then connects the UI through the Codori WebSocket proxy.
+When you open a stopped project and start chatting, Codori ensures the shared app-server is running and then connects the UI through the Codori WebSocket proxy.
 
 ## What Codori Does
 
 - Scans a configured root directory and finds descendant directories that contain a direct `.git` child.
-- Exposes CLI commands to list, start, stop, and inspect project runtimes.
-- Starts project-specific Codex app-server processes on demand.
+- Exposes CLI commands to list, start, stop, and inspect logical project workspace runtimes.
+- Starts one shared Codex app-server process on demand.
 - Allocates a free TCP port from a configured safe range.
 - Stores runtime metadata under `~/.codori/run/`.
 - Provides a Nuxt UI dashboard for project selection, chat, and thread resume.
-- Proxies browser WebSocket traffic to the correct project app-server.
+- Proxies browser WebSocket traffic for each project or chat workspace to the shared app-server.
 - Serves the built dashboard bundle from the same origin as the management API.
 
 ## What Codori Does Not Do
@@ -309,13 +311,13 @@ npx @codori/server list --root ~/Project
 npx @codori/server list --root ~/Project --json
 ```
 
-Start a project runtime:
+Start a project workspace runtime:
 
 ```bash
 npx @codori/server start codori --root ~/Project
 ```
 
-Stop a project runtime:
+Stop a project workspace runtime:
 
 ```bash
 npx @codori/server stop codori --root ~/Project
@@ -337,8 +339,8 @@ Notes:
 ## Security Notes
 
 - Codori assumes the host machine is trusted.
-- Codori can start Codex runtimes that can act on the selected repository.
-- Anyone who can reach your Codori server can potentially interact with those runtimes unless you place Codori behind a private network or another access control layer.
+- Codori can start a shared Codex runtime that can act on selected repositories through explicit workspace `cwd` values.
+- Anyone who can reach your Codori server can potentially interact with that runtime unless you place Codori behind a private network or another access control layer.
 - For remote use, prefer a private tailnet or equivalent private tunnel over direct public exposure.
 
 ## Practical Recommendation

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -153,7 +153,7 @@ Stop behavior:
 
 - Project and chat stop commands deactivate that logical workspace.
 - Stopping one workspace does not terminate the shared app-server while other workspaces may still use it.
-- Stopping the final active workspace terminates the shared app-server immediately unless a proxied WebSocket session is still open.
+- Stopping the final active workspace terminates the shared app-server immediately unless a proxied WebSocket session is still open; in that case, Codori terminates the runtime when the final session closes.
 - Idle cleanup and server reset also terminate the shared process when applicable.
 - Return a stable stopped status for the requested workspace.
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -5,15 +5,15 @@
 Codori is a self-hosted remote coding control plane for Codex app-server.
 
 - `@codori/server` discovers local Git projects under a configured root directory.
-- It manages one Codex app-server process per discovered project.
-- `@codori/client` provides a browser UI for browsing projects, starting/stopping project runtimes, listing prior Codex threads, starting new threads, and resuming prior threads.
+- It manages one shared Codex app-server process for project and projectless chat workspaces.
+- `@codori/client` provides a browser UI for browsing projects, activating/stopping project workspaces, listing prior Codex threads, starting new threads, and resuming prior threads.
 - Codori does not provide a private network tunnel. Users must expose the service through their own network layer such as Tailscale or Cloudflare Tunnel.
 
 ## 2. Goals
 
 - Provide a single server process that can enumerate local projects from one root directory.
-- Ensure each project has at most one active Codex app-server process.
-- Expose predictable CLI and HTTP management surfaces for project runtime control.
+- Ensure one Codex app-server process can cover multiple logical project/chat workspaces through explicit `cwd` handling.
+- Expose predictable CLI and HTTP management surfaces for logical project workspace runtime control.
 - Provide a Nuxt UI dashboard for project selection and per-project Codex chat.
 - Reuse only the useful, stable parts of Corazon instead of importing Corazon wholesale.
 
@@ -23,7 +23,7 @@ Codori is a self-hosted remote coding control plane for Codex app-server.
 - No tunnel, reverse proxy, or ingress automation in v1.
 - No multi-root support in v1.
 - No Codori-owned thread database in v1.
-- No direct browser connection to raw project app-server ports.
+- No direct browser connection to raw app-server ports.
 
 ## 4. Users And Usage Model
 
@@ -37,7 +37,7 @@ Expected usage:
 2. User exposes the service with an external private network solution if remote access is required.
 3. User opens the Codori dashboard.
 4. User chooses a project from the sidebar.
-5. Codori starts that project’s Codex app-server on demand if necessary.
+5. Codori starts the shared Codex app-server on demand if necessary.
 6. User starts a fresh thread or resumes a previous thread from the selected project.
 
 ## 5. Root Configuration
@@ -72,10 +72,10 @@ Config shape:
 Rules:
 
 - `root` is required at runtime after precedence resolution.
-- `ports.start` and `ports.end` define the inclusive port allocation range for project app-servers.
-- `idleShutdown.enabled` controls whether idle runtimes are reaped automatically.
-- `idleShutdown.timeoutMs` defines the inactivity window before a runtime becomes eligible for automatic stop.
-- `idleShutdown.sweepIntervalMs` defines how often Codori evaluates running runtimes for idle cleanup.
+- `ports.start` and `ports.end` define the inclusive port allocation range for the shared app-server.
+- `idleShutdown.enabled` controls whether the idle shared runtime is reaped automatically.
+- `idleShutdown.timeoutMs` defines the inactivity window before the shared runtime becomes eligible for automatic stop.
+- `idleShutdown.sweepIntervalMs` defines how often Codori evaluates the shared runtime for idle cleanup.
 - Invalid config should produce a startup error with a precise message.
 
 ## 6. Project Discovery
@@ -106,33 +106,34 @@ Discovery constraints:
 
 ## 7. Runtime Process Management
 
-Each discovered project can have at most one active Codex app-server.
+One Codori server instance can have at most one active Codex app-server process. Discovered projects and projectless chats are logical workspaces that share that process.
 
 Start command:
 
 ```bash
-codex app-server --listen ws://0.0.0.0:{PORT_NUMBER}
+codex app-server --listen ws://127.0.0.1:{PORT_NUMBER}
 ```
 
 Start behavior:
 
 - Resolve project directory from project id.
-- Check for an existing PID file.
-- If PID file exists and process is alive, return its stored port and do not spawn another process.
-- If PID file exists and process is dead, remove the stale PID file and continue.
+- Check for an existing shared runtime PID file.
+- If the shared PID file exists and the process is alive, return its stored port and do not spawn another process.
+- If the shared PID file exists and the process is dead, remove the stale PID file and continue.
 - Select the first available TCP port in the configured safe range.
-- Spawn the process with `cwd` set to the project directory.
+- Spawn the process with `cwd` set to the configured Codori root directory.
+- Track the selected project or chat as a logical active workspace.
 - Persist runtime metadata to a PID JSON file under `~/.codori/run/`.
 
 PID/runtime file requirements:
 
-- Filename uses a stable hash of the absolute project path.
+- Filename uses a stable hash of the configured root directory.
 - File contents:
 
 ```json
 {
-  "projectId": "codori",
-  "projectPath": "/Users/comfuture/Project/codori",
+  "projectId": "codori:shared-app-server",
+  "projectPath": "/Users/comfuture/Project",
   "pid": 12345,
   "port": 46001,
   "startedAt": 1760000000000,
@@ -142,22 +143,24 @@ PID/runtime file requirements:
 
 Idle lifecycle behavior:
 
-- Codori updates `lastActivityAt` when it starts or reuses a runtime.
+- Codori updates `lastActivityAt` when it starts or reuses the shared runtime.
 - Proxied WebSocket traffic counts as activity.
-- A runtime with at least one active proxied WebSocket session is not considered idle.
-- When `Date.now() - lastActivityAt >= idleShutdown.timeoutMs` and there are no active sessions, Codori stops the runtime automatically.
-- The next project interaction follows the same on-demand start path and transparently recreates the runtime.
+- The shared runtime is not considered idle while any workspace has an active proxied WebSocket session.
+- When `Date.now() - lastActivityAt >= idleShutdown.timeoutMs` and there are no active sessions, Codori stops the shared runtime automatically.
+- The next project or chat interaction follows the same on-demand start path and transparently recreates the shared runtime.
 
 Stop behavior:
 
-- If process is running, terminate it.
-- Remove the PID file after the process exits or after Codori determines it is already gone.
-- Return a stable stopped status even if the process was already absent.
+- Project and chat stop commands deactivate that logical workspace.
+- Stopping one workspace does not terminate the shared app-server while other workspaces may still use it.
+- Stopping the final active workspace terminates the shared app-server immediately unless a proxied WebSocket session is still open.
+- Idle cleanup and server reset also terminate the shared process when applicable.
+- Return a stable stopped status for the requested workspace.
 
 Status behavior:
 
-- `running`: PID file exists and process is alive
-- `stopped`: no PID file or PID file cleaned due to dead process
+- `running`: the workspace has been activated and the shared app-server process is alive
+- `stopped`: the workspace is not active, or the shared runtime is absent/dead
 - `error`: malformed runtime metadata or spawn/runtime failure detected by Codori
 
 ## 8. CLI Contract
@@ -178,7 +181,7 @@ Behavior:
 
 - Starts the HTTP + WebSocket management server.
 - Resolves config and validates required values.
-- Does not eagerly start project app-servers.
+- Does not eagerly start the shared app-server.
 
 ### `codori list`
 
@@ -188,7 +191,7 @@ codori list [--root <path>] [--json]
 
 Behavior:
 
-- Prints all discovered projects with runtime status.
+- Prints all discovered projects with logical workspace runtime status.
 
 ### `codori start`
 
@@ -198,8 +201,8 @@ codori start <projectId> [--root <path>] [--json]
 
 Behavior:
 
-- Starts the project runtime if not already running.
-- Returns the listening port either way.
+- Activates the project workspace and starts the shared runtime if it is not already running.
+- Returns the shared runtime listening port either way.
 
 ### `codori stop`
 
@@ -254,8 +257,8 @@ Returns:
 
 - resolved project metadata
 - runtime status
-- active port
-- whether the process was newly started or already running
+- active shared runtime port
+- whether the shared process was newly started or already running
 
 ### `POST /api/projects/:projectId/stop`
 
@@ -269,22 +272,22 @@ Returns:
 Returns:
 
 - same runtime envelope used by list/detail responses
-- includes `startedAt`, `lastActivityAt`, `activeSessionCount`, and `idleDeadlineAt` when the runtime is running
+- includes workspace-specific `startedAt`, `lastActivityAt`, `activeSessionCount`, and `idleDeadlineAt` when that workspace is active
 
 ### `WS /api/projects/:projectId/rpc`
 
 Behavior:
 
 - Resolve target project.
-- Ensure the project app-server is running; if not, start it first.
-- Open a WebSocket client connection from Codori server to the project app-server.
+- Ensure the shared app-server is running; if not, start it first.
+- Open a WebSocket client connection from Codori server to the shared app-server.
 - Proxy frames transparently in both directions.
 - Close both ends cleanly if either side disconnects.
 
 Protocol notes:
 
-- The project app-server is JSON-RPC over WebSocket.
-- The browser client should treat Codori as the single origin and should not connect directly to the project app-server port.
+- The shared app-server is JSON-RPC over WebSocket.
+- The browser client should treat Codori as the single origin and should not connect directly to the app-server port.
 
 ## 10. Client UX Requirements
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "pnpm --filter @codori/client build && pnpm --filter @codori/server build",
     "dev": "pnpm --filter @codori/client dev",
+    "run:local": "pnpm build && node packages/server/dist/cli.js serve --root .. --host 127.0.0.1",
     "lint": "pnpm -r --if-present lint",
     "release:publish": "node ./scripts/publish-release.mjs",
     "typecheck": "pnpm -r --if-present typecheck",

--- a/packages/server/src/process-manager.ts
+++ b/packages/server/src/process-manager.ts
@@ -149,6 +149,8 @@ export class RuntimeManager {
 
   private sharedRuntimeStart: Promise<StartProjectResult> | null = null
 
+  private sharedRuntimeStop: Promise<boolean> | null = null
+
   private idleReaper: NodeJS.Timeout | null = null
 
   private idleSweepInFlight = false
@@ -429,6 +431,11 @@ export class RuntimeManager {
     this.activeSessions.delete(projectId)
   }
 
+  private releaseWorkspaceSession(workspaceId: string) {
+    this.decrementActiveSessions(workspaceId)
+    void this.stopSharedRuntimeIfUnused().catch(() => {})
+  }
+
   private loadActiveRuntime() {
     const project = this.sharedRuntimeProject()
     const loaded = this.store.load(project.path)
@@ -518,7 +525,7 @@ export class RuntimeManager {
         }
 
         released = true
-        this.decrementActiveSessions(project.id)
+        this.releaseWorkspaceSession(project.id)
       }
     }
   }
@@ -538,7 +545,7 @@ export class RuntimeManager {
         }
 
         released = true
-        this.decrementActiveSessions(runtimeProject.id)
+        this.releaseWorkspaceSession(runtimeProject.id)
       }
     }
   }
@@ -605,6 +612,10 @@ export class RuntimeManager {
   }
 
   private async startSharedRuntime(workspace: ProjectRecord): Promise<StartProjectResult> {
+    if (this.sharedRuntimeStop) {
+      await this.sharedRuntimeStop
+    }
+
     if (this.sharedRuntimeStart) {
       await this.sharedRuntimeStart
       const runtime = this.loadActiveRuntime()
@@ -756,6 +767,30 @@ export class RuntimeManager {
   }
 
   private async stopSharedRuntimeIfUnused() {
+    if (
+      this.workspaceActivity.size > 0
+      || this.getTotalActiveSessionCount() > 0
+      || this.sharedRuntimeStart
+    ) {
+      return false
+    }
+
+    if (this.sharedRuntimeStop) {
+      return await this.sharedRuntimeStop
+    }
+
+    const stop = this.stopSharedRuntimeNow()
+    this.sharedRuntimeStop = stop
+    try {
+      return await stop
+    } finally {
+      if (this.sharedRuntimeStop === stop) {
+        this.sharedRuntimeStop = null
+      }
+    }
+  }
+
+  private async stopSharedRuntimeNow() {
     if (this.workspaceActivity.size > 0 || this.getTotalActiveSessionCount() > 0) {
       return false
     }

--- a/packages/server/src/process-manager.ts
+++ b/packages/server/src/process-manager.ts
@@ -48,17 +48,23 @@ type RuntimeManagerOptions = {
   commandFactory?: CommandFactory
 }
 
+type WorkspaceActivityRecord = {
+  startedAt: number
+  lastActivityAt: number
+}
+
 const CODORI_STOP_TIMEOUT_MS = 3_000
 const CODORI_STOP_POLL_MS = 50
 const CHAT_PARENT_DIR_NAME = 'Chats'
 const CHAT_MARKER_FILE = '.codori-chat.json'
 const CHAT_RECENT_LIMIT = 5
 const CHAT_RUNTIME_ID_PREFIX = 'chat:'
+const SHARED_RUNTIME_ID = 'codori:shared-app-server'
 const DEFAULT_CHAT_TITLE = 'New Chat'
 
 const defaultCommandFactory: CommandFactory = (port) => ({
   command: process.env.CODORI_CODEX_BIN ?? 'codex',
-  args: ['app-server', '--listen', `ws://0.0.0.0:${port}`]
+  args: ['app-server', '--listen', `ws://127.0.0.1:${port}`]
 })
 
 const isProcessAlive = (pid: number) => {
@@ -138,6 +144,10 @@ export class RuntimeManager {
   private readonly commandFactory: CommandFactory
 
   private readonly activeSessions = new Map<string, number>()
+
+  private readonly workspaceActivity = new Map<string, WorkspaceActivityRecord>()
+
+  private sharedRuntimeStart: Promise<StartProjectResult> | null = null
 
   private idleReaper: NodeJS.Timeout | null = null
 
@@ -286,6 +296,13 @@ export class RuntimeManager {
     }
   }
 
+  private sharedRuntimeProject(): ProjectRecord {
+    return {
+      id: SHARED_RUNTIME_ID,
+      path: this.config.root
+    }
+  }
+
   private resolveProject(projectId: string) {
     const project = this.listProjects().find(entry => entry.id === projectId)
     if (project) {
@@ -297,17 +314,19 @@ export class RuntimeManager {
 
   private normalizeStatus(project: ProjectRecord, runtime: RuntimeRecord | null, error: string | null): ProjectStatusRecord {
     const activeSessionCount = this.getActiveSessionCount(project.id)
+    const activity = this.workspaceActivity.get(project.id) ?? null
+    const running = activity !== null && runtime !== null
     return {
       projectId: project.id,
       projectPath: project.path,
-      status: error ? 'error' : runtime ? 'running' : 'stopped',
-      pid: runtime?.pid ?? null,
-      port: runtime?.port ?? null,
-      startedAt: runtime?.startedAt ?? null,
-      lastActivityAt: runtime?.lastActivityAt ?? null,
+      status: error ? 'error' : running ? 'running' : 'stopped',
+      pid: running ? runtime.pid : null,
+      port: running ? runtime.port : null,
+      startedAt: running ? activity.startedAt : null,
+      lastActivityAt: running ? activity.lastActivityAt : null,
       activeSessionCount,
       idleTimeoutMs: this.config.idleShutdown.enabled ? this.config.idleShutdown.timeoutMs : null,
-      idleDeadlineAt: this.resolveIdleDeadline(runtime, activeSessionCount),
+      idleDeadlineAt: this.resolveIdleDeadline(activity, activeSessionCount),
       error
     }
   }
@@ -317,17 +336,20 @@ export class RuntimeManager {
     runtime: RuntimeRecord | null,
     error: string | null
   ): ChatSessionStatusRecord {
-    const activeSessionCount = this.getActiveSessionCount(this.chatRuntimeId(chat.chatId))
+    const workspaceId = this.chatRuntimeId(chat.chatId)
+    const activeSessionCount = this.getActiveSessionCount(workspaceId)
+    const activity = this.workspaceActivity.get(workspaceId) ?? null
+    const running = activity !== null && runtime !== null
     return {
       ...chat,
-      status: error ? 'error' : runtime ? 'running' : 'stopped',
-      pid: runtime?.pid ?? null,
-      port: runtime?.port ?? null,
-      startedAt: runtime?.startedAt ?? null,
-      lastActivityAt: runtime?.lastActivityAt ?? null,
+      status: error ? 'error' : running ? 'running' : 'stopped',
+      pid: running ? runtime.pid : null,
+      port: running ? runtime.port : null,
+      startedAt: running ? activity.startedAt : null,
+      lastActivityAt: running ? activity.lastActivityAt : null,
       activeSessionCount,
       idleTimeoutMs: this.config.idleShutdown.enabled ? this.config.idleShutdown.timeoutMs : null,
-      idleDeadlineAt: this.resolveIdleDeadline(runtime, activeSessionCount),
+      idleDeadlineAt: this.resolveIdleDeadline(activity, activeSessionCount),
       error
     }
   }
@@ -336,12 +358,20 @@ export class RuntimeManager {
     return this.activeSessions.get(projectId) ?? 0
   }
 
-  private resolveIdleDeadline(runtime: RuntimeRecord | null, activeSessionCount: number) {
-    if (!runtime || !this.config.idleShutdown.enabled || activeSessionCount > 0) {
+  private getTotalActiveSessionCount() {
+    let total = 0
+    for (const count of this.activeSessions.values()) {
+      total += count
+    }
+    return total
+  }
+
+  private resolveIdleDeadline(activity: WorkspaceActivityRecord | null, activeSessionCount: number) {
+    if (!activity || !this.config.idleShutdown.enabled || activeSessionCount > 0) {
       return null
     }
 
-    return runtime.lastActivityAt + this.config.idleShutdown.timeoutMs
+    return activity.lastActivityAt + this.config.idleShutdown.timeoutMs
   }
 
   private writeRuntime(record: RuntimeRecord) {
@@ -354,6 +384,35 @@ export class RuntimeManager {
       ...record,
       lastActivityAt: Math.max(record.lastActivityAt, at)
     })
+  }
+
+  private activateWorkspace(workspaceId: string, at = Date.now()) {
+    const activity = this.workspaceActivity.get(workspaceId)
+    if (activity) {
+      activity.lastActivityAt = Math.max(activity.lastActivityAt, at)
+      return activity
+    }
+
+    const nextActivity = {
+      startedAt: at,
+      lastActivityAt: at
+    }
+    this.workspaceActivity.set(workspaceId, nextActivity)
+    return nextActivity
+  }
+
+  private touchWorkspaceActivity(workspaceId: string, at = Date.now()) {
+    const activity = this.workspaceActivity.get(workspaceId)
+    if (!activity) {
+      return null
+    }
+
+    activity.lastActivityAt = Math.max(activity.lastActivityAt, at)
+    return activity
+  }
+
+  private deactivateWorkspace(workspaceId: string) {
+    this.workspaceActivity.delete(workspaceId)
   }
 
   private incrementActiveSessions(projectId: string) {
@@ -370,7 +429,8 @@ export class RuntimeManager {
     this.activeSessions.delete(projectId)
   }
 
-  private loadActiveRuntime(project: ProjectRecord) {
+  private loadActiveRuntime() {
+    const project = this.sharedRuntimeProject()
     const loaded = this.store.load(project.path)
 
     if (loaded.kind === 'missing') {
@@ -390,30 +450,49 @@ export class RuntimeManager {
     return loaded.record
   }
 
-  private readRunningRuntime(project: ProjectRecord) {
+  private readSharedRuntime() {
+    const project = this.sharedRuntimeProject()
     const loaded = this.store.load(project.path)
     if (loaded.kind === 'missing') {
-      return this.normalizeStatus(project, null, null)
+      return {
+        runtime: null,
+        error: null
+      }
     }
 
     if (loaded.kind === 'invalid') {
-      return this.normalizeStatus(project, null, loaded.error)
+      return {
+        runtime: null,
+        error: loaded.error
+      }
     }
 
     if (!isProcessAlive(loaded.record.pid)) {
       this.store.remove(project.path)
-      return this.normalizeStatus(project, null, null)
+      return {
+        runtime: null,
+        error: null
+      }
     }
 
-    return this.normalizeStatus(project, loaded.record, null)
+    return {
+      runtime: loaded.record,
+      error: null
+    }
+  }
+
+  private readRunningRuntime(project: ProjectRecord) {
+    const shared = this.readSharedRuntime()
+    return this.normalizeStatus(project, shared.runtime, shared.error)
   }
 
   private touchProjectRuntime(project: ProjectRecord, at = Date.now()) {
-    const runtime = this.loadActiveRuntime(project)
+    const runtime = this.loadActiveRuntime()
     if (!runtime) {
       return this.normalizeStatus(project, null, null)
     }
 
+    this.touchWorkspaceActivity(project.id, at)
     return this.normalizeStatus(project, this.touchRuntimeRecord(runtime, at), null)
   }
 
@@ -513,75 +592,97 @@ export class RuntimeManager {
     }))
 
     this.activeSessions.clear()
+    this.workspaceActivity.clear()
     return resetResults.reduce((total, stopped) => total + stopped, 0)
   }
 
   private async startResolvedProject(project: ProjectRecord): Promise<StartProjectResult> {
-    const loaded = this.store.load(project.path)
+    const started = await this.startSharedRuntime(project)
+    return {
+      ...this.normalizeStatus(project, this.loadActiveRuntime(), null),
+      reusedExisting: started.reusedExisting
+    }
+  }
+
+  private async startSharedRuntime(workspace: ProjectRecord): Promise<StartProjectResult> {
+    if (this.sharedRuntimeStart) {
+      await this.sharedRuntimeStart
+      const runtime = this.loadActiveRuntime()
+      this.activateWorkspace(workspace.id)
+      if (!runtime) {
+        throw new CodoriError('PROCESS_START_FAILED', 'Shared app-server runtime did not start.')
+      }
+      return {
+        ...this.normalizeStatus(workspace, this.touchRuntimeRecord(runtime), null),
+        reusedExisting: true
+      }
+    }
+
+    this.sharedRuntimeStart = this.startSharedRuntimeNow(workspace)
+    try {
+      return await this.sharedRuntimeStart
+    } finally {
+      this.sharedRuntimeStart = null
+    }
+  }
+
+  private async startSharedRuntimeNow(workspace: ProjectRecord): Promise<StartProjectResult> {
+    const runtimeProject = this.sharedRuntimeProject()
+    const loaded = this.store.load(runtimeProject.path)
 
     if (loaded.kind === 'valid' && isProcessAlive(loaded.record.pid)) {
-      const runtime = this.touchRuntimeRecord(loaded.record)
+      const now = Date.now()
+      this.activateWorkspace(workspace.id, now)
+      const runtime = this.touchRuntimeRecord(loaded.record, now)
       return {
-        ...this.normalizeStatus(project, runtime, null),
+        ...this.normalizeStatus(workspace, runtime, null),
         reusedExisting: true
       }
     }
 
     if (loaded.kind !== 'missing') {
-      this.store.remove(project.path)
+      this.store.remove(runtimeProject.path)
     }
 
     const port = await findAvailablePort(this.config.ports.start, this.config.ports.end)
-    const command = this.commandFactory(port, project)
-    const child = await spawnDetached(command.command, command.args, project.path)
+    const command = this.commandFactory(port, runtimeProject)
+    const child = await spawnDetached(command.command, command.args, runtimeProject.path)
 
     if (typeof child.pid !== 'number') {
-      throw new CodoriError('PROCESS_START_FAILED', `Failed to determine PID for project "${project.id}".`)
+      throw new CodoriError('PROCESS_START_FAILED', 'Failed to determine PID for shared app-server runtime.')
     }
 
     const now = Date.now()
     const runtime: RuntimeRecord = {
-      projectId: project.id,
-      projectPath: project.path,
+      projectId: runtimeProject.id,
+      projectPath: runtimeProject.path,
       pid: child.pid,
       port,
       startedAt: now,
       lastActivityAt: now
     }
     this.writeRuntime(runtime)
+    this.activateWorkspace(workspace.id, now)
 
     return {
-      ...this.normalizeStatus(project, runtime, null),
+      ...this.normalizeStatus(workspace, runtime, null),
       reusedExisting: false
     }
   }
 
   private readRunningChatRuntime(chat: ChatSessionRecord) {
-    const runtimeProject = this.chatToRuntimeProject(chat)
-    const loaded = this.store.load(runtimeProject.path)
-    if (loaded.kind === 'missing') {
-      return this.normalizeChatStatus(chat, null, null)
-    }
-
-    if (loaded.kind === 'invalid') {
-      return this.normalizeChatStatus(chat, null, loaded.error)
-    }
-
-    if (!isProcessAlive(loaded.record.pid)) {
-      this.store.remove(runtimeProject.path)
-      return this.normalizeChatStatus(chat, null, null)
-    }
-
-    return this.normalizeChatStatus(chat, loaded.record, null)
+    const shared = this.readSharedRuntime()
+    return this.normalizeChatStatus(chat, shared.runtime, shared.error)
   }
 
   private touchChatRuntime(chat: ChatSessionRecord, at = Date.now()) {
     const runtimeProject = this.chatToRuntimeProject(chat)
-    const runtime = this.loadActiveRuntime(runtimeProject)
+    const runtime = this.loadActiveRuntime()
     if (!runtime) {
       return this.normalizeChatStatus(chat, null, null)
     }
 
+    this.touchWorkspaceActivity(runtimeProject.id, at)
     return this.normalizeChatStatus(chat, this.touchRuntimeRecord(runtime, at), null)
   }
 
@@ -601,7 +702,6 @@ export class RuntimeManager {
   async deleteChatSession(chatId: string): Promise<DeleteChatSessionResult> {
     const chat = this.resolveChatSession(chatId)
     await this.stopChatSession(chatId)
-    this.activeSessions.delete(this.chatRuntimeId(chatId))
     await rm(chat.chatPath, { recursive: true, force: true })
 
     return { chatId }
@@ -650,21 +750,25 @@ export class RuntimeManager {
   }
 
   private async stopResolvedProject(project: ProjectRecord) {
-    const loaded = this.store.load(project.path)
-
-    if (loaded.kind === 'missing') {
-      return this.normalizeStatus(project, null, null)
-    }
-
-    if (loaded.kind === 'invalid') {
-      this.store.remove(project.path)
-      return this.normalizeStatus(project, null, null)
-    }
-
-    await terminateProcess(loaded.record.pid)
-
-    this.store.remove(project.path)
+    this.deactivateWorkspace(project.id)
+    await this.stopSharedRuntimeIfUnused()
     return this.normalizeStatus(project, null, null)
+  }
+
+  private async stopSharedRuntimeIfUnused() {
+    if (this.workspaceActivity.size > 0 || this.getTotalActiveSessionCount() > 0) {
+      return false
+    }
+
+    const runtimeProject = this.sharedRuntimeProject()
+    const runtime = this.loadActiveRuntime()
+    if (!runtime) {
+      return false
+    }
+
+    await terminateProcess(runtime.pid)
+    this.store.remove(runtimeProject.path)
+    return true
   }
 
   async reapIdleRuntimes() {
@@ -676,26 +780,22 @@ export class RuntimeManager {
     let stopped = 0
 
     try {
+      const runtimeProject = this.sharedRuntimeProject()
+      const runtime = this.loadActiveRuntime()
+      if (!runtime) {
+        return 0
+      }
+
+      if (this.getTotalActiveSessionCount() > 0) {
+        return 0
+      }
+
       const now = Date.now()
-      for (const project of [
-        ...this.listProjects(),
-        ...this.listChatSessions(Number.POSITIVE_INFINITY).map(chat => this.chatToRuntimeProject(chat))
-      ]) {
-        const runtime = this.loadActiveRuntime(project)
-        if (!runtime) {
-          continue
-        }
-
-        if (this.getActiveSessionCount(project.id) > 0) {
-          continue
-        }
-
-        if (now - runtime.lastActivityAt < this.config.idleShutdown.timeoutMs) {
-          continue
-        }
-
-        await this.stopResolvedProject(project)
-        stopped += 1
+      if (now - runtime.lastActivityAt >= this.config.idleShutdown.timeoutMs) {
+        await terminateProcess(runtime.pid)
+        this.store.remove(runtimeProject.path)
+        this.workspaceActivity.clear()
+        stopped = 1
       }
 
       return stopped

--- a/packages/server/src/process-manager.ts
+++ b/packages/server/src/process-manager.ts
@@ -436,6 +436,11 @@ export class RuntimeManager {
     void this.stopSharedRuntimeIfUnused().catch(() => {})
   }
 
+  private removeSharedRuntime(project: ProjectRecord) {
+    this.store.remove(project.path)
+    this.workspaceActivity.clear()
+  }
+
   private loadActiveRuntime() {
     const project = this.sharedRuntimeProject()
     const loaded = this.store.load(project.path)
@@ -445,12 +450,12 @@ export class RuntimeManager {
     }
 
     if (loaded.kind === 'invalid') {
-      this.store.remove(project.path)
+      this.removeSharedRuntime(project)
       return null
     }
 
     if (!isProcessAlive(loaded.record.pid)) {
-      this.store.remove(project.path)
+      this.removeSharedRuntime(project)
       return null
     }
 
@@ -475,7 +480,7 @@ export class RuntimeManager {
     }
 
     if (!isProcessAlive(loaded.record.pid)) {
-      this.store.remove(project.path)
+      this.removeSharedRuntime(project)
       return {
         runtime: null,
         error: null
@@ -652,7 +657,7 @@ export class RuntimeManager {
     }
 
     if (loaded.kind !== 'missing') {
-      this.store.remove(runtimeProject.path)
+      this.removeSharedRuntime(runtimeProject)
     }
 
     const port = await findAvailablePort(this.config.ports.start, this.config.ports.end)

--- a/packages/server/test/http-server.test.ts
+++ b/packages/server/test/http-server.test.ts
@@ -733,34 +733,9 @@ describe('createHttpServer', () => {
   })
 
   it('bridges project and chat websocket routes to the same runtime port', async () => {
-    const tcpServer = createNetServer()
-    await new Promise<void>((resolvePromise, reject) => {
-      tcpServer.listen(0, '127.0.0.1', (error?: Error) => {
-        if (error) {
-          reject(error)
-          return
-        }
-        resolvePromise()
-      })
-    })
-    const address = tcpServer.address()
-    if (!address || typeof address === 'string') {
-      throw new Error('Failed to get test server address.')
-    }
-    const backendPort = address.port
-    await new Promise<void>((resolvePromise, reject) => {
-      tcpServer.close((error) => {
-        if (error) {
-          reject(error)
-          return
-        }
-        resolvePromise()
-      })
-    })
-
     const backend = new WebSocketServer({
       host: '127.0.0.1',
-      port: backendPort
+      port: 0
     })
     startedSocketServers.push(backend)
     await new Promise<void>((resolvePromise) => {
@@ -768,6 +743,11 @@ describe('createHttpServer', () => {
         resolvePromise()
       })
     })
+    const address = backend.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Failed to get test server address.')
+    }
+    const backendPort = address.port
     backend.on('connection', (socket: WebSocket) => {
       socket.on('message', (message: WebSocket.RawData) => {
         socket.send(`shared:${rawDataToString(message)}`)

--- a/packages/server/test/http-server.test.ts
+++ b/packages/server/test/http-server.test.ts
@@ -10,7 +10,12 @@ import { resolveProjectAttachmentsDir } from '../src/attachment-store.js'
 import { CodoriError } from '../src/errors.js'
 import { createHttpServer, startHttpServer, type RuntimeManagerLike } from '../src/http-server.js'
 import type { ServiceUpdateController } from '../src/service-update.js'
-import type { ChatSessionStatusRecord, ProjectStatusRecord, StartProjectResult } from '../src/types.js'
+import type {
+  ChatSessionStatusRecord,
+  ProjectStatusRecord,
+  StartChatSessionResult,
+  StartProjectResult
+} from '../src/types.js'
 
 const startedApps: Array<Awaited<ReturnType<typeof createHttpServer>>> = []
 const startedSocketServers: WebSocketServer[] = []
@@ -650,7 +655,7 @@ describe('createHttpServer', () => {
     })
   })
 
-  it('bridges websocket frames to the project app-server', async () => {
+  it('bridges websocket frames to the shared app-server', async () => {
     const tcpServer = createNetServer()
     await new Promise<void>((resolvePromise, reject) => {
       tcpServer.listen(0, '127.0.0.1', (error?: Error) => {
@@ -725,6 +730,103 @@ describe('createHttpServer', () => {
       })
       client.once('error', reject)
     })
+  })
+
+  it('bridges project and chat websocket routes to the same runtime port', async () => {
+    const tcpServer = createNetServer()
+    await new Promise<void>((resolvePromise, reject) => {
+      tcpServer.listen(0, '127.0.0.1', (error?: Error) => {
+        if (error) {
+          reject(error)
+          return
+        }
+        resolvePromise()
+      })
+    })
+    const address = tcpServer.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Failed to get test server address.')
+    }
+    const backendPort = address.port
+    await new Promise<void>((resolvePromise, reject) => {
+      tcpServer.close((error) => {
+        if (error) {
+          reject(error)
+          return
+        }
+        resolvePromise()
+      })
+    })
+
+    const backend = new WebSocketServer({
+      host: '127.0.0.1',
+      port: backendPort
+    })
+    startedSocketServers.push(backend)
+    await new Promise<void>((resolvePromise) => {
+      backend.once('listening', () => {
+        resolvePromise()
+      })
+    })
+    backend.on('connection', (socket: WebSocket) => {
+      socket.on('message', (message: WebSocket.RawData) => {
+        socket.send(`shared:${rawDataToString(message)}`)
+      })
+    })
+
+    const starts: string[] = []
+    const manager = createManager({
+      startProject: () => {
+        starts.push('project')
+        return {
+          ...createProjectRecord(),
+          port: backendPort,
+          reusedExisting: true
+        } satisfies StartProjectResult
+      },
+      startChatSession: () => {
+        starts.push('chat')
+        return {
+          ...createChatRecord(),
+          port: backendPort,
+          reusedExisting: true
+        } satisfies StartChatSessionResult
+      }
+    })
+    const app = await createHttpServer(manager)
+    startedApps.push(app)
+    await app.listen({
+      host: '127.0.0.1',
+      port: 0
+    })
+
+    const serverAddress = app.addresses()[0]
+    const sendAndRead = async (url: string, message: string) => await new Promise<string>((resolvePromise, reject) => {
+      const client = new WebSocket(url)
+      client.once('open', () => {
+        client.send(message)
+      })
+      client.once('message', (data: WebSocket.RawData) => {
+        try {
+          resolvePromise(rawDataToString(data))
+        } catch (error) {
+          reject(error instanceof Error ? error : new Error(String(error)))
+        } finally {
+          client.close()
+        }
+      })
+      client.once('error', reject)
+    })
+
+    await expect(sendAndRead(
+      `ws://127.0.0.1:${serverAddress.port}/api/projects/demo/rpc`,
+      'project'
+    )).resolves.toBe('shared:project')
+    await expect(sendAndRead(
+      `ws://127.0.0.1:${serverAddress.port}/api/chats/chat-test/rpc`,
+      'chat'
+    )).resolves.toBe('shared:chat')
+    expect(starts).toEqual(['project', 'chat'])
   })
 
   it('marks websocket sessions active while the proxy is connected', async () => {

--- a/packages/server/test/runtime-manager.test.ts
+++ b/packages/server/test/runtime-manager.test.ts
@@ -275,6 +275,35 @@ describe('RuntimeManager', () => {
     expect(started.pid).not.toBe(999999)
   })
 
+  it('clears stale workspace activity when the shared runtime dies before restart', async () => {
+    const fixture = createFixture()
+    const manager = createRuntimeManager({
+      homeDir: fixture.homeDir,
+      config: fixture.config,
+      commandFactory: () => ({
+        command: process.execPath,
+        args: ['-e', 'setInterval(() => {}, 1000)']
+      })
+    })
+    runningManagers.push(manager)
+
+    const demo = await manager.startProject('demo')
+    expect(demo.pid).not.toBeNull()
+    if (demo.pid === null) {
+      throw new Error('Expected a started shared runtime PID.')
+    }
+    const demoPid = demo.pid
+    process.kill(demoPid, 'SIGTERM')
+    await waitForCondition(() => !isProcessAlive(demoPid))
+
+    expect(manager.getProjectStatus('demo').status).toBe('stopped')
+
+    const other = await manager.startProject('other')
+    expect(other.status).toBe('running')
+    expect(other.reusedExisting).toBe(false)
+    expect(manager.getProjectStatus('demo').status).toBe('stopped')
+  })
+
   it('resets stored runtimes before a new server starts', async () => {
     const fixture = createFixture()
     const manager = createRuntimeManager({

--- a/packages/server/test/runtime-manager.test.ts
+++ b/packages/server/test/runtime-manager.test.ts
@@ -1,5 +1,5 @@
 import { createServer } from 'node:net'
-import { mkdirSync, mkdtempSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -23,6 +23,7 @@ afterEach(async () => {
         await manager.stopProject(workspace.id)
       }
     }
+    await manager.resetStoredRuntimes()
     manager.dispose()
   }
 
@@ -43,6 +44,7 @@ const createFixture = () => {
   const homeDir = mkdtempSync(join(os.tmpdir(), 'codori-home-'))
   const root = mkdtempSync(join(os.tmpdir(), 'codori-root-'))
   mkdirSync(join(root, 'demo', '.git'), { recursive: true })
+  mkdirSync(join(root, 'other', '.git'), { recursive: true })
   const documentsDir = join(homeDir, 'Documents')
 
   const config = resolveConfig({
@@ -110,6 +112,19 @@ const reservePortRange = async (size: number, start = 47000, end = 49000) => {
   throw new Error('Failed to reserve a free TCP port range for the runtime-manager test.')
 }
 
+const waitForFile = async (path: string, timeoutMs = 1_000) => {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (existsSync(path)) {
+      return
+    }
+
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 25))
+  }
+
+  throw new Error(`Timed out waiting for ${path}.`)
+}
+
 describe('RuntimeManager', () => {
   it('starts once and reuses the existing process', async () => {
     const fixture = createFixture()
@@ -125,18 +140,107 @@ describe('RuntimeManager', () => {
 
     const started = await manager.startProject('demo')
     const reused = await manager.startProject('demo')
+    const other = await manager.startProject('other')
 
     expect(started.status).toBe('running')
     expect(reused.reusedExisting).toBe(true)
     expect(reused.port).toBe(started.port)
+    expect(other.reusedExisting).toBe(true)
+    expect(other.pid).toBe(started.pid)
+    expect(other.port).toBe(started.port)
+  })
+
+  it('deduplicates concurrent starts across workspaces', async () => {
+    const fixture = createFixture()
+    let commandCalls = 0
+    const manager = createRuntimeManager({
+      homeDir: fixture.homeDir,
+      documentsDir: fixture.documentsDir,
+      config: fixture.config,
+      commandFactory: () => {
+        commandCalls += 1
+        return {
+          command: process.execPath,
+          args: ['-e', 'setInterval(() => {}, 1000)']
+        }
+      }
+    })
+    runningManagers.push(manager)
+
+    const [demo, other, chat] = await Promise.all([
+      manager.startProject('demo'),
+      manager.startProject('other'),
+      manager.createChatSession()
+    ])
+
+    expect(commandCalls).toBe(1)
+    expect(other.reusedExisting).toBe(true)
+    expect(chat.reusedExisting).toBe(true)
+    expect(other.pid).toBe(demo.pid)
+    expect(chat.pid).toBe(demo.pid)
+    expect(other.port).toBe(demo.port)
+    expect(chat.port).toBe(demo.port)
+  })
+
+  it('starts the default app-server command on loopback from the configured root', async () => {
+    const fixture = createFixture()
+    const capturePath = join(fixture.homeDir, 'codex-spawn.json')
+    const fakeCodexPath = join(fixture.homeDir, 'fake-codex.cjs')
+    writeFileSync(fakeCodexPath, [
+      '#!/usr/bin/env node',
+      "const { writeFileSync } = require('node:fs')",
+      'writeFileSync(process.env.CODORI_CAPTURE_PATH, JSON.stringify({',
+      '  argv: process.argv.slice(2),',
+      '  cwd: process.cwd()',
+      '}))',
+      'setInterval(() => {}, 1000)'
+    ].join('\n'))
+    chmodSync(fakeCodexPath, 0o755)
+    const previousCodexBin = process.env.CODORI_CODEX_BIN
+    const previousCapturePath = process.env.CODORI_CAPTURE_PATH
+    process.env.CODORI_CODEX_BIN = fakeCodexPath
+    process.env.CODORI_CAPTURE_PATH = capturePath
+
+    try {
+      const manager = createRuntimeManager({
+        homeDir: fixture.homeDir,
+        config: fixture.config
+      })
+      runningManagers.push(manager)
+
+      const started = await manager.startProject('demo')
+      await waitForFile(capturePath)
+      const capture = JSON.parse(readFileSync(capturePath, 'utf8')) as {
+        argv: string[]
+        cwd: string
+      }
+
+      expect(realpathSync(capture.cwd)).toBe(realpathSync(fixture.root))
+      expect(capture.argv).toEqual([
+        'app-server',
+        '--listen',
+        `ws://127.0.0.1:${started.port}`
+      ])
+    } finally {
+      if (previousCodexBin === undefined) {
+        delete process.env.CODORI_CODEX_BIN
+      } else {
+        process.env.CODORI_CODEX_BIN = previousCodexBin
+      }
+      if (previousCapturePath === undefined) {
+        delete process.env.CODORI_CAPTURE_PATH
+      } else {
+        process.env.CODORI_CAPTURE_PATH = previousCapturePath
+      }
+    }
   })
 
   it('cleans a stale pid file before starting', async () => {
     const fixture = createFixture()
     const store = new RuntimeStore(fixture.homeDir)
     store.write({
-      projectId: 'demo',
-      projectPath: join(fixture.root, 'demo'),
+      projectId: 'codori:shared-app-server',
+      projectPath: fixture.root,
       pid: 999999,
       port: 46000,
       startedAt: Date.now(),
@@ -193,7 +297,7 @@ describe('RuntimeManager', () => {
     expect(isProcessAlive(started.pid)).toBe(false)
 
     const store = new RuntimeStore(fixture.homeDir)
-    expect(store.load(join(fixture.root, 'demo')).kind).toBe('missing')
+    expect(store.load(fixture.root).kind).toBe('missing')
 
     const restarted = await nextManager.startProject('demo')
     expect(restarted.reusedExisting).toBe(false)
@@ -250,14 +354,14 @@ describe('RuntimeManager', () => {
     expect(started.lastActivityAt).not.toBeNull()
 
     const store = new RuntimeStore(fixture.homeDir)
-    const loaded = store.load(join(fixture.root, 'demo'))
+    const loaded = store.load(fixture.root)
     expect(loaded.kind).toBe('valid')
     if (loaded.kind !== 'valid') {
       throw new Error('Expected a valid runtime record.')
     }
 
     const session = manager.acquireProjectSession('demo')
-    const refreshed = store.load(join(fixture.root, 'demo'))
+    const refreshed = store.load(fixture.root)
     expect(refreshed.kind).toBe('valid')
     if (refreshed.kind !== 'valid') {
       throw new Error('Expected a refreshed runtime record.')
@@ -278,6 +382,64 @@ describe('RuntimeManager', () => {
     expect(manager.getProjectStatus('demo').status).toBe('stopped')
   })
 
+  it('keeps the shared runtime alive when one of multiple workspaces is stopped', async () => {
+    const fixture = createFixture()
+    const manager = createRuntimeManager({
+      homeDir: fixture.homeDir,
+      documentsDir: fixture.documentsDir,
+      config: fixture.config,
+      commandFactory: () => ({
+        command: process.execPath,
+        args: ['-e', 'setInterval(() => {}, 1000)']
+      })
+    })
+    runningManagers.push(manager)
+
+    const project = await manager.startProject('demo')
+    const chat = await manager.createChatSession()
+
+    expect(project.pid).not.toBeNull()
+    expect(chat.pid).toBe(project.pid)
+    expect(chat.port).toBe(project.port)
+    if (project.pid === null) {
+      throw new Error('Expected a started shared runtime PID.')
+    }
+
+    const stoppedProject = await manager.stopProject('demo')
+
+    expect(stoppedProject.status).toBe('stopped')
+    expect(stoppedProject.pid).toBeNull()
+    expect(isProcessAlive(project.pid)).toBe(true)
+    expect(manager.getChatStatus(chat.chatId).status).toBe('running')
+    expect(manager.getChatStatus(chat.chatId).pid).toBe(project.pid)
+  })
+
+  it('stops the shared runtime when the final workspace is stopped', async () => {
+    const fixture = createFixture()
+    const manager = createRuntimeManager({
+      homeDir: fixture.homeDir,
+      documentsDir: fixture.documentsDir,
+      config: fixture.config,
+      commandFactory: () => ({
+        command: process.execPath,
+        args: ['-e', 'setInterval(() => {}, 1000)']
+      })
+    })
+    runningManagers.push(manager)
+
+    const project = await manager.startProject('demo')
+    expect(project.pid).not.toBeNull()
+    if (project.pid === null) {
+      throw new Error('Expected a started shared runtime PID.')
+    }
+
+    const stoppedProject = await manager.stopProject('demo')
+
+    expect(stoppedProject.status).toBe('stopped')
+    expect(isProcessAlive(project.pid)).toBe(false)
+    expect(new RuntimeStore(fixture.homeDir).load(fixture.root).kind).toBe('missing')
+  })
+
   it('updates the last activity timestamp when project activity is noted', async () => {
     const fixture = createFixture()
     const manager = createRuntimeManager({
@@ -292,7 +454,7 @@ describe('RuntimeManager', () => {
 
     await manager.startProject('demo')
     const store = new RuntimeStore(fixture.homeDir)
-    const loaded = store.load(join(fixture.root, 'demo'))
+    const loaded = store.load(fixture.root)
     expect(loaded.kind).toBe('valid')
     if (loaded.kind !== 'valid') {
       throw new Error('Expected a valid runtime record.')
@@ -330,18 +492,23 @@ describe('RuntimeManager', () => {
     runningManagers.push(manager)
 
     const created = await manager.createChatSession()
+    const second = await manager.createChatSession()
 
     expect(created.status).toBe('running')
     expect(created.reusedExisting).toBe(false)
     expect(created.title).toBe('New Chat')
     expect(created.chatId).toMatch(/^chat-/)
     expect(created.chatPath.startsWith(join(fixture.documentsDir, 'Chats'))).toBe(true)
-    expect(spawnedCwds).toEqual([created.chatPath])
+    expect(second.status).toBe('running')
+    expect(second.reusedExisting).toBe(true)
+    expect(second.pid).toBe(created.pid)
+    expect(second.port).toBe(created.port)
+    expect(spawnedCwds).toEqual([fixture.root])
 
     const recent = manager.listChatStatuses()
-    expect(recent).toHaveLength(1)
-    expect(recent[0]?.chatId).toBe(created.chatId)
-    expect(recent[0]?.title).toBe('New Chat')
+    expect(recent).toHaveLength(2)
+    expect(recent.some(chat => chat.chatId === created.chatId && chat.title === 'New Chat')).toBe(true)
+    expect(recent.some(chat => chat.chatId === second.chatId && chat.title === 'New Chat')).toBe(true)
   })
 
   it('deletes a chat and removes its scratch directory', async () => {

--- a/packages/server/test/runtime-manager.test.ts
+++ b/packages/server/test/runtime-manager.test.ts
@@ -125,6 +125,19 @@ const waitForFile = async (path: string, timeoutMs = 1_000) => {
   throw new Error(`Timed out waiting for ${path}.`)
 }
 
+const waitForCondition = async (condition: () => boolean, timeoutMs = 1_000) => {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (condition()) {
+      return
+    }
+
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 25))
+  }
+
+  throw new Error('Timed out waiting for condition.')
+}
+
 describe('RuntimeManager', () => {
   it('starts once and reuses the existing process', async () => {
     const fixture = createFixture()
@@ -438,6 +451,41 @@ describe('RuntimeManager', () => {
     expect(stoppedProject.status).toBe('stopped')
     expect(isProcessAlive(project.pid)).toBe(false)
     expect(new RuntimeStore(fixture.homeDir).load(fixture.root).kind).toBe('missing')
+  })
+
+  it('stops the shared runtime after the final stopped workspace session closes', async () => {
+    const fixture = createFixture()
+    const manager = createRuntimeManager({
+      homeDir: fixture.homeDir,
+      config: fixture.config,
+      commandFactory: () => ({
+        command: process.execPath,
+        args: ['-e', 'setInterval(() => {}, 1000)']
+      })
+    })
+    runningManagers.push(manager)
+
+    const project = await manager.startProject('demo')
+    expect(project.pid).not.toBeNull()
+    if (project.pid === null) {
+      throw new Error('Expected a started shared runtime PID.')
+    }
+    const projectPid = project.pid
+
+    const session = manager.acquireProjectSession('demo')
+    const stoppedProject = await manager.stopProject('demo')
+
+    expect(stoppedProject.status).toBe('stopped')
+    expect(isProcessAlive(projectPid)).toBe(true)
+
+    session.release()
+
+    const store = new RuntimeStore(fixture.homeDir)
+    await waitForCondition(() => !isProcessAlive(projectPid) && store.load(fixture.root).kind === 'missing')
+
+    const restarted = await manager.startProject('demo')
+    expect(restarted.status).toBe('running')
+    expect(restarted.reusedExisting).toBe(false)
   })
 
   it('updates the last activity timestamp when project activity is noted', async () => {


### PR DESCRIPTION
## Summary
- Replace per-project and per-chat app-server spawning with one shared Codex app-server process per Codori server instance.
- Keep project and projectless chat workspaces logically separate through workspace activity/session tracking while proxying them to the shared runtime.
- Start the shared app-server on `127.0.0.1` from the configured root cwd, deduplicate concurrent starts, and stop the shared runtime when the final active workspace stops.
- Clean up the shared runtime after the final stopped workspace's last proxied session closes, without breaking the next start/ensure path.
- Clear stale workspace activity when the shared runtime metadata/process becomes invalid, and simplify the shared WebSocket proxy test to bind directly to port `0`.
- Add `pnpm run:local` so local development can rebuild the client/server and serve the bundled Codori UI from the server origin.
- Update runtime docs and regression tests for cross-project reuse, chat reuse, stale store cleanup, shared WebSocket proxying, default spawn arguments, and local server execution.

## Why
- Codex app-server accepts explicit cwd values on thread and turn operations, and Codori already sends workspace cwd values through the client protocol.
- A single shared runtime removes the resource cost of spawning one app-server per project or projectless chat thread.
- The Codori server currently serves generated client files through Fastify static handling, so a reliable local same-origin run should rebuild the client bundle before starting the server.

## Commits
- `58e7026` feat: share codex app server runtime
- `5f660ae` fix: clean up shared runtime after final session
- `225c462` fix: address shared runtime review feedback
- `9a7d1f3` chore: add local server run script

## Validation
- `pnpm --filter @codori/server test runtime-manager.test.ts http-server.test.ts -- --runInBand`
- `pnpm typecheck && pnpm lint && pnpm test && pnpm build`
- `pnpm build`
- `node packages/server/dist/cli.js serve --root .. --host 127.0.0.1 --port 4311`
- `curl -fsS http://127.0.0.1:4311/ | head -n 5`
- `curl -fsS http://127.0.0.1:4311/api/projects | head -c 300`

Closes #71
