### PR TITLE
Refine sidebar navigation hierarchy

### DIFF
--- a/packages/client/app/components/ProjectSidebar.vue
+++ b/packages/client/app/components/ProjectSidebar.vue
@@ -61,11 +61,22 @@ type ProjectSidebarNavigationItem =
   | ProjectThreadStatusNavigationItem
 
 type ChatNavigationItem = NavigationMenuItem & {
+  itemKind: 'chat'
   chatId: string
   title: string | null
   createdAt: number
   updatedAt: number | null
 }
+
+type ChatRootNavigationItem = NavigationMenuItem & {
+  itemKind: 'chat-root'
+  chatCount: number
+  children: ChatNavigationItem[]
+}
+
+type ChatSidebarNavigationItem =
+  | ChatRootNavigationItem
+  | ChatNavigationItem
 
 const route = useCodoriRoute()
 const router = useCodoriRouter()
@@ -123,6 +134,24 @@ const activeThreadId = computed(() => {
   const param = route.params.threadId
   return typeof param === 'string' ? param : null
 })
+
+const ACTIVE_NAVIGATION_ITEM_CLASS = 'font-semibold before:bg-primary/5'
+const ACTIVE_NAVIGATION_ITEM_UI = {
+  linkLeadingIcon: 'text-dimmed group-data-[state=open]:text-dimmed'
+}
+
+const navigationItemClass = (active: boolean) =>
+  active ? ACTIVE_NAVIGATION_ITEM_CLASS : undefined
+const navigationItemUi = (active: boolean) =>
+  active ? ACTIVE_NAVIGATION_ITEM_UI : undefined
+
+const isActiveNavigationItem = (item: NavigationMenuItem) => item.active === true
+const navigationTitleClass = (item: NavigationMenuItem) =>
+  isActiveNavigationItem(item) ? 'font-semibold text-highlighted' : 'font-medium text-highlighted'
+const navigationMetaClass = (item: NavigationMenuItem) =>
+  isActiveNavigationItem(item) ? 'font-medium text-muted' : 'text-muted'
+const navigationInlineTitleClass = (item: NavigationMenuItem) =>
+  isActiveNavigationItem(item) ? 'font-semibold text-highlighted' : 'font-medium text-highlighted'
 
 onMounted(() => {
   if (typeof navigator !== 'undefined') {
@@ -262,21 +291,40 @@ const removeChat = async (chatId: string) => {
   }
 }
 
-const chatItems = computed<ChatNavigationItem[][]>(() => [
-  chats.value.map(chat => ({
-    label: formatChatTitle(chat),
-    icon: 'i-lucide-message-square',
-    to: toChatRoute(chat.chatId),
-    active: activeChatId.value === chat.chatId,
+const chatItems = computed<ChatSidebarNavigationItem[][]>(() => {
+  const children = chats.value.map((chat) => {
+    const active = activeChatId.value === chat.chatId
+    return {
+      itemKind: 'chat' as const,
+      label: formatChatTitle(chat),
+      icon: 'i-lucide-message-square',
+      to: toChatRoute(chat.chatId),
+      active,
+      class: navigationItemClass(active),
+      ui: navigationItemUi(active),
+      tooltip: {
+        text: chat.chatId
+      },
+      chatId: chat.chatId,
+      title: chat.title,
+      createdAt: chat.createdAt,
+      updatedAt: chat.updatedAt
+    }
+  })
+
+  return [[{
+    itemKind: 'chat-root',
+    label: 'Projectless Chats',
+    icon: 'i-lucide-messages-square',
+    chatCount: children.length,
+    defaultOpen: activeChatId.value !== null,
+    open: activeChatId.value !== null,
+    children,
     tooltip: {
-      text: chat.chatId
-    },
-    chatId: chat.chatId,
-    title: chat.title,
-    createdAt: chat.createdAt,
-    updatedAt: chat.updatedAt
-  }))
-])
+      text: 'Projectless Chats'
+    }
+  }]]
+})
 
 const inlineThreadsHasOverflow = computed(() =>
   inlineThreadsHasMore.value || inlineThreads.value.length > INLINE_THREAD_ROW_LIMIT
@@ -289,31 +337,35 @@ const visibleInlineThreads = computed(() =>
 )
 
 const projectItems = computed<ProjectSidebarNavigationItem[][]>(() => [
-  sortSidebarProjects(projects.value, activeProjectId.value).flatMap((project) => {
-    const items: ProjectSidebarNavigationItem[] = [{
+  sortSidebarProjects(projects.value, activeProjectId.value).map((project) => {
+    const active = activeProjectId.value === project.projectId
+    const children: ProjectSidebarNavigationItem[] = []
+    const item: ProjectNavigationItem = {
       itemKind: 'project',
       label: project.projectId,
       icon: 'i-lucide-folder-git-2',
       to: toProjectRoute(project.projectId),
-      active: activeProjectId.value === project.projectId && !activeThreadId.value,
+      active,
+      class: navigationItemClass(active),
+      ui: navigationItemUi(active),
       tooltip: {
         text: project.projectId
       },
       projectId: project.projectId,
       projectPath: project.projectPath,
       error: project.error
-    }]
+    }
 
     if (props.collapsed || activeProjectId.value !== project.projectId) {
-      return items
+      return item
     }
 
     if (inlineThreadsProjectId.value !== project.projectId) {
-      return items
+      return item
     }
 
     if (inlineThreadsLoading.value) {
-      items.push({
+      children.push({
         itemKind: 'thread-status',
         label: 'Loading threads...',
         icon: 'i-lucide-loader-circle',
@@ -321,11 +373,14 @@ const projectItems = computed<ProjectSidebarNavigationItem[][]>(() => [
         projectId: project.projectId,
         message: 'Loading threads...'
       })
-      return items
+      item.children = children
+      item.defaultOpen = true
+      item.open = true
+      return item
     }
 
     if (inlineThreadsError.value) {
-      items.push({
+      children.push({
         itemKind: 'thread-status',
         label: 'Threads unavailable',
         icon: 'i-lucide-circle-alert',
@@ -333,16 +388,22 @@ const projectItems = computed<ProjectSidebarNavigationItem[][]>(() => [
         projectId: project.projectId,
         message: inlineThreadsError.value
       })
-      return items
+      item.children = children
+      item.defaultOpen = true
+      item.open = true
+      return item
     }
 
     for (const thread of visibleInlineThreads.value) {
-      items.push({
+      const active = activeThreadId.value === thread.id
+      children.push({
         itemKind: 'thread',
         label: thread.title,
         icon: 'i-lucide-message-square-text',
         to: toProjectThreadRoute(project.projectId, thread.id),
-        active: activeThreadId.value === thread.id,
+        active,
+        class: navigationItemClass(active),
+        ui: navigationItemUi(active),
         tooltip: {
           text: thread.title
         },
@@ -354,7 +415,7 @@ const projectItems = computed<ProjectSidebarNavigationItem[][]>(() => [
     }
 
     if (inlineThreadsHasOverflow.value) {
-      items.push({
+      children.push({
         itemKind: 'more',
         label: 'more..',
         icon: 'i-lucide-ellipsis',
@@ -368,7 +429,13 @@ const projectItems = computed<ProjectSidebarNavigationItem[][]>(() => [
       })
     }
 
-    return items
+    if (children.length) {
+      item.children = children
+      item.defaultOpen = true
+      item.open = true
+    }
+
+    return item
   })
 ])
 
@@ -377,8 +444,13 @@ const asProjectSidebarItem = (item: NavigationMenuItem) => item as ProjectSideba
 const asProjectThreadItem = (item: NavigationMenuItem) => item as ProjectThreadNavigationItem
 const asProjectThreadMoreItem = (item: NavigationMenuItem) => item as ProjectThreadMoreNavigationItem
 const asProjectThreadStatusItem = (item: NavigationMenuItem) => item as ProjectThreadStatusNavigationItem
+const asChatRootItem = (item: NavigationMenuItem) => item as ChatRootNavigationItem
 const asChatItem = (item: NavigationMenuItem) => item as ChatNavigationItem
 
+const isChatRootItem = (item: NavigationMenuItem): item is ChatRootNavigationItem =>
+  (item as ChatSidebarNavigationItem).itemKind === 'chat-root'
+const isChatItem = (item: NavigationMenuItem): item is ChatNavigationItem =>
+  (item as ChatSidebarNavigationItem).itemKind === 'chat'
 const isProjectItem = (item: NavigationMenuItem): item is ProjectNavigationItem =>
   asProjectSidebarItem(item).itemKind === 'project'
 const isThreadItem = (item: NavigationMenuItem): item is ProjectThreadNavigationItem =>
@@ -392,6 +464,54 @@ const isThreadStatusItem = (item: NavigationMenuItem): item is ProjectThreadStat
 <template>
   <div class="flex min-h-0 flex-1 flex-col gap-3">
     <div class="space-y-2">
+      <UTooltip text="Search Codori">
+        <UButton
+          v-if="props.collapsed"
+          icon="i-lucide-search"
+          color="neutral"
+          variant="outline"
+          size="xs"
+          class="w-full justify-center gap-0.5 px-1"
+          aria-label="Search Codori"
+          @click="emit('openCommandPalette')"
+        >
+          <UKbd
+            :value="isMac ? '⌘' : 'Ctrl'"
+            size="sm"
+          />
+          <UKbd
+            value="K"
+            size="sm"
+          />
+        </UButton>
+        <UButton
+          v-else
+          icon="i-lucide-search"
+          color="neutral"
+          variant="outline"
+          size="xs"
+          class="w-full justify-start"
+          aria-label="Search Codori"
+          @click="emit('openCommandPalette')"
+        >
+          <span class="min-w-0 flex-1 truncate text-left">
+            Search
+          </span>
+          <template #trailing>
+            <span class="flex items-center gap-1">
+              <UKbd
+                :value="isMac ? 'meta' : 'ctrl'"
+                size="sm"
+              />
+              <UKbd
+                value="K"
+                size="sm"
+              />
+            </span>
+          </template>
+        </UButton>
+      </UTooltip>
+
       <UTooltip text="New Chat">
         <UButton
           icon="i-lucide-message-square-plus"
@@ -415,7 +535,7 @@ const isThreadStatusItem = (item: NavigationMenuItem): item is ProjectThreadStat
         highlight
         color="primary"
         variant="link"
-        :popover="false"
+        :popover="props.collapsed"
         :tooltip="props.collapsed"
         class="w-full"
         :ui="{
@@ -425,20 +545,34 @@ const isThreadStatusItem = (item: NavigationMenuItem): item is ProjectThreadStat
           link: props.collapsed
             ? 'w-full justify-center rounded-lg px-2 py-2'
             : 'w-full rounded-lg px-3 py-2 text-sm',
-          linkLeadingIcon: props.collapsed ? 'size-4' : 'size-4 text-dimmed',
+          linkLeadingIcon: 'size-4',
           linkLabel: 'min-w-0 flex-1',
           linkTrailing: 'ms-3 shrink-0'
         }"
       >
         <template #item-label="{ item }">
           <div
-            v-if="!props.collapsed"
+            v-if="!props.collapsed && isChatRootItem(item)"
             class="min-w-0"
           >
             <div class="truncate font-medium text-highlighted">
+              {{ asChatRootItem(item).label }}
+            </div>
+          </div>
+          <div
+            v-else-if="!props.collapsed && isChatItem(item)"
+            class="min-w-0"
+          >
+            <div
+              class="truncate"
+              :class="navigationTitleClass(item)"
+            >
               {{ asChatItem(item).title || asChatItem(item).label }}
             </div>
-            <div class="truncate text-[11px] text-muted">
+            <div
+              class="truncate text-[11px]"
+              :class="navigationMetaClass(item)"
+            >
               {{ formatChatDate(asChatItem(item)) }}
             </div>
           </div>
@@ -446,7 +580,13 @@ const isThreadStatusItem = (item: NavigationMenuItem): item is ProjectThreadStat
 
         <template #item-trailing="{ item }">
           <div
-            v-if="!props.collapsed"
+            v-if="!props.collapsed && isChatRootItem(item)"
+            class="rounded-full bg-elevated px-2 py-0.5 text-[11px] font-medium text-muted"
+          >
+            {{ asChatRootItem(item).chatCount }}
+          </div>
+          <div
+            v-else-if="!props.collapsed && isChatItem(item)"
             class="flex items-center"
           >
             <UTooltip text="Delete chat">
@@ -481,65 +621,15 @@ const isThreadStatusItem = (item: NavigationMenuItem): item is ProjectThreadStat
         Projects
       </div>
       <div class="flex items-center gap-1">
-        <UTooltip text="Search Codori">
-          <UButton
-            v-if="props.collapsed"
-            icon="i-lucide-search"
-            color="neutral"
-            variant="ghost"
-            size="xs"
-            square
-            aria-label="Search Codori"
-            @click="emit('openCommandPalette')"
-          />
-          <UButton
-            v-else
-            icon="i-lucide-search"
-            color="neutral"
-            variant="outline"
-            size="xs"
-            class="min-w-32 justify-start"
-            aria-label="Search Codori"
-            @click="emit('openCommandPalette')"
-          >
-            <span class="min-w-0 flex-1 truncate text-left">
-              Search
-            </span>
-            <template #trailing>
-              <span class="flex items-center gap-1">
-                <UKbd
-                  :value="isMac ? 'meta' : 'ctrl'"
-                  size="sm"
-                />
-                <UKbd
-                  value="K"
-                  size="sm"
-                />
-              </span>
-            </template>
-          </UButton>
-        </UTooltip>
         <UTooltip text="Add project">
           <UButton
-            icon="i-lucide-plus"
-            color="neutral"
-            variant="ghost"
+            icon="i-lucide-folder-plus"
+            color="primary"
+            variant="soft"
             size="xs"
             :square="props.collapsed"
             aria-label="Add project"
             @click="addProjectOpen = true"
-          />
-        </UTooltip>
-        <UTooltip text="Refresh projects">
-          <UButton
-            icon="i-lucide-refresh-cw"
-            color="neutral"
-            variant="ghost"
-            size="xs"
-            :loading="loading"
-            :square="props.collapsed"
-            aria-label="Refresh projects"
-            @click="refreshProjects"
           />
         </UTooltip>
       </div>
@@ -571,7 +661,7 @@ const isThreadStatusItem = (item: NavigationMenuItem): item is ProjectThreadStat
           link: props.collapsed
             ? 'w-full justify-center rounded-lg px-2 py-2'
             : 'w-full rounded-lg px-3 py-2.5 text-sm',
-          linkLeadingIcon: props.collapsed ? 'size-4' : 'size-4 text-dimmed',
+          linkLeadingIcon: 'size-4',
           linkLabel: 'min-w-0 flex-1',
           linkTrailing: 'ms-3 shrink-0'
         }"
@@ -581,10 +671,16 @@ const isThreadStatusItem = (item: NavigationMenuItem): item is ProjectThreadStat
             v-if="!props.collapsed && isProjectItem(item)"
             class="min-w-0"
           >
-            <div class="truncate font-medium text-highlighted">
+            <div
+              class="truncate"
+              :class="navigationTitleClass(item)"
+            >
               {{ asProjectItem(item).projectId }}
             </div>
-            <div class="truncate text-[11px] text-muted">
+            <div
+              class="truncate text-[11px]"
+              :class="navigationMetaClass(item)"
+            >
               {{ asProjectItem(item).projectPath }}
             </div>
             <div
@@ -598,7 +694,10 @@ const isThreadStatusItem = (item: NavigationMenuItem): item is ProjectThreadStat
             v-else-if="!props.collapsed && isThreadItem(item)"
             class="min-w-0 ps-2"
           >
-            <div class="truncate text-xs font-medium text-highlighted">
+            <div
+              class="truncate text-xs"
+              :class="navigationInlineTitleClass(item)"
+            >
               {{ asProjectThreadItem(item).title }}
             </div>
           </div>

--- a/packages/client/app/components/ProjectSidebar.vue
+++ b/packages/client/app/components/ProjectSidebar.vue
@@ -21,6 +21,8 @@ import { toChatRoute, toChatsRoute, toProjectRoute, toProjectThreadRoute } from 
 
 const INLINE_THREAD_ROW_LIMIT = 5
 const INLINE_THREAD_ROWS_WITH_MORE = INLINE_THREAD_ROW_LIMIT - 1
+const CHAT_ROOT_NAVIGATION_VALUE = 'chat-root'
+const projectNavigationValue = (projectId: string) => `project:${projectId}`
 
 const props = defineProps<{
   collapsed?: boolean
@@ -134,6 +136,20 @@ const activeThreadId = computed(() => {
   const param = route.params.threadId
   return typeof param === 'string' ? param : null
 })
+const openChatNavigationValues = ref<string[]>([])
+const openProjectNavigationValues = ref<string[]>([])
+
+watch(activeChatId, (chatId) => {
+  if (chatId && !openChatNavigationValues.value.includes(CHAT_ROOT_NAVIGATION_VALUE)) {
+    openChatNavigationValues.value = [...openChatNavigationValues.value, CHAT_ROOT_NAVIGATION_VALUE]
+  }
+}, { immediate: true })
+
+watch([activeProjectId, activeThreadId], ([projectId]) => {
+  openProjectNavigationValues.value = projectId
+    ? [projectNavigationValue(projectId)]
+    : []
+}, { immediate: true })
 
 const ACTIVE_NAVIGATION_ITEM_CLASS = 'font-semibold before:bg-primary/5'
 const ACTIVE_NAVIGATION_ITEM_UI = {
@@ -296,6 +312,7 @@ const chatItems = computed<ChatSidebarNavigationItem[][]>(() => {
     const active = activeChatId.value === chat.chatId
     return {
       itemKind: 'chat' as const,
+      value: `chat:${chat.chatId}`,
       label: formatChatTitle(chat),
       icon: 'i-lucide-message-square',
       to: toChatRoute(chat.chatId),
@@ -314,11 +331,10 @@ const chatItems = computed<ChatSidebarNavigationItem[][]>(() => {
 
   return [[{
     itemKind: 'chat-root',
+    value: CHAT_ROOT_NAVIGATION_VALUE,
     label: 'Projectless Chats',
     icon: 'i-lucide-messages-square',
     chatCount: children.length,
-    defaultOpen: activeChatId.value !== null,
-    open: activeChatId.value !== null,
     children,
     tooltip: {
       text: 'Projectless Chats'
@@ -342,6 +358,7 @@ const projectItems = computed<ProjectSidebarNavigationItem[][]>(() => [
     const children: ProjectSidebarNavigationItem[] = []
     const item: ProjectNavigationItem = {
       itemKind: 'project',
+      value: projectNavigationValue(project.projectId),
       label: project.projectId,
       icon: 'i-lucide-folder-git-2',
       to: toProjectRoute(project.projectId),
@@ -374,8 +391,6 @@ const projectItems = computed<ProjectSidebarNavigationItem[][]>(() => [
         message: 'Loading threads...'
       })
       item.children = children
-      item.defaultOpen = true
-      item.open = true
       return item
     }
 
@@ -389,8 +404,6 @@ const projectItems = computed<ProjectSidebarNavigationItem[][]>(() => [
         message: inlineThreadsError.value
       })
       item.children = children
-      item.defaultOpen = true
-      item.open = true
       return item
     }
 
@@ -431,8 +444,6 @@ const projectItems = computed<ProjectSidebarNavigationItem[][]>(() => [
 
     if (children.length) {
       item.children = children
-      item.defaultOpen = true
-      item.open = true
     }
 
     return item
@@ -529,6 +540,7 @@ const isThreadStatusItem = (item: NavigationMenuItem): item is ProjectThreadStat
 
       <UNavigationMenu
         v-if="chats.length"
+        v-model="openChatNavigationValues"
         :items="chatItems"
         orientation="vertical"
         :collapsed="props.collapsed"
@@ -581,9 +593,15 @@ const isThreadStatusItem = (item: NavigationMenuItem): item is ProjectThreadStat
         <template #item-trailing="{ item }">
           <div
             v-if="!props.collapsed && isChatRootItem(item)"
-            class="rounded-full bg-elevated px-2 py-0.5 text-[11px] font-medium text-muted"
+            class="flex items-center gap-1 text-muted"
           >
-            {{ asChatRootItem(item).chatCount }}
+            <span class="rounded-full bg-elevated px-2 py-0.5 text-[11px] font-medium">
+              {{ asChatRootItem(item).chatCount }}
+            </span>
+            <UIcon
+              name="i-lucide-chevron-down"
+              class="size-3.5 shrink-0 transition-transform group-data-[state=open]:rotate-180"
+            />
           </div>
           <div
             v-else-if="!props.collapsed && isChatItem(item)"
@@ -645,6 +663,7 @@ const isThreadStatusItem = (item: NavigationMenuItem): item is ProjectThreadStat
 
     <div class="min-h-0 flex-1 overflow-y-auto">
       <UNavigationMenu
+        v-model="openProjectNavigationValues"
         :items="projectItems"
         orientation="vertical"
         :collapsed="props.collapsed"

--- a/packages/client/app/layouts/default.vue
+++ b/packages/client/app/layouts/default.vue
@@ -117,15 +117,15 @@ const sidebarUi = computed(() =>
       </template>
 
       <template #footer>
-        <div class="flex items-center justify-between gap-2">
+        <div class="flex w-full items-center gap-2">
           <span
             v-if="!sidebarCollapsed"
-            class="truncate text-xs text-muted"
+            class="min-w-0 flex-1 truncate text-xs text-muted"
           >
             Dashboard
           </span>
           <UDashboardSidebarCollapse
-            class="relative z-20 -me-4 shrink-0"
+            class="relative z-20 ms-auto shrink-0"
           />
         </div>
       </template>

--- a/packages/client/test/project-sidebar-command-palette.test.ts
+++ b/packages/client/test/project-sidebar-command-palette.test.ts
@@ -130,6 +130,10 @@ const NavigationMenuStub = defineComponent({
     items: {
       type: Array,
       default: () => []
+    },
+    modelValue: {
+      type: [Array, String],
+      default: undefined
     }
   },
   setup(props, { slots }) {
@@ -155,7 +159,10 @@ const NavigationMenuStub = defineComponent({
           })
         })
 
-    return () => h('nav', { class: 'navigation-menu-stub' }, flattenNavigationItems(props.items as unknown[]).map(({ item, depth }) => {
+    return () => h('nav', {
+      class: 'navigation-menu-stub',
+      'data-model-value': JSON.stringify(props.modelValue)
+    }, flattenNavigationItems(props.items as unknown[]).map(({ item, depth }) => {
       const children = [
         h('span', { class: 'navigation-menu-icon' }, String(item.icon ?? '')),
         slots['item-label']?.({ item }) ?? h('span', String(item.label ?? '')),
@@ -170,6 +177,7 @@ const NavigationMenuStub = defineComponent({
         'data-kind': String(item.itemKind ?? ''),
         'data-label': String(item.label ?? ''),
         'data-to': String(item.to ?? ''),
+        'data-value': String(item.value ?? ''),
         'data-depth': String(depth),
         'data-active': item.active ? 'true' : 'false',
         onClick: (event: MouseEvent) => {
@@ -407,6 +415,7 @@ describe('project sidebar command palette trigger', () => {
     const activeChat = wrapper.get('[data-to="/chats/chat-a"]')
     const inactiveChat = wrapper.get('[data-to="/chats/chat-b"]')
     expect(chatRoot.attributes('data-depth')).toBe('0')
+    expect(chatRoot.attributes('data-value')).toBe('chat-root')
     expect(chatRoot.text()).toContain('Projectless Chats')
     expect(chatRoot.text()).toContain('2')
     expect(activeChat.attributes('data-depth')).toBe('1')
@@ -417,6 +426,27 @@ describe('project sidebar command palette trigger', () => {
     expect(inactiveChat.attributes('data-depth')).toBe('1')
     expect(inactiveChat.attributes('data-active')).toBe('false')
     expect(inactiveChat.classes()).not.toContain('before:bg-primary/5')
+    expect(wrapper.get('.navigation-menu-stub').attributes('data-model-value')).toBe('["chat-root"]')
+  })
+
+  it('opens the projectless chat group after an in-app route transition', async () => {
+    mockChats.value = [makeChat({
+      chatId: 'chat-a',
+      title: 'Chat A'
+    })]
+
+    const wrapper = mountSidebar({
+      collapsed: false
+    })
+    await waitForSidebar()
+    expect(wrapper.get('.navigation-menu-stub').attributes('data-model-value')).toBe('[]')
+
+    mockRoute.params = {
+      chatId: 'chat-a'
+    }
+    await waitForSidebar()
+
+    expect(wrapper.get('.navigation-menu-stub').attributes('data-model-value')).toBe('["chat-root"]')
   })
 })
 
@@ -480,6 +510,7 @@ describe('project sidebar inline threads', () => {
     const activeProject = wrapper.get('[data-kind="project"][data-to="/projects/codori"]')
     const inactiveProject = wrapper.get('[data-kind="project"][data-to="/projects/other"]')
     expect(activeProject.attributes('data-depth')).toBe('0')
+    expect(activeProject.attributes('data-value')).toBe('project:codori')
     expect(activeProject.attributes('data-active')).toBe('true')
     expect(activeProject.classes()).toContain('before:bg-primary/5')
     expect(activeProject.classes()).not.toContain('ring-1')
@@ -487,6 +518,7 @@ describe('project sidebar inline threads', () => {
     expect(inactiveProject.attributes('data-depth')).toBe('0')
     expect(inactiveProject.attributes('data-active')).toBe('false')
     expect(inactiveProject.classes()).not.toContain('before:bg-primary/5')
+    expect(wrapper.get('.navigation-menu-stub').attributes('data-model-value')).toBe('["project:codori"]')
     expect(mockGetClient).toHaveBeenCalledTimes(1)
     expect(mockGetClient).toHaveBeenCalledWith('codori')
     expect(mockRpcRequest).toHaveBeenCalledWith('thread/list', {
@@ -543,6 +575,24 @@ describe('project sidebar inline threads', () => {
     expect(inactiveThread.attributes('data-depth')).toBe('1')
     expect(inactiveThread.attributes('data-active')).toBe('false')
     expect(inactiveThread.classes()).not.toContain('before:bg-primary/5')
+  })
+
+  it('opens the next active project group after an in-app route transition', async () => {
+    mockRpcRequest.mockResolvedValue(makeThreadListResponse(2))
+
+    const wrapper = mountSidebar({
+      collapsed: false
+    })
+    await waitForSidebar()
+    expect(wrapper.get('.navigation-menu-stub').attributes('data-model-value')).toBe('["project:codori"]')
+
+    mockRoute.params = {
+      projectId: 'other',
+      threadId: 'thread-2'
+    }
+    await waitForSidebar()
+
+    expect(wrapper.get('.navigation-menu-stub').attributes('data-model-value')).toBe('["project:other"]')
   })
 
   it('keeps selected project inline rows synced with shared thread summaries', async () => {

--- a/packages/client/test/project-sidebar-command-palette.test.ts
+++ b/packages/client/test/project-sidebar-command-palette.test.ts
@@ -9,7 +9,7 @@ import {
   resolveProjectThreadSummaryKey,
   useThreadSummaries
 } from '../app/composables/useThreadSummaries'
-import type { ProjectRecord } from '../shared/codori'
+import type { ChatSessionRecord, ProjectRecord } from '../shared/codori'
 import type { ThreadListResponse } from '../shared/generated/codex-app-server/v2/ThreadListResponse'
 
 const mockRoute = reactive({
@@ -23,7 +23,7 @@ const mockGetClient = vi.fn()
 const mockRpcRequest = vi.fn()
 const mockOpenPanel = vi.fn()
 const mockProjects = ref<ProjectRecord[]>([])
-const mockChats = ref([])
+const mockChats = ref<ChatSessionRecord[]>([])
 const mockProjectsLoaded = ref(true)
 const mockProjectsLoading = ref(false)
 
@@ -93,6 +93,9 @@ const ButtonStub = defineComponent({
     return () => h('button', {
       type: 'button',
       'aria-label': ariaLabel(),
+      'data-icon': String(attrs.icon ?? ''),
+      'data-color': String(attrs.color ?? ''),
+      'data-variant': String(attrs.variant ?? ''),
       onClick: (event: MouseEvent) => emit('click', event)
     }, [
       slots.default?.() ?? props.label,
@@ -130,21 +133,44 @@ const NavigationMenuStub = defineComponent({
     }
   },
   setup(props, { slots }) {
-    const flattenItems = () => (props.items as unknown[])
-      .flatMap(group => Array.isArray(group) ? group : [group])
-      .filter(Boolean) as Array<Record<string, unknown>>
+    const flattenNavigationItems = (
+      items: unknown[],
+      depth = 0
+    ): Array<{ item: Record<string, unknown>, depth: number }> =>
+      items
+        .flatMap((entry) => {
+          const groupItems = Array.isArray(entry) ? entry : [entry]
+          return groupItems.flatMap((item) => {
+            if (!item || typeof item !== 'object') {
+              return []
+            }
+            const navigationItem = item as Record<string, unknown>
+            const children = Array.isArray(navigationItem.children)
+              ? flattenNavigationItems(navigationItem.children, depth + 1)
+              : []
+            return [{
+              item: navigationItem,
+              depth
+            }, ...children]
+          })
+        })
 
-    return () => h('nav', { class: 'navigation-menu-stub' }, flattenItems().map((item) => {
+    return () => h('nav', { class: 'navigation-menu-stub' }, flattenNavigationItems(props.items as unknown[]).map(({ item, depth }) => {
       const children = [
         h('span', { class: 'navigation-menu-icon' }, String(item.icon ?? '')),
         slots['item-label']?.({ item }) ?? h('span', String(item.label ?? '')),
         slots['item-trailing']?.({ item })
       ]
       const baseAttrs = {
-        class: ['navigation-menu-item', item.itemKind ? `navigation-menu-item-${String(item.itemKind)}` : ''],
+        class: [
+          'navigation-menu-item',
+          item.itemKind ? `navigation-menu-item-${String(item.itemKind)}` : '',
+          item.class
+        ],
         'data-kind': String(item.itemKind ?? ''),
         'data-label': String(item.label ?? ''),
         'data-to': String(item.to ?? ''),
+        'data-depth': String(depth),
         'data-active': item.active ? 'true' : 'false',
         onClick: (event: MouseEvent) => {
           const onSelect = item.onSelect
@@ -188,6 +214,28 @@ const makeThread = (index: number) => ({
   preview: null,
   updatedAt: 1_000 - index
 })
+
+const makeChat = (input: Partial<ChatSessionRecord> & Pick<ChatSessionRecord, 'chatId'>): ChatSessionRecord => {
+  const { chatId, ...rest } = input
+  return {
+    chatId,
+    chatPath: `/chats/${chatId}`,
+    threadId: null,
+    title: null,
+    createdAt: 1,
+    updatedAt: null,
+    status: 'running',
+    pid: 101,
+    port: 46000,
+    startedAt: 1,
+    lastActivityAt: 1,
+    activeSessionCount: 0,
+    idleTimeoutMs: null,
+    idleDeadlineAt: null,
+    error: null,
+    ...rest
+  }
+}
 
 const makeThreadListResponse = (
   count: number,
@@ -287,7 +335,7 @@ describe('project sidebar command palette trigger', () => {
     platformSpy.mockRestore()
   })
 
-  it('renders an input-like expanded search trigger before project action buttons', async () => {
+  it('renders search first and keeps add project in the projects section', async () => {
     const wrapper = mountSidebar({
       collapsed: false
     })
@@ -297,8 +345,14 @@ describe('project sidebar command palette trigger', () => {
     expect(wrapper.text()).toContain('K')
 
     const actionLabels = wrapper.findAll('button').map(button => button.attributes('aria-label') ?? button.text())
-    expect(actionLabels.indexOf('Search Codori')).toBeLessThan(actionLabels.indexOf('Add project'))
-    expect(actionLabels.indexOf('Add project')).toBeLessThan(actionLabels.indexOf('Refresh projects'))
+    expect(actionLabels.indexOf('Search Codori')).toBeLessThan(actionLabels.indexOf('New Chat'))
+    expect(actionLabels.indexOf('New Chat')).toBeLessThan(actionLabels.indexOf('Add project'))
+    expect(actionLabels).not.toContain('Refresh projects')
+
+    const addProject = wrapper.get('button[aria-label="Add project"]')
+    expect(addProject.attributes('data-icon')).toBe('i-lucide-folder-plus')
+    expect(addProject.attributes('data-color')).toBe('primary')
+    expect(addProject.attributes('data-variant')).toBe('soft')
 
     await wrapper.get('button[aria-label="Search Codori"]').trigger('click')
 
@@ -321,10 +375,48 @@ describe('project sidebar command palette trigger', () => {
     })
 
     expect(wrapper.text()).not.toContain('Search')
+    expect(wrapper.text()).toContain('⌘')
+    expect(wrapper.text()).toContain('K')
 
     await wrapper.get('button[aria-label="Search Codori"]').trigger('click')
 
     expect(wrapper.emitted('openCommandPalette')).toHaveLength(1)
+  })
+
+  it('emphasizes the active chat row', async () => {
+    mockRoute.params = {
+      chatId: 'chat-a'
+    }
+    mockChats.value = [
+      makeChat({
+        chatId: 'chat-a',
+        title: 'Chat A'
+      }),
+      makeChat({
+        chatId: 'chat-b',
+        title: 'Chat B'
+      })
+    ]
+
+    const wrapper = mountSidebar({
+      collapsed: false
+    })
+    await waitForSidebar()
+
+    const chatRoot = wrapper.get('[data-kind="chat-root"]')
+    const activeChat = wrapper.get('[data-to="/chats/chat-a"]')
+    const inactiveChat = wrapper.get('[data-to="/chats/chat-b"]')
+    expect(chatRoot.attributes('data-depth')).toBe('0')
+    expect(chatRoot.text()).toContain('Projectless Chats')
+    expect(chatRoot.text()).toContain('2')
+    expect(activeChat.attributes('data-depth')).toBe('1')
+    expect(activeChat.attributes('data-active')).toBe('true')
+    expect(activeChat.classes()).toContain('before:bg-primary/5')
+    expect(activeChat.classes()).not.toContain('ring-1')
+    expect(activeChat.classes()).not.toContain('shadow-sm')
+    expect(inactiveChat.attributes('data-depth')).toBe('1')
+    expect(inactiveChat.attributes('data-active')).toBe('false')
+    expect(inactiveChat.classes()).not.toContain('before:bg-primary/5')
   })
 })
 
@@ -382,7 +474,19 @@ describe('project sidebar inline threads', () => {
 
     const threadLink = wrapper.get('[data-kind="thread"][data-to="/projects/codori/threads/thread-1"]')
     expect(threadLink.text()).toContain('Thread 1')
+    expect(threadLink.attributes('data-depth')).toBe('1')
     expect(wrapper.find('[data-kind="thread"][data-to="/projects/other/threads/thread-1"]').exists()).toBe(false)
+
+    const activeProject = wrapper.get('[data-kind="project"][data-to="/projects/codori"]')
+    const inactiveProject = wrapper.get('[data-kind="project"][data-to="/projects/other"]')
+    expect(activeProject.attributes('data-depth')).toBe('0')
+    expect(activeProject.attributes('data-active')).toBe('true')
+    expect(activeProject.classes()).toContain('before:bg-primary/5')
+    expect(activeProject.classes()).not.toContain('ring-1')
+    expect(activeProject.classes()).not.toContain('shadow-sm')
+    expect(inactiveProject.attributes('data-depth')).toBe('0')
+    expect(inactiveProject.attributes('data-active')).toBe('false')
+    expect(inactiveProject.classes()).not.toContain('before:bg-primary/5')
     expect(mockGetClient).toHaveBeenCalledTimes(1)
     expect(mockGetClient).toHaveBeenCalledWith('codori')
     expect(mockRpcRequest).toHaveBeenCalledWith('thread/list', {
@@ -410,6 +514,35 @@ describe('project sidebar inline threads', () => {
     await wrapper.get('[data-kind="more"]').trigger('click')
 
     expect(mockOpenPanel).toHaveBeenCalledTimes(1)
+  })
+
+  it('emphasizes the active inline thread row', async () => {
+    mockRoute.params = {
+      projectId: 'codori',
+      threadId: 'thread-1'
+    }
+    mockRpcRequest.mockResolvedValue(makeThreadListResponse(2))
+
+    const wrapper = mountSidebar({
+      collapsed: false
+    })
+    await waitForSidebar()
+
+    const activeProject = wrapper.get('[data-kind="project"][data-to="/projects/codori"]')
+    const activeThread = wrapper.get('[data-kind="thread"][data-to="/projects/codori/threads/thread-1"]')
+    const inactiveThread = wrapper.get('[data-kind="thread"][data-to="/projects/codori/threads/thread-2"]')
+    expect(activeProject.attributes('data-active')).toBe('true')
+    expect(activeProject.classes()).toContain('before:bg-primary/5')
+    expect(activeProject.classes()).not.toContain('ring-1')
+    expect(activeProject.classes()).not.toContain('shadow-sm')
+    expect(activeThread.attributes('data-depth')).toBe('1')
+    expect(activeThread.attributes('data-active')).toBe('true')
+    expect(activeThread.classes()).toContain('before:bg-primary/5')
+    expect(activeThread.classes()).not.toContain('ring-1')
+    expect(activeThread.classes()).not.toContain('shadow-sm')
+    expect(inactiveThread.attributes('data-depth')).toBe('1')
+    expect(inactiveThread.attributes('data-active')).toBe('false')
+    expect(inactiveThread.classes()).not.toContain('before:bg-primary/5')
   })
 
   it('keeps selected project inline rows synced with shared thread summaries', async () => {


### PR DESCRIPTION
## Summary

- group projectless chats under a compact expandable navigation parent
- nest recent project threads beneath the active project and strengthen active-row emphasis
- move search and project actions into clearer locations while keeping the collapsed sidebar compact
- keep the active project or projectless-chat group expanded across client-side route transitions
- expand sidebar component coverage for hierarchy, active state, route transitions, and action styling

## Why

This is a focused follow-up to the merged recent-project-threads work. It makes the sidebar hierarchy easier to scan and uses space more effectively in both expanded and collapsed layouts. Controlling the expanded navigation values also prevents the active group from collapsing when navigating between projects or chats without a full page reload.

## Validation

- `pnpm typecheck`
- `pnpm test` (client: 271 tests, server: 88 tests)
- `pnpm lint`
- `pnpm build`
- `git diff --check`
- browser QA for project-to-project and projectless-chat SPA transitions, with no console warnings or errors