### PR TITLE
Show recent project threads in the sidebar

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -300,7 +300,7 @@ Routes:
 Layout:
 
 - Use Nuxt UI dashboard primitives as the main shell.
-- Left sidebar shows projects and basic runtime state.
+- Left sidebar shows projects, recent project threads for the selected project, and projectless chats.
 - Main panel shows the selected project chat screen.
 - Top navbar includes:
   - `New thread`

--- a/packages/client/app/components/ProjectSidebar.vue
+++ b/packages/client/app/components/ProjectSidebar.vue
@@ -130,6 +130,21 @@ const resetInlineThreads = () => {
   inlineThreadsHasMore.value = false
 }
 
+const waitForProjectsRefresh = async () => {
+  if (loaded.value || !loading.value) {
+    return
+  }
+
+  await new Promise<void>((resolve) => {
+    const stop = watch([loaded, loading], ([projectsLoaded, projectsLoading]) => {
+      if (projectsLoaded || !projectsLoading) {
+        stop()
+        resolve()
+      }
+    })
+  })
+}
+
 const fetchInlineThreads = async () => {
   const projectId = activeProjectId.value
   if (!projectId || props.collapsed) {
@@ -146,6 +161,11 @@ const fetchInlineThreads = async () => {
   try {
     if (!loaded.value) {
       await refreshProjects()
+      await waitForProjectsRefresh()
+    }
+
+    if (sequence !== inlineThreadFetchSequence) {
+      return
     }
 
     const project = getProject(projectId)

--- a/packages/client/app/components/ProjectSidebar.vue
+++ b/packages/client/app/components/ProjectSidebar.vue
@@ -113,7 +113,7 @@ onMounted(() => {
   if (typeof navigator !== 'undefined') {
     platform.value = navigator.platform
   }
-  if (!loaded.value && !activeProjectId.value) {
+  if (!loaded.value) {
     void refreshProjects()
   }
   if (!chatsLoaded.value) {
@@ -160,7 +160,9 @@ const fetchInlineThreads = async () => {
 
   try {
     if (!loaded.value) {
-      await refreshProjects()
+      if (!loading.value) {
+        await refreshProjects()
+      }
       await waitForProjectsRefresh()
     }
 
@@ -175,6 +177,10 @@ const fetchInlineThreads = async () => {
 
     if (project.status !== 'running') {
       await startProject(projectId)
+    }
+
+    if (sequence !== inlineThreadFetchSequence) {
+      return
     }
 
     const refreshedProject = getProject(projectId) ?? project
@@ -285,7 +291,11 @@ const projectItems = computed<ProjectSidebarNavigationItem[][]>(() => [
       return items
     }
 
-    if (inlineThreadsProjectId.value === project.projectId && inlineThreadsLoading.value) {
+    if (inlineThreadsProjectId.value !== project.projectId) {
+      return items
+    }
+
+    if (inlineThreadsLoading.value) {
       items.push({
         itemKind: 'thread-status',
         label: 'Loading threads...',
@@ -297,7 +307,7 @@ const projectItems = computed<ProjectSidebarNavigationItem[][]>(() => [
       return items
     }
 
-    if (inlineThreadsProjectId.value === project.projectId && inlineThreadsError.value) {
+    if (inlineThreadsError.value) {
       items.push({
         itemKind: 'thread-status',
         label: 'Threads unavailable',

--- a/packages/client/app/components/ProjectSidebar.vue
+++ b/packages/client/app/components/ProjectSidebar.vue
@@ -7,7 +7,12 @@ import { useCodoriRouter } from '../composables/useCodoriRouter'
 import { useProjects } from '../composables/useProjects'
 import { useRpc } from '../composables/useRpc'
 import { useThreadPanel } from '../composables/useThreadPanel'
-import { resolveThreadSummaryTitle, type ThreadSummary } from '../composables/useThreadSummaries'
+import {
+  resolveProjectThreadSummaryKey,
+  resolveThreadSummaryTitle,
+  useThreadSummaries,
+  type ThreadSummary
+} from '../composables/useThreadSummaries'
 import { isMacLikePlatform } from '../utils/global-command-palette-shortcut'
 import { sortSidebarProjects } from '../utils/project-sidebar-order'
 import type { ThreadListParams } from '~~/shared/generated/codex-app-server/v2/ThreadListParams'
@@ -67,7 +72,6 @@ const router = useCodoriRouter()
 const addProjectOpen = ref(false)
 const platform = ref(typeof navigator === 'undefined' ? '' : navigator.platform)
 const isMac = computed(() => isMacLikePlatform(platform.value))
-const inlineThreads = ref<ThreadSummary[]>([])
 const inlineThreadsProjectId = ref<string | null>(null)
 const inlineThreadsLoading = ref(false)
 const inlineThreadsError = ref<string | null>(null)
@@ -92,6 +96,17 @@ const {
   refreshChats,
   deleteChat
 } = useChats()
+
+const inlineThreadSummariesForProject = (projectId: string | null) =>
+  useThreadSummaries(resolveProjectThreadSummaryKey(projectId))
+
+const inlineThreads = computed<ThreadSummary[]>(() => {
+  if (!inlineThreadsProjectId.value) {
+    return []
+  }
+
+  return inlineThreadSummariesForProject(inlineThreadsProjectId.value).threads.value
+})
 
 const activeProjectId = computed(() => {
   const param = route.params.projectId
@@ -123,7 +138,6 @@ onMounted(() => {
 })
 
 const resetInlineThreads = () => {
-  inlineThreads.value = []
   inlineThreadsProjectId.value = null
   inlineThreadsLoading.value = false
   inlineThreadsError.value = null
@@ -196,17 +210,16 @@ const fetchInlineThreads = async () => {
       return
     }
 
-    inlineThreads.value = response.data.map(thread => ({
+    inlineThreadSummariesForProject(projectId).setThreads(response.data.map(thread => ({
       id: thread.id,
       title: resolveThreadSummaryTitle(thread),
       updatedAt: thread.updatedAt
-    }))
+    })))
     inlineThreadsHasMore.value = response.nextCursor !== null
   } catch (caughtError) {
     if (sequence !== inlineThreadFetchSequence) {
       return
     }
-    inlineThreads.value = []
     inlineThreadsError.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
   } finally {
     if (sequence === inlineThreadFetchSequence) {
@@ -265,8 +278,12 @@ const chatItems = computed<ChatNavigationItem[][]>(() => [
   }))
 ])
 
+const inlineThreadsHasOverflow = computed(() =>
+  inlineThreadsHasMore.value || inlineThreads.value.length > INLINE_THREAD_ROW_LIMIT
+)
+
 const visibleInlineThreads = computed(() =>
-  inlineThreadsHasMore.value
+  inlineThreadsHasOverflow.value
     ? inlineThreads.value.slice(0, INLINE_THREAD_ROWS_WITH_MORE)
     : inlineThreads.value.slice(0, INLINE_THREAD_ROW_LIMIT)
 )
@@ -336,7 +353,7 @@ const projectItems = computed<ProjectSidebarNavigationItem[][]>(() => [
       })
     }
 
-    if (inlineThreadsHasMore.value) {
+    if (inlineThreadsHasOverflow.value) {
       items.push({
         itemKind: 'more',
         label: 'more..',

--- a/packages/client/app/components/ProjectSidebar.vue
+++ b/packages/client/app/components/ProjectSidebar.vue
@@ -1,13 +1,21 @@
 <script setup lang="ts">
 import type { NavigationMenuItem } from '@nuxt/ui'
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useChats } from '../composables/useChats'
 import { useCodoriRoute } from '../composables/useCodoriRoute'
 import { useCodoriRouter } from '../composables/useCodoriRouter'
 import { useProjects } from '../composables/useProjects'
+import { useRpc } from '../composables/useRpc'
+import { useThreadPanel } from '../composables/useThreadPanel'
+import { resolveThreadSummaryTitle, type ThreadSummary } from '../composables/useThreadSummaries'
 import { isMacLikePlatform } from '../utils/global-command-palette-shortcut'
 import { sortSidebarProjects } from '../utils/project-sidebar-order'
-import { toChatRoute, toChatsRoute, toProjectRoute } from '~~/shared/codori'
+import type { ThreadListParams } from '~~/shared/generated/codex-app-server/v2/ThreadListParams'
+import type { ThreadListResponse } from '~~/shared/generated/codex-app-server/v2/ThreadListResponse'
+import { toChatRoute, toChatsRoute, toProjectRoute, toProjectThreadRoute } from '~~/shared/codori'
+
+const INLINE_THREAD_ROW_LIMIT = 5
+const INLINE_THREAD_ROWS_WITH_MORE = INLINE_THREAD_ROW_LIMIT - 1
 
 const props = defineProps<{
   collapsed?: boolean
@@ -16,11 +24,36 @@ const emit = defineEmits<{
   openCommandPalette: []
 }>()
 type ProjectNavigationItem = NavigationMenuItem & {
+  itemKind: 'project'
   projectId: string
   projectPath: string
-  status: 'running' | 'stopped' | 'error'
   error: string | null
 }
+
+type ProjectThreadNavigationItem = NavigationMenuItem & {
+  itemKind: 'thread'
+  projectId: string
+  threadId: string
+  title: string
+  updatedAt: number
+}
+
+type ProjectThreadMoreNavigationItem = NavigationMenuItem & {
+  itemKind: 'more'
+  projectId: string
+}
+
+type ProjectThreadStatusNavigationItem = NavigationMenuItem & {
+  itemKind: 'thread-status'
+  projectId: string
+  message: string
+}
+
+type ProjectSidebarNavigationItem =
+  | ProjectNavigationItem
+  | ProjectThreadNavigationItem
+  | ProjectThreadMoreNavigationItem
+  | ProjectThreadStatusNavigationItem
 
 type ChatNavigationItem = NavigationMenuItem & {
   chatId: string
@@ -34,12 +67,22 @@ const router = useCodoriRouter()
 const addProjectOpen = ref(false)
 const platform = ref(typeof navigator === 'undefined' ? '' : navigator.platform)
 const isMac = computed(() => isMacLikePlatform(platform.value))
+const inlineThreads = ref<ThreadSummary[]>([])
+const inlineThreadsProjectId = ref<string | null>(null)
+const inlineThreadsLoading = ref(false)
+const inlineThreadsError = ref<string | null>(null)
+const inlineThreadsHasMore = ref(false)
+let inlineThreadFetchSequence = 0
 const {
   projects,
   loaded,
   loading,
   refreshProjects,
+  startProject,
+  getProject
 } = useProjects()
+const { getClient } = useRpc()
+const { openPanel } = useThreadPanel()
 const {
   chats,
   loaded: chatsLoaded,
@@ -61,17 +104,96 @@ const activeChatId = computed(() => {
   const param = route.params.chatId
   return typeof param === 'string' ? param : null
 })
+const activeThreadId = computed(() => {
+  const param = route.params.threadId
+  return typeof param === 'string' ? param : null
+})
 
 onMounted(() => {
   if (typeof navigator !== 'undefined') {
     platform.value = navigator.platform
   }
-  if (!loaded.value) {
+  if (!loaded.value && !activeProjectId.value) {
     void refreshProjects()
   }
   if (!chatsLoaded.value) {
     void refreshChats()
   }
+  void fetchInlineThreads()
+})
+
+const resetInlineThreads = () => {
+  inlineThreads.value = []
+  inlineThreadsProjectId.value = null
+  inlineThreadsLoading.value = false
+  inlineThreadsError.value = null
+  inlineThreadsHasMore.value = false
+}
+
+const fetchInlineThreads = async () => {
+  const projectId = activeProjectId.value
+  if (!projectId || props.collapsed) {
+    resetInlineThreads()
+    return
+  }
+
+  const sequence = ++inlineThreadFetchSequence
+  inlineThreadsProjectId.value = projectId
+  inlineThreadsLoading.value = true
+  inlineThreadsError.value = null
+  inlineThreadsHasMore.value = false
+
+  try {
+    if (!loaded.value) {
+      await refreshProjects()
+    }
+
+    const project = getProject(projectId)
+    if (!project) {
+      throw new Error(`Project "${projectId}" was not found.`)
+    }
+
+    if (project.status !== 'running') {
+      await startProject(projectId)
+    }
+
+    const refreshedProject = getProject(projectId) ?? project
+    const client = getClient(projectId)
+    const response = await client.request<ThreadListResponse>('thread/list', {
+      limit: INLINE_THREAD_ROW_LIMIT,
+      sortKey: 'updated_at',
+      sortDirection: 'desc',
+      cwd: refreshedProject.projectPath
+    } satisfies ThreadListParams)
+
+    if (sequence !== inlineThreadFetchSequence) {
+      return
+    }
+
+    inlineThreads.value = response.data.map(thread => ({
+      id: thread.id,
+      title: resolveThreadSummaryTitle(thread),
+      updatedAt: thread.updatedAt
+    }))
+    inlineThreadsHasMore.value = response.nextCursor !== null
+  } catch (caughtError) {
+    if (sequence !== inlineThreadFetchSequence) {
+      return
+    }
+    inlineThreads.value = []
+    inlineThreadsError.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
+  } finally {
+    if (sequence === inlineThreadFetchSequence) {
+      inlineThreadsLoading.value = false
+    }
+  }
+}
+
+watch([
+  activeProjectId,
+  () => props.collapsed
+], () => {
+  void fetchInlineThreads()
 })
 
 const formatChatTitle = (chat: { chatId: string, title: string | null }) =>
@@ -117,26 +239,107 @@ const chatItems = computed<ChatNavigationItem[][]>(() => [
   }))
 ])
 
-const projectItems = computed<ProjectNavigationItem[][]>(() => [
-  sortSidebarProjects(projects.value, activeProjectId.value).map(project => ({
-    label: project.projectId,
-    icon: 'i-lucide-folder-git-2',
-    to: toProjectRoute(project.projectId),
-    active: activeProjectId.value === project.projectId,
-    tooltip: {
-      text: project.projectId
-    },
-    projectId: project.projectId,
-    projectPath: project.projectPath,
-    status: project.status,
-    error: project.error
-  }))
+const visibleInlineThreads = computed(() =>
+  inlineThreadsHasMore.value
+    ? inlineThreads.value.slice(0, INLINE_THREAD_ROWS_WITH_MORE)
+    : inlineThreads.value.slice(0, INLINE_THREAD_ROW_LIMIT)
+)
+
+const projectItems = computed<ProjectSidebarNavigationItem[][]>(() => [
+  sortSidebarProjects(projects.value, activeProjectId.value).flatMap((project) => {
+    const items: ProjectSidebarNavigationItem[] = [{
+      itemKind: 'project',
+      label: project.projectId,
+      icon: 'i-lucide-folder-git-2',
+      to: toProjectRoute(project.projectId),
+      active: activeProjectId.value === project.projectId && !activeThreadId.value,
+      tooltip: {
+        text: project.projectId
+      },
+      projectId: project.projectId,
+      projectPath: project.projectPath,
+      error: project.error
+    }]
+
+    if (props.collapsed || activeProjectId.value !== project.projectId) {
+      return items
+    }
+
+    if (inlineThreadsProjectId.value === project.projectId && inlineThreadsLoading.value) {
+      items.push({
+        itemKind: 'thread-status',
+        label: 'Loading threads...',
+        icon: 'i-lucide-loader-circle',
+        disabled: true,
+        projectId: project.projectId,
+        message: 'Loading threads...'
+      })
+      return items
+    }
+
+    if (inlineThreadsProjectId.value === project.projectId && inlineThreadsError.value) {
+      items.push({
+        itemKind: 'thread-status',
+        label: 'Threads unavailable',
+        icon: 'i-lucide-circle-alert',
+        disabled: true,
+        projectId: project.projectId,
+        message: inlineThreadsError.value
+      })
+      return items
+    }
+
+    for (const thread of visibleInlineThreads.value) {
+      items.push({
+        itemKind: 'thread',
+        label: thread.title,
+        icon: 'i-lucide-message-square-text',
+        to: toProjectThreadRoute(project.projectId, thread.id),
+        active: activeThreadId.value === thread.id,
+        tooltip: {
+          text: thread.title
+        },
+        projectId: project.projectId,
+        threadId: thread.id,
+        title: thread.title,
+        updatedAt: thread.updatedAt
+      })
+    }
+
+    if (inlineThreadsHasMore.value) {
+      items.push({
+        itemKind: 'more',
+        label: 'more..',
+        icon: 'i-lucide-ellipsis',
+        projectId: project.projectId,
+        tooltip: {
+          text: 'Open all threads'
+        },
+        onSelect: () => {
+          openPanel()
+        }
+      })
+    }
+
+    return items
+  })
 ])
 
 const asProjectItem = (item: NavigationMenuItem) => item as ProjectNavigationItem
+const asProjectSidebarItem = (item: NavigationMenuItem) => item as ProjectSidebarNavigationItem
+const asProjectThreadItem = (item: NavigationMenuItem) => item as ProjectThreadNavigationItem
+const asProjectThreadMoreItem = (item: NavigationMenuItem) => item as ProjectThreadMoreNavigationItem
+const asProjectThreadStatusItem = (item: NavigationMenuItem) => item as ProjectThreadStatusNavigationItem
 const asChatItem = (item: NavigationMenuItem) => item as ChatNavigationItem
 
-const isActiveProject = (item: ProjectNavigationItem) => activeProjectId.value === item.projectId
+const isProjectItem = (item: NavigationMenuItem): item is ProjectNavigationItem =>
+  asProjectSidebarItem(item).itemKind === 'project'
+const isThreadItem = (item: NavigationMenuItem): item is ProjectThreadNavigationItem =>
+  asProjectSidebarItem(item).itemKind === 'thread'
+const isMoreItem = (item: NavigationMenuItem): item is ProjectThreadMoreNavigationItem =>
+  asProjectSidebarItem(item).itemKind === 'more'
+const isThreadStatusItem = (item: NavigationMenuItem): item is ProjectThreadStatusNavigationItem =>
+  asProjectSidebarItem(item).itemKind === 'thread-status'
 </script>
 
 <template>
@@ -328,7 +531,7 @@ const isActiveProject = (item: ProjectNavigationItem) => activeProjectId.value =
       >
         <template #item-label="{ item }">
           <div
-            v-if="!props.collapsed"
+            v-if="!props.collapsed && isProjectItem(item)"
             class="min-w-0"
           >
             <div class="truncate font-medium text-highlighted">
@@ -344,17 +547,32 @@ const isActiveProject = (item: ProjectNavigationItem) => activeProjectId.value =
               {{ asProjectItem(item).error }}
             </div>
           </div>
-        </template>
-
-        <template #item-trailing="{ item }">
           <div
-            v-if="!props.collapsed"
-            class="flex items-center"
+            v-else-if="!props.collapsed && isThreadItem(item)"
+            class="min-w-0 ps-2"
           >
-            <ProjectStatusDot
-              :status="asProjectItem(item).status"
-              :pulse="isActiveProject(asProjectItem(item))"
-            />
+            <div class="truncate text-xs font-medium text-highlighted">
+              {{ asProjectThreadItem(item).title }}
+            </div>
+          </div>
+          <div
+            v-else-if="!props.collapsed && isMoreItem(item)"
+            class="min-w-0 ps-2"
+          >
+            <div class="truncate text-xs font-medium text-muted">
+              {{ asProjectThreadMoreItem(item).label }}
+            </div>
+          </div>
+          <div
+            v-else-if="!props.collapsed && isThreadStatusItem(item)"
+            class="min-w-0 ps-2"
+          >
+            <div
+              class="truncate text-xs"
+              :class="asProjectThreadStatusItem(item).message === 'Loading threads...' ? 'text-muted' : 'text-error'"
+            >
+              {{ asProjectThreadStatusItem(item).message }}
+            </div>
           </div>
         </template>
       </UNavigationMenu>

--- a/packages/client/app/components/ThreadList.vue
+++ b/packages/client/app/components/ThreadList.vue
@@ -6,6 +6,7 @@ import { useProjects } from '../composables/useProjects'
 import { useRpc } from '../composables/useRpc'
 import { useThreadPanel } from '../composables/useThreadPanel'
 import {
+  resolveProjectThreadSummaryKey,
   resolveThreadSummaryTitle,
   useThreadSummaries,
   type ThreadSummary
@@ -26,9 +27,7 @@ const route = useRoute()
 const { loaded, refreshProjects, startProject, getProject } = useProjects()
 const { getClient } = useRpc()
 const { closePanel } = useThreadPanel()
-const resolveThreadSummaryKey = (projectId: string | null) =>
-  projectId ? `project:${projectId}` : '__missing-project__'
-const currentThreadSummaries = () => useThreadSummaries(resolveThreadSummaryKey(props.projectId))
+const currentThreadSummaries = () => useThreadSummaries(resolveProjectThreadSummaryKey(props.projectId))
 const threads = computed(() => currentThreadSummaries().threads.value)
 const loading = computed(() => currentThreadSummaries().loading.value)
 const error = computed(() => currentThreadSummaries().error.value)

--- a/packages/client/app/composables/useThreadSummaries.ts
+++ b/packages/client/app/composables/useThreadSummaries.ts
@@ -86,6 +86,9 @@ const createState = (): ThreadSummariesState => ({
   error: ref<string | null>(null)
 })
 
+export const resolveProjectThreadSummaryKey = (projectId: string | null) =>
+  projectId ? `project:${projectId}` : '__missing-project__'
+
 const createApi = (state: ThreadSummariesState): UseThreadSummariesResult => ({
   ...state,
   setThreads: (nextThreads: ThreadSummary[]) => {

--- a/packages/client/test/project-sidebar-command-palette.test.ts
+++ b/packages/client/test/project-sidebar-command-palette.test.ts
@@ -1,19 +1,27 @@
 /* eslint-disable vue/one-component-per-file */
 // @vitest-environment jsdom
 
-import { mount } from '@vue/test-utils'
-import { defineComponent, h, ref } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent, h, nextTick, ref } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import ProjectSidebar from '../app/components/ProjectSidebar.vue'
+import type { ProjectRecord } from '../shared/codori'
+import type { ThreadListResponse } from '../shared/generated/codex-app-server/v2/ThreadListResponse'
 
 const mockRoute = {
-  params: {}
+  params: {} as Record<string, unknown>
 }
 const mockRouterPush = vi.fn()
 const mockRefreshProjects = vi.fn()
 const mockRefreshChats = vi.fn()
-const mockProjects = ref([])
+const mockStartProject = vi.fn()
+const mockGetClient = vi.fn()
+const mockRpcRequest = vi.fn()
+const mockOpenPanel = vi.fn()
+const mockProjects = ref<ProjectRecord[]>([])
 const mockChats = ref([])
+const mockProjectsLoaded = ref(true)
+const mockProjectsLoading = ref(false)
 
 vi.mock('../app/composables/useCodoriRoute', () => ({
   useCodoriRoute: () => mockRoute
@@ -28,9 +36,24 @@ vi.mock('../app/composables/useCodoriRouter', () => ({
 vi.mock('../app/composables/useProjects', () => ({
   useProjects: () => ({
     projects: mockProjects,
-    loaded: ref(true),
-    loading: ref(false),
-    refreshProjects: mockRefreshProjects
+    loaded: mockProjectsLoaded,
+    loading: mockProjectsLoading,
+    refreshProjects: mockRefreshProjects,
+    startProject: mockStartProject,
+    getProject: (projectId: string | null) =>
+      mockProjects.value.find(project => project.projectId === projectId) ?? null
+  })
+}))
+
+vi.mock('../app/composables/useRpc', () => ({
+  useRpc: () => ({
+    getClient: mockGetClient
+  })
+}))
+
+vi.mock('../app/composables/useThreadPanel', () => ({
+  useThreadPanel: () => ({
+    openPanel: mockOpenPanel
   })
 }))
 
@@ -94,6 +117,88 @@ const KbdStub = defineComponent({
   }
 })
 
+const NavigationMenuStub = defineComponent({
+  name: 'NavigationMenuStub',
+  props: {
+    items: {
+      type: Array,
+      default: () => []
+    }
+  },
+  setup(props, { slots }) {
+    const flattenItems = () => (props.items as unknown[])
+      .flatMap(group => Array.isArray(group) ? group : [group])
+      .filter(Boolean) as Array<Record<string, unknown>>
+
+    return () => h('nav', { class: 'navigation-menu-stub' }, flattenItems().map((item) => {
+      const children = [
+        h('span', { class: 'navigation-menu-icon' }, String(item.icon ?? '')),
+        slots['item-label']?.({ item }) ?? h('span', String(item.label ?? '')),
+        slots['item-trailing']?.({ item })
+      ]
+      const baseAttrs = {
+        class: ['navigation-menu-item', item.itemKind ? `navigation-menu-item-${String(item.itemKind)}` : ''],
+        'data-kind': String(item.itemKind ?? ''),
+        'data-label': String(item.label ?? ''),
+        'data-to': String(item.to ?? ''),
+        'data-active': item.active ? 'true' : 'false',
+        onClick: (event: MouseEvent) => {
+          const onSelect = item.onSelect
+          if (typeof onSelect === 'function') {
+            event.preventDefault()
+            onSelect(event)
+          }
+        }
+      }
+
+      return item.to
+        ? h('a', {
+            ...baseAttrs,
+            href: String(item.to)
+          }, children)
+        : h('button', {
+            ...baseAttrs,
+            type: 'button',
+            disabled: Boolean(item.disabled)
+          }, children)
+    }))
+  }
+})
+
+const makeProject = (input: Partial<ProjectRecord> & Pick<ProjectRecord, 'projectId' | 'projectPath'>): ProjectRecord => ({
+  status: 'running',
+  pid: 101,
+  port: 46000,
+  startedAt: 1,
+  lastActivityAt: 1,
+  activeSessionCount: 0,
+  idleTimeoutMs: null,
+  idleDeadlineAt: null,
+  error: null,
+  ...input
+})
+
+const makeThread = (index: number) => ({
+  id: `thread-${index}`,
+  name: `Thread ${index}`,
+  preview: null,
+  updatedAt: 1_000 - index
+})
+
+const makeThreadListResponse = (
+  count: number,
+  nextCursor: string | null = null
+) => ({
+  data: Array.from({ length: count }, (_, index) => makeThread(index + 1)),
+  nextCursor,
+  backwardsCursor: null
+}) as unknown as ThreadListResponse
+
+const waitForSidebar = async () => {
+  await flushPromises()
+  await nextTick()
+}
+
 const mountSidebar = (props: Record<string, unknown> = {}) =>
   mount(ProjectSidebar, {
     props,
@@ -102,12 +207,7 @@ const mountSidebar = (props: Record<string, unknown> = {}) =>
         UTooltip: TooltipStub,
         UButton: ButtonStub,
         UKbd: KbdStub,
-        UNavigationMenu: defineComponent({
-          name: 'NavigationMenuStub',
-          setup() {
-            return () => h('nav')
-          }
-        }),
+        UNavigationMenu: NavigationMenuStub,
         AddProjectModal: defineComponent({
           name: 'AddProjectModalStub',
           setup() {
@@ -117,7 +217,7 @@ const mountSidebar = (props: Record<string, unknown> = {}) =>
         ProjectStatusDot: defineComponent({
           name: 'ProjectStatusDotStub',
           setup() {
-            return () => h('span')
+            return () => h('span', { class: 'status-dot-stub' })
           }
         })
       }
@@ -128,11 +228,22 @@ describe('project sidebar command palette trigger', () => {
   let platformSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
+    mockRoute.params = {}
     mockRouterPush.mockReset()
     mockRefreshProjects.mockReset()
     mockRefreshChats.mockReset()
+    mockStartProject.mockReset()
+    mockGetClient.mockReset()
+    mockRpcRequest.mockReset()
+    mockOpenPanel.mockReset()
     mockProjects.value = []
     mockChats.value = []
+    mockProjectsLoaded.value = true
+    mockProjectsLoading.value = false
+    mockGetClient.mockReturnValue({
+      request: mockRpcRequest
+    })
+    mockRpcRequest.mockResolvedValue(makeThreadListResponse(0))
     platformSpy = vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('MacIntel')
   })
 
@@ -178,5 +289,103 @@ describe('project sidebar command palette trigger', () => {
     await wrapper.get('button[aria-label="Search Codori"]').trigger('click')
 
     expect(wrapper.emitted('openCommandPalette')).toHaveLength(1)
+  })
+})
+
+describe('project sidebar inline threads', () => {
+  let platformSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    mockRoute.params = {
+      projectId: 'codori'
+    }
+    mockRouterPush.mockReset()
+    mockRefreshProjects.mockReset()
+    mockRefreshChats.mockReset()
+    mockStartProject.mockReset()
+    mockGetClient.mockReset()
+    mockRpcRequest.mockReset()
+    mockOpenPanel.mockReset()
+    mockProjects.value = [
+      makeProject({
+        projectId: 'codori',
+        projectPath: '/repo/codori'
+      }),
+      makeProject({
+        projectId: 'other',
+        projectPath: '/repo/other'
+      })
+    ]
+    mockChats.value = []
+    mockProjectsLoaded.value = true
+    mockProjectsLoading.value = false
+    mockGetClient.mockReturnValue({
+      request: mockRpcRequest
+    })
+    platformSpy = vi.spyOn(window.navigator, 'platform', 'get').mockReturnValue('MacIntel')
+  })
+
+  afterEach(() => {
+    platformSpy.mockRestore()
+  })
+
+  it('renders selected project threads inline without project status dots', async () => {
+    mockRpcRequest.mockResolvedValue(makeThreadListResponse(2))
+
+    const wrapper = mountSidebar({
+      collapsed: false
+    })
+    await waitForSidebar()
+
+    expect(wrapper.find('.status-dot-stub').exists()).toBe(false)
+    expect(wrapper.text()).toContain('codori')
+    expect(wrapper.text()).toContain('other')
+    expect(wrapper.text()).toContain('Thread 1')
+    expect(wrapper.text()).toContain('Thread 2')
+
+    const threadLink = wrapper.get('[data-kind="thread"][data-to="/projects/codori/threads/thread-1"]')
+    expect(threadLink.text()).toContain('Thread 1')
+    expect(wrapper.find('[data-kind="thread"][data-to="/projects/other/threads/thread-1"]').exists()).toBe(false)
+    expect(mockGetClient).toHaveBeenCalledTimes(1)
+    expect(mockGetClient).toHaveBeenCalledWith('codori')
+    expect(mockRpcRequest).toHaveBeenCalledWith('thread/list', {
+      limit: 5,
+      sortKey: 'updated_at',
+      sortDirection: 'desc',
+      cwd: '/repo/codori'
+    })
+  })
+
+  it('uses the fifth inline row for more.. when additional threads exist', async () => {
+    mockRpcRequest.mockResolvedValue(makeThreadListResponse(5, 'next-page'))
+
+    const wrapper = mountSidebar({
+      collapsed: false
+    })
+    await waitForSidebar()
+
+    expect(wrapper.text()).toContain('Thread 1')
+    expect(wrapper.text()).toContain('Thread 4')
+    expect(wrapper.text()).not.toContain('Thread 5')
+    expect(wrapper.text()).toContain('more..')
+    expect(wrapper.findAll('[data-kind="thread"]')).toHaveLength(4)
+
+    await wrapper.get('[data-kind="more"]').trigger('click')
+
+    expect(mockOpenPanel).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps collapsed sidebar project-only and does not fetch inline threads', async () => {
+    mockRpcRequest.mockResolvedValue(makeThreadListResponse(2))
+
+    const wrapper = mountSidebar({
+      collapsed: true
+    })
+    await waitForSidebar()
+
+    expect(mockGetClient).not.toHaveBeenCalled()
+    expect(mockRpcRequest).not.toHaveBeenCalled()
+    expect(wrapper.text()).not.toContain('Thread 1')
+    expect(wrapper.findAll('[data-kind="thread"]')).toHaveLength(0)
   })
 })

--- a/packages/client/test/project-sidebar-command-palette.test.ts
+++ b/packages/client/test/project-sidebar-command-palette.test.ts
@@ -2,15 +2,15 @@
 // @vitest-environment jsdom
 
 import { flushPromises, mount } from '@vue/test-utils'
-import { defineComponent, h, nextTick, ref } from 'vue'
+import { defineComponent, h, nextTick, reactive, ref } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import ProjectSidebar from '../app/components/ProjectSidebar.vue'
 import type { ProjectRecord } from '../shared/codori'
 import type { ThreadListResponse } from '../shared/generated/codex-app-server/v2/ThreadListResponse'
 
-const mockRoute = {
+const mockRoute = reactive({
   params: {} as Record<string, unknown>
-}
+})
 const mockRouterPush = vi.fn()
 const mockRefreshProjects = vi.fn()
 const mockRefreshChats = vi.fn()
@@ -199,8 +199,21 @@ const waitForSidebar = async () => {
   await nextTick()
 }
 
-const mountSidebar = (props: Record<string, unknown> = {}) =>
-  mount(ProjectSidebar, {
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return {
+    promise,
+    resolve
+  }
+}
+
+const mountedWrappers: Array<{ unmount: () => void }> = []
+
+const mountSidebar = (props: Record<string, unknown> = {}) => {
+  const wrapper = mount(ProjectSidebar, {
     props,
     global: {
       stubs: {
@@ -223,6 +236,15 @@ const mountSidebar = (props: Record<string, unknown> = {}) =>
       }
     }
   })
+  mountedWrappers.push(wrapper)
+  return wrapper
+}
+
+afterEach(() => {
+  for (const wrapper of mountedWrappers.splice(0)) {
+    wrapper.unmount()
+  }
+})
 
 describe('project sidebar command palette trigger', () => {
   let platformSpy: ReturnType<typeof vi.spyOn>
@@ -375,6 +397,26 @@ describe('project sidebar inline threads', () => {
     expect(mockOpenPanel).toHaveBeenCalledTimes(1)
   })
 
+  it('does not render stale inline threads under a newly selected project', async () => {
+    mockRpcRequest.mockResolvedValueOnce(makeThreadListResponse(2))
+
+    const wrapper = mountSidebar({
+      collapsed: false
+    })
+    await waitForSidebar()
+
+    expect(wrapper.text()).toContain('Thread 1')
+
+    mockRpcRequest.mockResolvedValueOnce(makeThreadListResponse(0))
+    mockRoute.params = {
+      projectId: 'other'
+    }
+    await nextTick()
+
+    expect(wrapper.text()).not.toContain('Thread 1')
+    expect(wrapper.text()).toContain('Loading threads...')
+  })
+
   it('waits for an in-flight project refresh before loading selected project threads', async () => {
     mockProjects.value = []
     mockProjectsLoaded.value = false
@@ -408,6 +450,58 @@ describe('project sidebar inline threads', () => {
       cwd: '/repo/codori'
     })
     expect(wrapper.text()).toContain('Thread 1')
+  })
+
+  it('refreshes projects when mounted collapsed with an active project', async () => {
+    mockProjects.value = []
+    mockProjectsLoaded.value = false
+    mockProjectsLoading.value = false
+    mockRpcRequest.mockResolvedValue(makeThreadListResponse(1))
+
+    mountSidebar({
+      collapsed: true
+    })
+    await waitForSidebar()
+
+    expect(mockRefreshProjects).toHaveBeenCalledTimes(1)
+    expect(mockGetClient).not.toHaveBeenCalled()
+  })
+
+  it('does not continue a stale stopped-project fetch after project selection changes', async () => {
+    const startProject = createDeferred<unknown>()
+    mockProjects.value = [
+      makeProject({
+        projectId: 'codori',
+        projectPath: '/repo/codori',
+        status: 'stopped',
+        pid: null,
+        port: null
+      }),
+      makeProject({
+        projectId: 'other',
+        projectPath: '/repo/other'
+      })
+    ]
+    mockStartProject.mockReturnValue(startProject.promise)
+    mockRpcRequest.mockResolvedValue(makeThreadListResponse(0))
+
+    mountSidebar({
+      collapsed: false
+    })
+    await waitForSidebar()
+
+    expect(mockStartProject).toHaveBeenCalledWith('codori')
+
+    mockRoute.params = {
+      projectId: 'other'
+    }
+    await waitForSidebar()
+
+    startProject.resolve({})
+    await waitForSidebar()
+
+    expect(mockGetClient).not.toHaveBeenCalledWith('codori')
+    expect(mockGetClient).toHaveBeenCalledWith('other')
   })
 
   it('keeps collapsed sidebar project-only and does not fetch inline threads', async () => {

--- a/packages/client/test/project-sidebar-command-palette.test.ts
+++ b/packages/client/test/project-sidebar-command-palette.test.ts
@@ -375,6 +375,41 @@ describe('project sidebar inline threads', () => {
     expect(mockOpenPanel).toHaveBeenCalledTimes(1)
   })
 
+  it('waits for an in-flight project refresh before loading selected project threads', async () => {
+    mockProjects.value = []
+    mockProjectsLoaded.value = false
+    mockProjectsLoading.value = true
+    mockRpcRequest.mockResolvedValue(makeThreadListResponse(1))
+
+    const wrapper = mountSidebar({
+      collapsed: false
+    })
+    await waitForSidebar()
+
+    expect(mockRefreshProjects).toHaveBeenCalledTimes(1)
+    expect(mockGetClient).not.toHaveBeenCalled()
+    expect(wrapper.text()).not.toContain('Project "codori" was not found.')
+
+    mockProjects.value = [
+      makeProject({
+        projectId: 'codori',
+        projectPath: '/repo/codori'
+      })
+    ]
+    mockProjectsLoaded.value = true
+    mockProjectsLoading.value = false
+    await waitForSidebar()
+
+    expect(mockGetClient).toHaveBeenCalledWith('codori')
+    expect(mockRpcRequest).toHaveBeenCalledWith('thread/list', {
+      limit: 5,
+      sortKey: 'updated_at',
+      sortDirection: 'desc',
+      cwd: '/repo/codori'
+    })
+    expect(wrapper.text()).toContain('Thread 1')
+  })
+
   it('keeps collapsed sidebar project-only and does not fetch inline threads', async () => {
     mockRpcRequest.mockResolvedValue(makeThreadListResponse(2))
 

--- a/packages/client/test/project-sidebar-command-palette.test.ts
+++ b/packages/client/test/project-sidebar-command-palette.test.ts
@@ -5,6 +5,10 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { defineComponent, h, nextTick, reactive, ref } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import ProjectSidebar from '../app/components/ProjectSidebar.vue'
+import {
+  resolveProjectThreadSummaryKey,
+  useThreadSummaries
+} from '../app/composables/useThreadSummaries'
 import type { ProjectRecord } from '../shared/codori'
 import type { ThreadListResponse } from '../shared/generated/codex-app-server/v2/ThreadListResponse'
 
@@ -210,6 +214,15 @@ const createDeferred = <T>() => {
   }
 }
 
+const resetThreadSummaries = () => {
+  for (const projectId of ['codori', 'other']) {
+    const summaries = useThreadSummaries(resolveProjectThreadSummaryKey(projectId))
+    summaries.setThreads([])
+    summaries.setLoading(false)
+    summaries.setError(null)
+  }
+}
+
 const mountedWrappers: Array<{ unmount: () => void }> = []
 
 const mountSidebar = (props: Record<string, unknown> = {}) => {
@@ -251,6 +264,7 @@ describe('project sidebar command palette trigger', () => {
 
   beforeEach(() => {
     mockRoute.params = {}
+    resetThreadSummaries()
     mockRouterPush.mockReset()
     mockRefreshProjects.mockReset()
     mockRefreshChats.mockReset()
@@ -321,6 +335,7 @@ describe('project sidebar inline threads', () => {
     mockRoute.params = {
       projectId: 'codori'
     }
+    resetThreadSummaries()
     mockRouterPush.mockReset()
     mockRefreshProjects.mockReset()
     mockRefreshChats.mockReset()
@@ -395,6 +410,31 @@ describe('project sidebar inline threads', () => {
     await wrapper.get('[data-kind="more"]').trigger('click')
 
     expect(mockOpenPanel).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps selected project inline rows synced with shared thread summaries', async () => {
+    mockRpcRequest.mockResolvedValue(makeThreadListResponse(1))
+
+    const wrapper = mountSidebar({
+      collapsed: false
+    })
+    await waitForSidebar()
+
+    expect(wrapper.text()).toContain('Thread 1')
+
+    const summaries = useThreadSummaries(resolveProjectThreadSummaryKey('codori'))
+    summaries.syncThreadSummary({
+      id: 'thread-new',
+      name: 'Fresh thread',
+      preview: '',
+      updatedAt: 2_000
+    })
+    summaries.updateThreadSummaryTitle('thread-1', 'Renamed thread', 3_000)
+    await nextTick()
+
+    expect(wrapper.text()).toContain('Fresh thread')
+    expect(wrapper.text()).toContain('Renamed thread')
+    expect(wrapper.text()).not.toContain('Thread 1')
   })
 
   it('does not render stale inline threads under a newly selected project', async () => {


### PR DESCRIPTION
## Summary
- Remove the per-project runtime status dot from the project sidebar.
- Expand the selected project in the sidebar with recent thread child rows, capped at 5 total rows.
- Show 4 recent threads plus a final `more..` row when additional threads exist, and reuse the existing right-side thread panel for `more..`.
- Share the project thread summary key helper with `ThreadList` and update the PRD sidebar wording.
- Wait for in-flight project discovery before loading selected-project inline threads.
- Address review race cases for collapsed active-project mount, route-switch stale rows, and stopped-project startup races.
- Keep sidebar inline rows synced with shared thread summary updates from the active workspace.

Closes #73

## Commits
- `e343f39` feat: show recent project threads in sidebar
- `4006c3e` fix: wait for project refresh before sidebar thread load
- `2ccaae7` fix: address sidebar review races
- `1d8697e` fix: sync sidebar thread summaries

## Validation
- `pnpm --filter @codori/client test -- project-sidebar-command-palette.test.ts`
- `pnpm --filter @codori/client typecheck`
- `pnpm --filter @codori/client lint`
- `pnpm --filter @codori/client build`
- `pnpm --filter @codori/client typecheck && pnpm test && pnpm typecheck`
- `pnpm lint`

## Notes
- Browser smoke was attempted with the in-app browser, but the browser tool blocked local-page access under its security policy. The attempted Nuxt dev request also hit a local Vite Node IPC error, so live browser verification was not used as evidence.