### PR TITLE
feat: add read-only workspace file explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,9 @@ The client dashboard provides:
 - a main chat workspace
 - a new thread action
 - a previous threads panel for resume
+- a read-only workspace file explorer for projects and projectless chats
+
+The file explorer loads one directory at a time, hides common generated folders by default, and opens supported text and image files in the existing preview. All browser requests use workspace-relative paths; the server canonicalizes each target and rejects traversal and symlink escapes outside the active workspace root.
 
 When you open a stopped project and start chatting, Codori ensures the shared app-server is running and then connects the UI through the Codori WebSocket proxy.
 
@@ -303,6 +306,7 @@ When you open a stopped project and start chatting, Codori ensures the shared ap
 - Allocates a free TCP port from a configured safe range.
 - Stores runtime metadata under `~/.codori/run/`.
 - Provides a Nuxt UI dashboard for project selection, chat, and thread resume.
+- Provides bounded, read-only workspace file navigation and local file preview.
 - Proxies browser WebSocket traffic for each project or chat workspace to the shared app-server.
 - Serves the built dashboard bundle from the same origin as the management API.
 
@@ -316,6 +320,7 @@ Codori v1 does not provide:
 - SSO
 - multi-root project indexing
 - a separate Codori-owned thread database
+- file create, edit, rename, move, or delete operations
 
 If you want to access Codori from another machine, you must provide your own private network path with something like Tailscale or Cloudflare Tunnel.
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -274,6 +274,18 @@ Returns:
 - same runtime envelope used by list/detail responses
 - includes workspace-specific `startedAt`, `lastActivityAt`, `activeSessionCount`, and `idleDeadlineAt` when that workspace is active
 
+### `GET /api/projects/:projectId/files` and `GET /api/chats/:chatId/files`
+
+Behavior:
+
+- Accept a normalized workspace-root-relative `path`; an empty path selects the workspace root.
+- Return direct children only, with directories before files, stable name ordering, metadata, symlink/accessibility state, and explicit truncation metadata.
+- Canonicalize the workspace and target on every request, rejecting absolute paths, traversal, missing directories, and symlink escapes.
+- Enforce a fixed entry bound and load nested directories only when the client expands them.
+- Hide common heavy generated folders such as `.git`, `node_modules`, `.nuxt`, `.output`, `dist`, `build`, and `coverage` unless `showIgnored=true`; useful dotfiles remain available.
+
+The matching `/local-file` project/chat routes accept both existing absolute transcript-link paths and workspace-relative explorer paths. Both forms are canonicalized against the active workspace before preview.
+
 ### `WS /api/projects/:projectId/rpc`
 
 Behavior:
@@ -302,12 +314,15 @@ Layout:
 - Use Nuxt UI dashboard primitives as the main shell.
 - Left sidebar shows projects, recent project threads for the selected project, and projectless chats.
 - Main panel shows the selected project chat screen.
+- The composer toolbar includes a workspace-files trigger for active project and projectless-chat workspaces.
 - Top navbar includes:
   - `New thread`
   - `Previous threads`
 - Previous threads open in:
   - right-side panel on desktop
   - drawer/slideover on smaller screens
+- Workspace files open in a responsive Nuxt UI slideover with an accessible lazy tree, breadcrumbs, manual refresh, relative-path copy, and a generated-folder toggle.
+- Selecting a supported file reuses the existing fullscreen local-file viewer; the explorer never exposes create, edit, rename, move, or delete actions.
 
 Required states:
 
@@ -320,6 +335,7 @@ Required states:
 - thread empty state
 - chat streaming
 - chat failure
+- workspace directory loading, empty, permission/error, inaccessible symlink, disappeared entry, and truncated states
 
 Required messaging:
 

--- a/packages/client/app/components/ChatSessionShell.vue
+++ b/packages/client/app/components/ChatSessionShell.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useRouter } from '#imports'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import WorkspaceFilesPanel from './WorkspaceFilesPanel.vue'
 import { useChats } from '../composables/useChats'
 import { useChatSession } from '../composables/useChatSession'
 import { useVisualSubagentPanels } from '../composables/useVisualSubagentPanels'
@@ -234,35 +235,42 @@ watch(
             </div>
           </template>
           <template #right>
-            <UTooltip
-              v-if="hasAvailableSubagents"
-              text="Subagents"
-            >
-              <UButton
-                :color="isSubagentsSurfaceOpen ? 'primary' : 'neutral'"
-                :variant="isSubagentsSurfaceOpen ? 'soft' : 'ghost'"
-                icon="i-lucide-bot"
-                size="sm"
-                class="px-2 xl:ps-2 xl:pe-2.5"
-                :aria-label="subagentsToggleLabel"
-                @click="toggleSubagentsPanel"
+            <div class="flex items-center gap-1.5 lg:gap-2">
+              <WorkspaceFilesPanel
+                v-if="chatId"
+                :workspace="{ kind: 'chat', id: chatId }"
+                :workspace-label="chatTitle"
+              />
+              <UTooltip
+                v-if="hasAvailableSubagents"
+                text="Subagents"
               >
-                <UAvatarGroup
-                  class="hidden xl:flex"
-                  size="xs"
-                  :max="4"
-                  :ui="{ base: 'ring-2 -me-2 first:me-0' }"
+                <UButton
+                  :color="isSubagentsSurfaceOpen ? 'primary' : 'neutral'"
+                  :variant="isSubagentsSurfaceOpen ? 'soft' : 'ghost'"
+                  icon="i-lucide-bot"
+                  size="sm"
+                  class="px-2 xl:ps-2 xl:pe-2.5"
+                  :aria-label="subagentsToggleLabel"
+                  @click="toggleSubagentsPanel"
                 >
-                  <UAvatar
-                    v-for="agent in subagentAvatarItems"
-                    :key="agent.threadId"
-                    :text="agent.text"
-                    :alt="agent.name"
-                    :class="agent.class"
-                  />
-                </UAvatarGroup>
-              </UButton>
-            </UTooltip>
+                  <UAvatarGroup
+                    class="hidden xl:flex"
+                    size="xs"
+                    :max="4"
+                    :ui="{ base: 'ring-2 -me-2 first:me-0' }"
+                  >
+                    <UAvatar
+                      v-for="agent in subagentAvatarItems"
+                      :key="agent.threadId"
+                      :text="agent.text"
+                      :alt="agent.name"
+                      :class="agent.class"
+                    />
+                  </UAvatarGroup>
+                </UButton>
+              </UTooltip>
+            </div>
           </template>
         </UDashboardNavbar>
       </template>

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -17,7 +17,6 @@ import ReviewStartDrawer from './ReviewStartDrawer.vue'
 import PendingUserRequestDrawer from './PendingUserRequestDrawer.vue'
 import UsageStatusModal from './UsageStatusModal.vue'
 import WorkspaceBranchControl from './WorkspaceBranchControl.vue'
-import WorkspaceFilesPanel from './WorkspaceFilesPanel.vue'
 import WorkspaceTerminalSurface from './WorkspaceTerminalSurface.vue'
 import {
   reconcileOptimisticUserMessage,
@@ -5258,12 +5257,6 @@ watch(
                     :ui="{ leadingIcon: 'size-4', base: 'px-0' }"
                     aria-label="Attach image"
                     @click="openFilePicker"
-                  />
-
-                  <WorkspaceFilesPanel
-                    v-if="workspaceId"
-                    :workspace="workspaceScope"
-                    :workspace-label="projectTitle"
                   />
 
                   <UPopover

--- a/packages/client/app/components/ChatWorkspace.vue
+++ b/packages/client/app/components/ChatWorkspace.vue
@@ -17,6 +17,7 @@ import ReviewStartDrawer from './ReviewStartDrawer.vue'
 import PendingUserRequestDrawer from './PendingUserRequestDrawer.vue'
 import UsageStatusModal from './UsageStatusModal.vue'
 import WorkspaceBranchControl from './WorkspaceBranchControl.vue'
+import WorkspaceFilesPanel from './WorkspaceFilesPanel.vue'
 import WorkspaceTerminalSurface from './WorkspaceTerminalSurface.vue'
 import {
   reconcileOptimisticUserMessage,
@@ -5257,6 +5258,12 @@ watch(
                     :ui="{ leadingIcon: 'size-4', base: 'px-0' }"
                     aria-label="Attach image"
                     @click="openFilePicker"
+                  />
+
+                  <WorkspaceFilesPanel
+                    v-if="workspaceId"
+                    :workspace="workspaceScope"
+                    :workspace-label="projectTitle"
                   />
 
                   <UPopover

--- a/packages/client/app/components/LocalFilePreview.vue
+++ b/packages/client/app/components/LocalFilePreview.vue
@@ -1,0 +1,333 @@
+<script setup lang="ts">
+import { Comark } from '@comark/vue'
+import highlight from '@comark/vue/plugins/highlight'
+import { computed, nextTick, ref, watch } from 'vue'
+import { useRuntimeConfig } from '#imports'
+import {
+  formatLocalFileSize,
+  resolveProjectLocalFileUrl,
+  type ProjectLocalFileResponse,
+  type WorkspaceLocalFileScope
+} from '../../shared/local-files'
+import {
+  buildHighlightedFileMarkdown,
+  inferLocalFileLanguage,
+  resolveLocalFileLanguageLabel
+} from '../../shared/file-highlighting'
+
+const props = withDefaults(defineProps<{
+  workspace: WorkspaceLocalFileScope
+  path: string
+  line?: number | null
+  eyebrow?: string
+}>(), {
+  line: null,
+  eyebrow: 'Local file viewer'
+})
+
+const runtimeConfig = useRuntimeConfig()
+const loading = ref(false)
+const error = ref<string | null>(null)
+const file = ref<ProjectLocalFileResponse['file'] | null>(null)
+const lineContainer = ref<HTMLElement | null>(null)
+const viewerPlugins = [
+  highlight({ preStyles: false })
+]
+
+const relativePathLabel = computed(() =>
+  file.value?.relativePath || file.value?.name || props.path
+)
+
+const textFile = computed(() =>
+  file.value?.kind === 'text' ? file.value : null
+)
+
+const imageFile = computed(() =>
+  file.value?.kind === 'image' ? file.value : null
+)
+
+const lineCount = computed(() => {
+  if (!textFile.value) {
+    return 0
+  }
+
+  return textFile.value.text.split('\n').length
+})
+
+const inferredLanguage = computed(() =>
+  textFile.value ? inferLocalFileLanguage(textFile.value.path, textFile.value.text) : null
+)
+
+const languageLabel = computed(() =>
+  resolveLocalFileLanguageLabel(inferredLanguage.value)
+)
+
+const mediaTypeLabel = computed(() =>
+  imageFile.value?.mediaType ?? null
+)
+
+const imagePreviewSrc = computed(() =>
+  imageFile.value
+    ? `data:${imageFile.value.mediaType};base64,${imageFile.value.base64}`
+    : ''
+)
+
+const highlightedMarkdown = computed(() => {
+  if (!textFile.value) {
+    return ''
+  }
+
+  return buildHighlightedFileMarkdown(textFile.value.text, inferredLanguage.value)
+})
+
+const lineNumberWidth = computed(() =>
+  `${Math.max(3, String(lineCount.value || 1).length + 1)}ch`
+)
+
+const updatedAtLabel = computed(() => {
+  if (!file.value) {
+    return null
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  }).format(new Date(file.value.updatedAt))
+})
+
+const isCurrentPreview = (workspace: WorkspaceLocalFileScope, path: string) =>
+  props.workspace.kind === workspace.kind
+  && props.workspace.id === workspace.id
+  && props.path === path
+
+const syncRenderedCodeLines = async () => {
+  if (!textFile.value) {
+    return
+  }
+
+  await nextTick()
+  requestAnimationFrame(() => {
+    if (!lineContainer.value || !textFile.value) {
+      return
+    }
+
+    const renderedLines = Array.from(lineContainer.value.querySelectorAll<HTMLElement>('.line'))
+    for (const [index, renderedLine] of renderedLines.entries()) {
+      const lineNumber = index + 1
+      renderedLine.dataset.fileLine = String(lineNumber)
+      renderedLine.classList.toggle('is-target-line', props.line === lineNumber)
+    }
+
+    const targetLine = props.line
+    if (!targetLine) {
+      return
+    }
+
+    const target = lineContainer.value?.querySelector<HTMLElement>(`[data-file-line="${targetLine}"]`)
+    target?.scrollIntoView({
+      block: 'center'
+    })
+  })
+}
+
+watch(
+  () => [props.workspace.kind, props.workspace.id, props.path] as const,
+  async ([kind, id, path]) => {
+    const workspace: WorkspaceLocalFileScope = { kind, id }
+    loading.value = true
+    error.value = null
+    file.value = null
+
+    try {
+      const response = await $fetch<ProjectLocalFileResponse>(resolveProjectLocalFileUrl({
+        workspace,
+        path,
+        configuredBase: String(runtimeConfig.public.serverBase ?? '')
+      }))
+      if (!isCurrentPreview(workspace, path)) {
+        return
+      }
+
+      file.value = response.file
+      await syncRenderedCodeLines()
+    } catch (caughtError) {
+      if (!isCurrentPreview(workspace, path)) {
+        return
+      }
+
+      error.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
+    } finally {
+      if (isCurrentPreview(workspace, path)) {
+        loading.value = false
+      }
+    }
+  },
+  { immediate: true }
+)
+
+watch(() => props.line, () => {
+  if (textFile.value) {
+    void syncRenderedCodeLines()
+  }
+})
+
+watch(highlightedMarkdown, () => {
+  if (textFile.value) {
+    void syncRenderedCodeLines()
+  }
+}, { flush: 'post' })
+</script>
+
+<template>
+  <section class="flex h-full min-h-0 flex-col bg-default">
+    <header class="flex items-center justify-between gap-3 border-b border-default px-4 py-3">
+      <div class="min-w-0 text-left">
+        <div class="truncate text-xs font-medium text-primary">
+          {{ eyebrow }}
+        </div>
+        <div class="truncate text-sm font-semibold text-highlighted">
+          {{ relativePathLabel }}
+        </div>
+        <div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted">
+          <span v-if="file">{{ formatLocalFileSize(file.size) }}</span>
+          <span v-if="textFile">{{ lineCount }} lines</span>
+          <span v-if="updatedAtLabel">{{ updatedAtLabel }}</span>
+          <span v-if="mediaTypeLabel">{{ mediaTypeLabel }}</span>
+          <span v-if="languageLabel">{{ languageLabel }}</span>
+          <span v-if="textFile && line">Line {{ line }}</span>
+        </div>
+      </div>
+
+      <div
+        v-if="$slots.actions"
+        class="shrink-0"
+      >
+        <slot name="actions" />
+      </div>
+    </header>
+
+    <div
+      v-if="loading"
+      class="flex min-h-0 flex-1 items-center justify-center px-6 py-10 text-sm text-muted"
+    >
+      Loading local file preview...
+    </div>
+
+    <div
+      v-else-if="error"
+      class="flex min-h-0 flex-1 items-center justify-center px-6 py-10"
+    >
+      <UAlert
+        color="error"
+        variant="soft"
+        icon="i-lucide-circle-alert"
+        :title="error"
+        class="w-full max-w-2xl"
+      />
+    </div>
+
+    <div
+      v-else-if="imageFile"
+      class="local-file-viewer-image min-h-0 flex-1 overflow-auto bg-elevated/15"
+    >
+      <div class="flex min-h-full items-center justify-center p-6">
+        <img
+          class="max-h-full max-w-full object-contain"
+          :src="imagePreviewSrc"
+          :alt="imageFile.name"
+        >
+      </div>
+    </div>
+
+    <div
+      v-else-if="textFile"
+      ref="lineContainer"
+      class="local-file-viewer-code min-h-0 flex-1 overflow-auto bg-elevated/15"
+      :style="{ '--lfv-line-number-width': lineNumberWidth }"
+    >
+      <Suspense>
+        <Comark
+          class="local-file-viewer-markdown"
+          :markdown="highlightedMarkdown"
+          :plugins="viewerPlugins"
+        />
+      </Suspense>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.local-file-viewer-code :deep(.local-file-viewer-markdown) {
+  min-width: max-content;
+}
+
+.local-file-viewer-code :deep(.local-file-viewer-markdown > * + *) {
+  margin-top: 0;
+}
+
+.local-file-viewer-code :deep(pre),
+.local-file-viewer-code :deep(.shiki) {
+  margin: 0;
+  min-width: max-content;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+  background: transparent !important;
+}
+
+.local-file-viewer-code :deep(pre code),
+.local-file-viewer-code :deep(.shiki code) {
+  display: block;
+  min-width: max-content;
+  padding: 0;
+}
+
+.local-file-viewer-code :deep(.line) {
+  display: block;
+  min-width: max-content;
+  padding: 0 1.5rem 0 0;
+  padding-left: calc(var(--lfv-line-number-width) + 1.5rem);
+  position: relative;
+  white-space: pre;
+}
+
+.local-file-viewer-code :deep(.line::before) {
+  content: attr(data-file-line);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: var(--lfv-line-number-width);
+  padding-right: 0.75rem;
+  text-align: right;
+  color: var(--ui-text-muted);
+  user-select: none;
+  font-variant-numeric: tabular-nums;
+}
+
+.local-file-viewer-code :deep(.line.is-target-line) {
+  background: color-mix(in srgb, var(--ui-primary) 10%, transparent);
+}
+
+.local-file-viewer-code :deep(.line.is-target-line::before) {
+  color: var(--ui-primary);
+}
+
+.local-file-viewer-code :deep(.shiki),
+.local-file-viewer-code :deep(.shiki code),
+.local-file-viewer-code :deep(pre),
+.local-file-viewer-code :deep(pre code) {
+  font-size: 13px;
+  line-height: 1.75;
+}
+
+:global(.dark) .local-file-viewer-code :deep(.shiki),
+:global(.dark) .local-file-viewer-code :deep(.shiki span) {
+  color: var(--shiki-dark) !important;
+  background-color: var(--shiki-dark-bg) !important;
+  font-style: var(--shiki-dark-font-style) !important;
+  font-weight: var(--shiki-dark-font-weight) !important;
+  text-decoration: var(--shiki-dark-text-decoration) !important;
+}
+</style>

--- a/packages/client/app/components/LocalFileViewerModal.vue
+++ b/packages/client/app/components/LocalFileViewerModal.vue
@@ -1,27 +1,9 @@
 <script setup lang="ts">
-import { Comark } from '@comark/vue'
-import highlight from '@comark/vue/plugins/highlight'
-import { computed, nextTick, ref, watch } from 'vue'
-import { useRuntimeConfig } from '#imports'
+import { computed } from 'vue'
 import { useLocalFileViewer } from '../composables/useLocalFileViewer'
-import { formatLocalFileSize, resolveProjectLocalFileUrl, type ProjectLocalFileResponse } from '../../shared/local-files'
-import {
-  buildHighlightedFileMarkdown,
-  inferLocalFileLanguage,
-  resolveLocalFileLanguageLabel
-} from '../../shared/file-highlighting'
-import type { WorkspaceLocalFileScope } from '../../shared/local-files'
+import LocalFilePreview from './LocalFilePreview.vue'
 
-const runtimeConfig = useRuntimeConfig()
 const { state, closeViewer } = useLocalFileViewer()
-
-const loading = ref(false)
-const error = ref<string | null>(null)
-const file = ref<ProjectLocalFileResponse['file'] | null>(null)
-const lineContainer = ref<HTMLElement | null>(null)
-const viewerPlugins = [
-  highlight({ preStyles: false })
-]
 
 const isOpen = computed({
   get: () => state.value.open,
@@ -31,160 +13,6 @@ const isOpen = computed({
     }
   }
 })
-
-const relativePathLabel = computed(() => {
-  if (!file.value) {
-    return state.value.path ?? ''
-  }
-
-  return file.value.relativePath || file.value.name
-})
-
-const textFile = computed(() =>
-  file.value?.kind === 'text' ? file.value : null
-)
-
-const imageFile = computed(() =>
-  file.value?.kind === 'image' ? file.value : null
-)
-
-const lineCount = computed(() => {
-  if (!textFile.value) {
-    return 0
-  }
-
-  return textFile.value.text.split('\n').length
-})
-
-const inferredLanguage = computed(() =>
-  textFile.value ? inferLocalFileLanguage(textFile.value.path, textFile.value.text) : null
-)
-
-const languageLabel = computed(() =>
-  resolveLocalFileLanguageLabel(inferredLanguage.value)
-)
-
-const mediaTypeLabel = computed(() =>
-  imageFile.value?.mediaType ?? null
-)
-
-const imagePreviewSrc = computed(() =>
-  imageFile.value
-    ? `data:${imageFile.value.mediaType};base64,${imageFile.value.base64}`
-    : ''
-)
-
-const highlightedMarkdown = computed(() => {
-  if (!textFile.value) {
-    return ''
-  }
-
-  return buildHighlightedFileMarkdown(textFile.value.text, inferredLanguage.value)
-})
-
-const lineNumberWidth = computed(() =>
-  `${Math.max(3, String(lineCount.value || 1).length + 1)}ch`
-)
-
-const updatedAtLabel = computed(() => {
-  if (!file.value) {
-    return null
-  }
-
-  return new Intl.DateTimeFormat(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit'
-  }).format(new Date(file.value.updatedAt))
-})
-
-const isSameWorkspace = (left: WorkspaceLocalFileScope | null, right: WorkspaceLocalFileScope | null) =>
-  left?.kind === right?.kind && left?.id === right?.id
-
-const syncRenderedCodeLines = async () => {
-  if (!textFile.value) {
-    return
-  }
-
-  await nextTick()
-  requestAnimationFrame(() => {
-    if (!lineContainer.value || !textFile.value) {
-      return
-    }
-
-    const renderedLines = Array.from(lineContainer.value.querySelectorAll<HTMLElement>('.line'))
-    for (const [index, line] of renderedLines.entries()) {
-      const lineNumber = index + 1
-      line.dataset.fileLine = String(lineNumber)
-      line.classList.toggle('is-target-line', state.value.line === lineNumber)
-    }
-
-    const targetLine = state.value.line
-    if (!targetLine) {
-      return
-    }
-
-    const target = lineContainer.value?.querySelector<HTMLElement>(`[data-file-line="${targetLine}"]`)
-    target?.scrollIntoView({
-      block: 'center'
-    })
-  })
-}
-
-watch(
-  () => [state.value.open, state.value.workspace?.kind, state.value.workspace?.id, state.value.path] as const,
-  async ([open, , , path]) => {
-    const workspace = state.value.workspace ? { ...state.value.workspace } : null
-    if (!open || !workspace || !path) {
-      loading.value = false
-      error.value = null
-      file.value = null
-      return
-    }
-
-    loading.value = true
-    error.value = null
-    file.value = null
-
-    try {
-      const response = await $fetch<ProjectLocalFileResponse>(resolveProjectLocalFileUrl({
-        workspace,
-        path,
-        configuredBase: String(runtimeConfig.public.serverBase ?? '')
-      }))
-      if (!state.value.open || !isSameWorkspace(state.value.workspace, workspace) || state.value.path !== path) {
-        return
-      }
-
-      file.value = response.file
-      await syncRenderedCodeLines()
-    } catch (caughtError) {
-      if (!state.value.open || !isSameWorkspace(state.value.workspace, workspace) || state.value.path !== path) {
-        return
-      }
-
-      error.value = caughtError instanceof Error ? caughtError.message : String(caughtError)
-    } finally {
-      if (state.value.open && isSameWorkspace(state.value.workspace, workspace) && state.value.path === path) {
-        loading.value = false
-      }
-    }
-  },
-  { immediate: true }
-)
-
-watch(() => state.value.line, () => {
-  if (textFile.value) {
-    void syncRenderedCodeLines()
-  }
-})
-
-watch(highlightedMarkdown, () => {
-  if (textFile.value) {
-    void syncRenderedCodeLines()
-  }
-}, { flush: 'post' })
 </script>
 
 <template>
@@ -199,25 +27,13 @@ watch(highlightedMarkdown, () => {
     }"
   >
     <template #body>
-      <section class="flex h-full min-h-0 flex-col bg-default">
-        <header class="flex items-center justify-between gap-3 border-b border-default px-4 py-3">
-          <div class="min-w-0">
-            <div class="truncate text-xs font-medium text-primary">
-              Local file viewer
-            </div>
-            <div class="truncate text-sm font-semibold text-highlighted">
-              {{ relativePathLabel }}
-            </div>
-            <div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted">
-              <span v-if="file">{{ formatLocalFileSize(file.size) }}</span>
-              <span v-if="textFile">{{ lineCount }} lines</span>
-              <span v-if="updatedAtLabel">{{ updatedAtLabel }}</span>
-              <span v-if="mediaTypeLabel">{{ mediaTypeLabel }}</span>
-              <span v-if="languageLabel">{{ languageLabel }}</span>
-              <span v-if="textFile && state.line">Line {{ state.line }}</span>
-            </div>
-          </div>
-
+      <LocalFilePreview
+        v-if="state.workspace && state.path"
+        :workspace="state.workspace"
+        :path="state.path"
+        :line="state.line"
+      >
+        <template #actions>
           <UButton
             icon="i-lucide-x"
             color="neutral"
@@ -226,130 +42,8 @@ watch(highlightedMarkdown, () => {
             aria-label="Close local file viewer"
             @click="closeViewer"
           />
-        </header>
-
-        <div
-          v-if="loading"
-          class="flex min-h-0 flex-1 items-center justify-center px-6 py-10 text-sm text-muted"
-        >
-          Loading local file preview...
-        </div>
-
-        <div
-          v-else-if="error"
-          class="flex min-h-0 flex-1 items-center justify-center px-6 py-10"
-        >
-          <UAlert
-            color="error"
-            variant="soft"
-            icon="i-lucide-circle-alert"
-            :title="error"
-            class="w-full max-w-2xl"
-          />
-        </div>
-
-        <div
-          v-else-if="imageFile"
-          class="local-file-viewer-image min-h-0 flex-1 overflow-auto bg-elevated/15"
-        >
-          <div class="flex min-h-full items-center justify-center p-6">
-            <img
-              class="max-h-full max-w-full object-contain"
-              :src="imagePreviewSrc"
-              :alt="imageFile.name"
-            >
-          </div>
-        </div>
-
-        <div
-          v-else-if="textFile"
-          ref="lineContainer"
-          class="local-file-viewer-code min-h-0 flex-1 overflow-auto bg-elevated/15"
-          :style="{ '--lfv-line-number-width': lineNumberWidth }"
-        >
-          <Suspense>
-            <Comark
-              class="local-file-viewer-markdown"
-              :markdown="highlightedMarkdown"
-              :plugins="viewerPlugins"
-            />
-          </Suspense>
-        </div>
-      </section>
+        </template>
+      </LocalFilePreview>
     </template>
   </UModal>
 </template>
-
-<style scoped>
-.local-file-viewer-code :deep(.local-file-viewer-markdown) {
-  min-width: max-content;
-}
-
-.local-file-viewer-code :deep(.local-file-viewer-markdown > * + *) {
-  margin-top: 0;
-}
-
-.local-file-viewer-code :deep(pre),
-.local-file-viewer-code :deep(.shiki) {
-  margin: 0;
-  min-width: max-content;
-  border: 0;
-  border-radius: 0;
-  padding: 0;
-  background: transparent !important;
-}
-
-.local-file-viewer-code :deep(pre code),
-.local-file-viewer-code :deep(.shiki code) {
-  display: block;
-  min-width: max-content;
-  padding: 0;
-}
-
-.local-file-viewer-code :deep(.line) {
-  display: block;
-  min-width: max-content;
-  padding: 0 1.5rem 0 0;
-  padding-left: calc(var(--lfv-line-number-width) + 1.5rem);
-  position: relative;
-  white-space: pre;
-}
-
-.local-file-viewer-code :deep(.line::before) {
-  content: attr(data-file-line);
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: var(--lfv-line-number-width);
-  padding-right: 0.75rem;
-  text-align: right;
-  color: var(--ui-text-muted);
-  user-select: none;
-  font-variant-numeric: tabular-nums;
-}
-
-.local-file-viewer-code :deep(.line.is-target-line) {
-  background: color-mix(in srgb, var(--ui-primary) 10%, transparent);
-}
-
-.local-file-viewer-code :deep(.line.is-target-line::before) {
-  color: var(--ui-primary);
-}
-
-.local-file-viewer-code :deep(.shiki),
-.local-file-viewer-code :deep(.shiki code),
-.local-file-viewer-code :deep(pre),
-.local-file-viewer-code :deep(pre code) {
-  font-size: 13px;
-  line-height: 1.75;
-}
-
-:global(.dark) .local-file-viewer-code :deep(.shiki),
-:global(.dark) .local-file-viewer-code :deep(.shiki span) {
-  color: var(--shiki-dark) !important;
-  background-color: var(--shiki-dark-bg) !important;
-  font-style: var(--shiki-dark-font-style) !important;
-  font-weight: var(--shiki-dark-font-weight) !important;
-  text-decoration: var(--shiki-dark-text-decoration) !important;
-}
-</style>

--- a/packages/client/app/components/WorkspaceFilesPanel.vue
+++ b/packages/client/app/components/WorkspaceFilesPanel.vue
@@ -344,8 +344,8 @@ watch(open, (nextOpen) => {
             size="sm"
             class="w-full"
             :ui="{
-              link: 'min-w-0 rounded-lg',
-              linkLabel: 'min-w-0 flex-1',
+              link: 'min-w-0 justify-start rounded-lg text-left',
+              linkLabel: 'min-w-0 flex-1 text-left',
               linkLeadingIcon: 'shrink-0'
             }"
             @update:model-value="handleSelectedNode"
@@ -355,7 +355,7 @@ watch(open, (nextOpen) => {
           >
             <template #item-label="{ item }">
               <span
-                class="flex min-w-0 items-center gap-2"
+                class="flex min-w-0 w-full items-center justify-start gap-2 text-left"
                 :class="item.status ? 'text-muted' : ''"
               >
                 <span class="min-w-0 flex-1 truncate">{{ item.label }}</span>

--- a/packages/client/app/components/WorkspaceFilesPanel.vue
+++ b/packages/client/app/components/WorkspaceFilesPanel.vue
@@ -1,0 +1,387 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue'
+import { useLocalFileViewer } from '../composables/useLocalFileViewer'
+import {
+  useWorkspaceFiles,
+  type WorkspaceFileTreeNode
+} from '../composables/useWorkspaceFiles'
+import { formatLocalFileSize, type WorkspaceLocalFileScope } from '../../shared/local-files'
+
+const props = defineProps<{
+  workspace: WorkspaceLocalFileScope
+  workspaceLabel: string
+}>()
+
+const workspace = computed(() => props.workspace)
+const {
+  snapshot,
+  treeItems,
+  rootLoading,
+  rootError,
+  currentDirectoryError,
+  breadcrumbs,
+  selectedEntry,
+  loadDirectory,
+  selectEntry,
+  navigateTo,
+  refreshCurrentDirectory,
+  setShowIgnored
+} = useWorkspaceFiles(workspace)
+const { openViewer } = useLocalFileViewer()
+
+const open = ref(false)
+const copyStatus = ref<string | null>(null)
+const pendingViewerPath = ref<string | null>(null)
+
+const breadcrumbItems = computed(() => breadcrumbs.value.map((item, index) => ({
+  ...item,
+  label: index === 0 ? props.workspaceLabel : item.label,
+  active: index === breadcrumbs.value.length - 1
+})))
+
+const selectedNode = computed(() => {
+  const selectedPath = snapshot.value.selectedPath
+  if (!selectedPath) {
+    return undefined
+  }
+
+  const findNode = (nodes: WorkspaceFileTreeNode[]): WorkspaceFileTreeNode | undefined => {
+    for (const node of nodes) {
+      if (node.key === selectedPath) {
+        return node
+      }
+      const child = node.children ? findNode(node.children) : undefined
+      if (child) {
+        return child
+      }
+    }
+    return undefined
+  }
+
+  return findNode(treeItems.value)
+})
+
+const copyTarget = computed(() => selectedEntry.value?.path ?? snapshot.value.currentPath)
+
+const entryStatusLabel = (node: WorkspaceFileTreeNode) => {
+  const entry = node.entry
+  if (!entry || entry.accessible) {
+    return null
+  }
+
+  switch (entry.errorCode) {
+    case 'FORBIDDEN':
+      return 'Outside workspace'
+    case 'NOT_FOUND':
+      return 'Unavailable'
+    case 'PERMISSION_DENIED':
+      return 'Permission denied'
+    default:
+      return 'Unsupported'
+  }
+}
+
+const handleOpenChange = async (nextOpen: boolean) => {
+  open.value = nextOpen
+  if (nextOpen && !snapshot.value.listings['']) {
+    await loadDirectory('')
+  }
+}
+
+const handleTreeToggle = async (
+  event: { detail: { isExpanded: boolean } },
+  node: WorkspaceFileTreeNode
+) => {
+  const entry = node.entry
+  if (!entry || entry.kind !== 'directory' || !entry.accessible) {
+    return
+  }
+
+  selectEntry(entry)
+  if (!event.detail.isExpanded && !snapshot.value.listings[entry.path]) {
+    await loadDirectory(entry.path)
+  }
+}
+
+const handleTreeSelect = async (
+  _event: Event,
+  node: WorkspaceFileTreeNode
+) => {
+  const entry = node.entry
+  if (!entry || !entry.accessible) {
+    return
+  }
+
+  selectEntry(entry)
+  if (entry.kind !== 'file') {
+    return
+  }
+
+  pendingViewerPath.value = entry.path
+  open.value = false
+}
+
+const handleAfterLeave = async () => {
+  const path = pendingViewerPath.value
+  if (!path) {
+    return
+  }
+
+  pendingViewerPath.value = null
+  await nextTick()
+  openViewer({
+    workspace: props.workspace,
+    path
+  })
+}
+
+const handleSelectedNode = (node: WorkspaceFileTreeNode | undefined) => {
+  if (node?.entry?.accessible) {
+    selectEntry(node.entry)
+  }
+}
+
+const copyRelativePath = async () => {
+  if (!copyTarget.value) {
+    return
+  }
+
+  try {
+    await navigator.clipboard.writeText(copyTarget.value)
+    copyStatus.value = `Copied ${copyTarget.value}`
+  } catch {
+    copyStatus.value = 'Could not copy the relative path.'
+  }
+}
+
+watch(
+  () => [props.workspace.kind, props.workspace.id] as const,
+  () => {
+    open.value = false
+    copyStatus.value = null
+    pendingViewerPath.value = null
+  }
+)
+
+watch(copyTarget, () => {
+  copyStatus.value = null
+})
+
+watch(open, (nextOpen) => {
+  if (!nextOpen) {
+    copyStatus.value = null
+  }
+})
+</script>
+
+<template>
+  <UTooltip text="Workspace files">
+    <UButton
+      type="button"
+      color="neutral"
+      :variant="open ? 'soft' : 'ghost'"
+      size="sm"
+      icon="i-lucide-folder-tree"
+      class="size-8 shrink-0 justify-center rounded-full border border-default/70"
+      :ui="{ leadingIcon: 'size-4', base: 'px-0' }"
+      :aria-expanded="open"
+      aria-label="Browse workspace files"
+      @click="handleOpenChange(!open)"
+    />
+  </UTooltip>
+
+  <USlideover
+    :open="open"
+    title="Workspace files"
+    :description="`Read-only files rooted at ${workspaceLabel}.`"
+    side="right"
+    dismissible
+    :ui="{
+      content: 'w-[92vw] max-w-[92vw] sm:w-[28rem] sm:max-w-[28rem]',
+      header: 'px-4 py-3',
+      body: '!p-0 sm:!p-0',
+      footer: 'px-4 py-3'
+    }"
+    @update:open="handleOpenChange"
+    @after:leave="handleAfterLeave"
+  >
+    <template #actions>
+      <UTooltip text="Refresh current folder">
+        <UButton
+          icon="i-lucide-refresh-cw"
+          color="neutral"
+          variant="ghost"
+          size="xs"
+          square
+          :loading="snapshot.loadingPaths.includes(snapshot.currentPath)"
+          aria-label="Refresh current folder"
+          @click="refreshCurrentDirectory"
+        />
+      </UTooltip>
+      <UTooltip text="Copy relative path">
+        <UButton
+          icon="i-lucide-copy"
+          color="neutral"
+          variant="ghost"
+          size="xs"
+          square
+          :disabled="!copyTarget"
+          aria-label="Copy relative path"
+          @click="copyRelativePath"
+        />
+      </UTooltip>
+    </template>
+
+    <template #body>
+      <div class="flex h-full min-h-0 flex-col bg-default">
+        <div class="space-y-3 border-b border-default bg-elevated/20 px-4 py-3">
+          <UBreadcrumb
+            :items="breadcrumbItems"
+            class="min-w-0 overflow-x-auto"
+            :ui="{ list: 'flex-nowrap', linkLabel: 'max-w-32 truncate' }"
+          >
+            <template #item="{ item }">
+              <button
+                type="button"
+                class="max-w-32 truncate rounded text-sm hover:text-highlighted focus-visible:outline-2 focus-visible:outline-primary"
+                :aria-current="item.active ? 'page' : undefined"
+                @click="navigateTo(item.path)"
+              >
+                {{ item.label }}
+              </button>
+            </template>
+          </UBreadcrumb>
+
+          <div class="flex items-center justify-between gap-3">
+            <UCheckbox
+              :model-value="snapshot.showIgnored"
+              label="Show generated folders"
+              size="sm"
+              @update:model-value="(value: boolean | 'indeterminate') => setShowIgnored(Boolean(value))"
+            />
+            <span class="text-xs text-muted">Read only</span>
+          </div>
+
+          <p
+            v-if="copyStatus"
+            class="text-xs text-muted"
+            role="status"
+          >
+            {{ copyStatus }}
+          </p>
+        </div>
+
+        <UScrollArea class="min-h-0 flex-1 px-2 py-3">
+          <div
+            v-if="rootLoading"
+            class="space-y-2 px-2"
+            aria-label="Loading workspace files"
+          >
+            <USkeleton
+              v-for="index in 6"
+              :key="index"
+              class="h-8 w-full"
+            />
+          </div>
+
+          <div
+            v-else-if="rootError"
+            class="space-y-3 px-2"
+          >
+            <UAlert
+              color="error"
+              variant="soft"
+              icon="i-lucide-triangle-alert"
+              title="Could not load workspace files"
+              :description="rootError"
+            />
+            <UButton
+              label="Retry"
+              icon="i-lucide-refresh-cw"
+              color="neutral"
+              variant="outline"
+              size="sm"
+              @click="loadDirectory('', { force: true })"
+            />
+          </div>
+
+          <div
+            v-else-if="currentDirectoryError"
+            class="space-y-3 px-2 pb-3"
+            role="status"
+            aria-live="polite"
+          >
+            <UAlert
+              color="error"
+              variant="soft"
+              icon="i-lucide-triangle-alert"
+              title="Could not load folder"
+              :description="currentDirectoryError"
+            />
+            <UButton
+              label="Retry folder"
+              icon="i-lucide-refresh-cw"
+              color="neutral"
+              variant="outline"
+              size="sm"
+              @click="loadDirectory(snapshot.currentPath, { force: true })"
+            />
+          </div>
+
+          <UTree
+            v-if="!rootLoading && !rootError"
+            :items="treeItems"
+            :get-key="(item: WorkspaceFileTreeNode) => item.key"
+            :model-value="selectedNode"
+            :expanded="snapshot.expandedPaths"
+            color="primary"
+            size="sm"
+            class="w-full"
+            :ui="{
+              link: 'min-w-0 rounded-lg',
+              linkLabel: 'min-w-0 flex-1',
+              linkLeadingIcon: 'shrink-0'
+            }"
+            @update:model-value="handleSelectedNode"
+            @update:expanded="(paths: string[]) => { snapshot.expandedPaths = paths }"
+            @toggle="handleTreeToggle"
+            @select="handleTreeSelect"
+          >
+            <template #item-label="{ item }">
+              <span
+                class="flex min-w-0 items-center gap-2"
+                :class="item.status ? 'text-muted' : ''"
+              >
+                <span class="min-w-0 flex-1 truncate">{{ item.label }}</span>
+                <UBadge
+                  v-if="item.entry?.isSymlink"
+                  color="neutral"
+                  variant="subtle"
+                  size="xs"
+                >
+                  link
+                </UBadge>
+                <span
+                  v-if="item.entry?.kind === 'file' && item.entry.size !== null"
+                  class="shrink-0 text-[11px] text-dimmed"
+                >
+                  {{ formatLocalFileSize(item.entry.size) }}
+                </span>
+                <span
+                  v-if="entryStatusLabel(item)"
+                  class="shrink-0 text-[11px] text-warning"
+                >
+                  {{ entryStatusLabel(item) }}
+                </span>
+              </span>
+            </template>
+          </UTree>
+        </UScrollArea>
+
+        <div class="border-t border-default px-4 py-3 text-xs leading-5 text-muted">
+          Select a supported text or image file to open the existing preview. File changes are not available here.
+        </div>
+      </div>
+    </template>
+  </USlideover>
+</template>

--- a/packages/client/app/components/WorkspaceFilesPanel.vue
+++ b/packages/client/app/components/WorkspaceFilesPanel.vue
@@ -24,8 +24,7 @@ const {
   loadDirectory,
   selectEntry,
   navigateTo,
-  refreshCurrentDirectory,
-  setShowIgnored
+  refreshCurrentDirectory
 } = useWorkspaceFiles(workspace)
 const open = ref(false)
 const copyStatus = ref<string | null>(null)
@@ -174,7 +173,6 @@ watch(open, (nextOpen) => {
   <UModal
     :open="open"
     title="Workspace files"
-    :description="`Read-only files rooted at ${workspaceLabel}.`"
     fullscreen
     dismissible
     :ui="{
@@ -184,37 +182,10 @@ watch(open, (nextOpen) => {
     }"
     @update:open="handleOpenChange"
   >
-    <template #actions>
-      <UTooltip text="Refresh current folder">
-        <UButton
-          icon="i-lucide-refresh-cw"
-          color="neutral"
-          variant="ghost"
-          size="xs"
-          square
-          :loading="snapshot.loadingPaths.includes(snapshot.currentPath)"
-          aria-label="Refresh current folder"
-          @click="refreshCurrentDirectory"
-        />
-      </UTooltip>
-      <UTooltip text="Copy relative path">
-        <UButton
-          icon="i-lucide-copy"
-          color="neutral"
-          variant="ghost"
-          size="xs"
-          square
-          :disabled="!copyTarget"
-          aria-label="Copy relative path"
-          @click="copyRelativePath"
-        />
-      </UTooltip>
-    </template>
-
     <template #body>
       <div class="grid h-full min-h-0 grid-rows-[minmax(14rem,42%)_minmax(0,1fr)] bg-default md:grid-cols-[minmax(18rem,26rem)_minmax(0,1fr)] md:grid-rows-1">
         <aside class="flex min-h-0 flex-col border-b border-default bg-default md:border-r md:border-b-0">
-          <div class="space-y-3 border-b border-default bg-elevated/20 px-4 py-3">
+          <div class="border-b border-default bg-elevated/20 px-4 py-3">
             <UBreadcrumb
               :items="breadcrumbItems"
               class="min-w-0 overflow-x-auto"
@@ -231,24 +202,6 @@ watch(open, (nextOpen) => {
                 </button>
               </template>
             </UBreadcrumb>
-
-            <div class="flex items-center justify-between gap-3">
-              <UCheckbox
-                :model-value="snapshot.showIgnored"
-                label="Show generated folders"
-                size="sm"
-                @update:model-value="(value: boolean | 'indeterminate') => setShowIgnored(Boolean(value))"
-              />
-              <span class="text-xs text-muted">Read only</span>
-            </div>
-
-            <p
-              v-if="copyStatus"
-              class="text-xs text-muted"
-              role="status"
-            >
-              {{ copyStatus }}
-            </p>
           </div>
 
           <UScrollArea class="min-h-0 flex-1 px-2 py-3">
@@ -358,8 +311,43 @@ watch(open, (nextOpen) => {
             </UTree>
           </UScrollArea>
 
-          <div class="border-t border-default px-4 py-3 text-xs leading-5 text-muted">
-            Read-only workspace files. File changes are not available here.
+          <div
+            class="flex min-h-12 items-center gap-2 border-t border-default bg-elevated/20 px-2 py-2"
+            role="group"
+            aria-label="File tree actions"
+          >
+            <p
+              class="min-w-0 flex-1 truncate px-2 text-xs text-muted"
+              :role="copyStatus ? 'status' : undefined"
+            >
+              {{ copyStatus ?? (copyTarget || 'Workspace root') }}
+            </p>
+            <div class="flex shrink-0 items-center gap-1">
+              <UTooltip text="Refresh current folder">
+                <UButton
+                  icon="i-lucide-refresh-cw"
+                  color="neutral"
+                  variant="ghost"
+                  size="xs"
+                  square
+                  :loading="snapshot.loadingPaths.includes(snapshot.currentPath)"
+                  aria-label="Refresh current folder"
+                  @click="refreshCurrentDirectory"
+                />
+              </UTooltip>
+              <UTooltip text="Copy relative path">
+                <UButton
+                  icon="i-lucide-copy"
+                  color="neutral"
+                  variant="ghost"
+                  size="xs"
+                  square
+                  :disabled="!copyTarget"
+                  aria-label="Copy relative path"
+                  @click="copyRelativePath"
+                />
+              </UTooltip>
+            </div>
           </div>
         </aside>
 

--- a/packages/client/app/components/WorkspaceFilesPanel.vue
+++ b/packages/client/app/components/WorkspaceFilesPanel.vue
@@ -146,8 +146,14 @@ const copyRelativePath = async () => {
     return
   }
 
+  const clipboard = typeof navigator === 'undefined' ? undefined : navigator.clipboard
+  if (!clipboard?.writeText) {
+    copyStatus.value = 'Could not copy the relative path.'
+    return
+  }
+
   try {
-    await navigator.clipboard.writeText(copyTarget.value)
+    await clipboard.writeText(copyTarget.value)
     copyStatus.value = `Copied ${copyTarget.value}`
   } catch {
     copyStatus.value = 'Could not copy the relative path.'

--- a/packages/client/app/components/WorkspaceFilesPanel.vue
+++ b/packages/client/app/components/WorkspaceFilesPanel.vue
@@ -161,11 +161,10 @@ watch(open, (nextOpen) => {
     <UButton
       type="button"
       color="neutral"
-      :variant="open ? 'soft' : 'ghost'"
+      :variant="open ? 'soft' : 'outline'"
       size="sm"
       icon="i-lucide-folder-tree"
-      class="size-8 shrink-0 justify-center rounded-full border border-default/70"
-      :ui="{ leadingIcon: 'size-4', base: 'px-0' }"
+      square
       :aria-expanded="open"
       aria-label="Browse workspace files"
       @click="handleOpenChange(!open)"

--- a/packages/client/app/components/WorkspaceFilesPanel.vue
+++ b/packages/client/app/components/WorkspaceFilesPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from 'vue'
-import { useLocalFileViewer } from '../composables/useLocalFileViewer'
+import { computed, ref, watch } from 'vue'
+import LocalFilePreview from './LocalFilePreview.vue'
 import {
   useWorkspaceFiles,
   type WorkspaceFileTreeNode
@@ -27,11 +27,8 @@ const {
   refreshCurrentDirectory,
   setShowIgnored
 } = useWorkspaceFiles(workspace)
-const { openViewer } = useLocalFileViewer()
-
 const open = ref(false)
 const copyStatus = ref<string | null>(null)
-const pendingViewerPath = ref<string | null>(null)
 
 const breadcrumbItems = computed(() => breadcrumbs.value.map((item, index) => ({
   ...item,
@@ -103,7 +100,7 @@ const handleTreeToggle = async (
   }
 }
 
-const handleTreeSelect = async (
+const handleTreeSelect = (
   _event: Event,
   node: WorkspaceFileTreeNode
 ) => {
@@ -113,26 +110,6 @@ const handleTreeSelect = async (
   }
 
   selectEntry(entry)
-  if (entry.kind !== 'file') {
-    return
-  }
-
-  pendingViewerPath.value = entry.path
-  open.value = false
-}
-
-const handleAfterLeave = async () => {
-  const path = pendingViewerPath.value
-  if (!path) {
-    return
-  }
-
-  pendingViewerPath.value = null
-  await nextTick()
-  openViewer({
-    workspace: props.workspace,
-    path
-  })
 }
 
 const handleSelectedNode = (node: WorkspaceFileTreeNode | undefined) => {
@@ -165,7 +142,6 @@ watch(
   () => {
     open.value = false
     copyStatus.value = null
-    pendingViewerPath.value = null
   }
 )
 
@@ -196,20 +172,18 @@ watch(open, (nextOpen) => {
     />
   </UTooltip>
 
-  <USlideover
+  <UModal
     :open="open"
     title="Workspace files"
     :description="`Read-only files rooted at ${workspaceLabel}.`"
-    side="right"
+    fullscreen
     dismissible
     :ui="{
-      content: 'w-[92vw] max-w-[92vw] sm:w-[28rem] sm:max-w-[28rem]',
+      content: 'overflow-hidden bg-default',
       header: 'px-4 py-3',
-      body: '!p-0 sm:!p-0',
-      footer: 'px-4 py-3'
+      body: 'min-h-0 overflow-hidden !p-0 sm:!p-0'
     }"
     @update:open="handleOpenChange"
-    @after:leave="handleAfterLeave"
   >
     <template #actions>
       <UTooltip text="Refresh current folder">
@@ -239,155 +213,182 @@ watch(open, (nextOpen) => {
     </template>
 
     <template #body>
-      <div class="flex h-full min-h-0 flex-col bg-default">
-        <div class="space-y-3 border-b border-default bg-elevated/20 px-4 py-3">
-          <UBreadcrumb
-            :items="breadcrumbItems"
-            class="min-w-0 overflow-x-auto"
-            :ui="{ list: 'flex-nowrap', linkLabel: 'max-w-32 truncate' }"
-          >
-            <template #item="{ item }">
-              <button
-                type="button"
-                class="max-w-32 truncate rounded text-sm hover:text-highlighted focus-visible:outline-2 focus-visible:outline-primary"
-                :aria-current="item.active ? 'page' : undefined"
-                @click="navigateTo(item.path)"
-              >
-                {{ item.label }}
-              </button>
-            </template>
-          </UBreadcrumb>
-
-          <div class="flex items-center justify-between gap-3">
-            <UCheckbox
-              :model-value="snapshot.showIgnored"
-              label="Show generated folders"
-              size="sm"
-              @update:model-value="(value: boolean | 'indeterminate') => setShowIgnored(Boolean(value))"
-            />
-            <span class="text-xs text-muted">Read only</span>
-          </div>
-
-          <p
-            v-if="copyStatus"
-            class="text-xs text-muted"
-            role="status"
-          >
-            {{ copyStatus }}
-          </p>
-        </div>
-
-        <UScrollArea class="min-h-0 flex-1 px-2 py-3">
-          <div
-            v-if="rootLoading"
-            class="space-y-2 px-2"
-            aria-label="Loading workspace files"
-          >
-            <USkeleton
-              v-for="index in 6"
-              :key="index"
-              class="h-8 w-full"
-            />
-          </div>
-
-          <div
-            v-else-if="rootError"
-            class="space-y-3 px-2"
-          >
-            <UAlert
-              color="error"
-              variant="soft"
-              icon="i-lucide-triangle-alert"
-              title="Could not load workspace files"
-              :description="rootError"
-            />
-            <UButton
-              label="Retry"
-              icon="i-lucide-refresh-cw"
-              color="neutral"
-              variant="outline"
-              size="sm"
-              @click="loadDirectory('', { force: true })"
-            />
-          </div>
-
-          <div
-            v-else-if="currentDirectoryError"
-            class="space-y-3 px-2 pb-3"
-            role="status"
-            aria-live="polite"
-          >
-            <UAlert
-              color="error"
-              variant="soft"
-              icon="i-lucide-triangle-alert"
-              title="Could not load folder"
-              :description="currentDirectoryError"
-            />
-            <UButton
-              label="Retry folder"
-              icon="i-lucide-refresh-cw"
-              color="neutral"
-              variant="outline"
-              size="sm"
-              @click="loadDirectory(snapshot.currentPath, { force: true })"
-            />
-          </div>
-
-          <UTree
-            v-if="!rootLoading && !rootError"
-            :items="treeItems"
-            :get-key="(item: WorkspaceFileTreeNode) => item.key"
-            :model-value="selectedNode"
-            :expanded="snapshot.expandedPaths"
-            color="primary"
-            size="sm"
-            class="w-full"
-            :ui="{
-              link: 'min-w-0 justify-start rounded-lg text-left',
-              linkLabel: 'min-w-0 flex-1 text-left',
-              linkLeadingIcon: 'shrink-0'
-            }"
-            @update:model-value="handleSelectedNode"
-            @update:expanded="(paths: string[]) => { snapshot.expandedPaths = paths }"
-            @toggle="handleTreeToggle"
-            @select="handleTreeSelect"
-          >
-            <template #item-label="{ item }">
-              <span
-                class="flex min-w-0 w-full items-center justify-start gap-2 text-left"
-                :class="item.status ? 'text-muted' : ''"
-              >
-                <span class="min-w-0 flex-1 truncate">{{ item.label }}</span>
-                <UBadge
-                  v-if="item.entry?.isSymlink"
-                  color="neutral"
-                  variant="subtle"
-                  size="xs"
+      <div class="grid h-full min-h-0 grid-rows-[minmax(14rem,42%)_minmax(0,1fr)] bg-default md:grid-cols-[minmax(18rem,26rem)_minmax(0,1fr)] md:grid-rows-1">
+        <aside class="flex min-h-0 flex-col border-b border-default bg-default md:border-r md:border-b-0">
+          <div class="space-y-3 border-b border-default bg-elevated/20 px-4 py-3">
+            <UBreadcrumb
+              :items="breadcrumbItems"
+              class="min-w-0 overflow-x-auto"
+              :ui="{ list: 'flex-nowrap', linkLabel: 'max-w-32 truncate' }"
+            >
+              <template #item="{ item }">
+                <button
+                  type="button"
+                  class="max-w-32 truncate rounded text-sm hover:text-highlighted focus-visible:outline-2 focus-visible:outline-primary"
+                  :aria-current="item.active ? 'page' : undefined"
+                  @click="navigateTo(item.path)"
                 >
-                  link
-                </UBadge>
+                  {{ item.label }}
+                </button>
+              </template>
+            </UBreadcrumb>
+
+            <div class="flex items-center justify-between gap-3">
+              <UCheckbox
+                :model-value="snapshot.showIgnored"
+                label="Show generated folders"
+                size="sm"
+                @update:model-value="(value: boolean | 'indeterminate') => setShowIgnored(Boolean(value))"
+              />
+              <span class="text-xs text-muted">Read only</span>
+            </div>
+
+            <p
+              v-if="copyStatus"
+              class="text-xs text-muted"
+              role="status"
+            >
+              {{ copyStatus }}
+            </p>
+          </div>
+
+          <UScrollArea class="min-h-0 flex-1 px-2 py-3">
+            <div
+              v-if="rootLoading"
+              class="space-y-2 px-2"
+              aria-label="Loading workspace files"
+            >
+              <USkeleton
+                v-for="index in 6"
+                :key="index"
+                class="h-8 w-full"
+              />
+            </div>
+
+            <div
+              v-else-if="rootError"
+              class="space-y-3 px-2"
+            >
+              <UAlert
+                color="error"
+                variant="soft"
+                icon="i-lucide-triangle-alert"
+                title="Could not load workspace files"
+                :description="rootError"
+              />
+              <UButton
+                label="Retry"
+                icon="i-lucide-refresh-cw"
+                color="neutral"
+                variant="outline"
+                size="sm"
+                @click="loadDirectory('', { force: true })"
+              />
+            </div>
+
+            <div
+              v-else-if="currentDirectoryError"
+              class="space-y-3 px-2 pb-3"
+              role="status"
+              aria-live="polite"
+            >
+              <UAlert
+                color="error"
+                variant="soft"
+                icon="i-lucide-triangle-alert"
+                title="Could not load folder"
+                :description="currentDirectoryError"
+              />
+              <UButton
+                label="Retry folder"
+                icon="i-lucide-refresh-cw"
+                color="neutral"
+                variant="outline"
+                size="sm"
+                @click="loadDirectory(snapshot.currentPath, { force: true })"
+              />
+            </div>
+
+            <UTree
+              v-if="!rootLoading && !rootError"
+              :items="treeItems"
+              :get-key="(item: WorkspaceFileTreeNode) => item.key"
+              :model-value="selectedNode"
+              :expanded="snapshot.expandedPaths"
+              color="primary"
+              size="sm"
+              class="w-full"
+              :ui="{
+                link: 'min-w-0 justify-start rounded-lg text-left',
+                linkLabel: 'min-w-0 flex-1 text-left',
+                linkLeadingIcon: 'shrink-0'
+              }"
+              @update:model-value="handleSelectedNode"
+              @update:expanded="(paths: string[]) => { snapshot.expandedPaths = paths }"
+              @toggle="handleTreeToggle"
+              @select="handleTreeSelect"
+            >
+              <template #item-label="{ item }">
                 <span
-                  v-if="item.entry?.kind === 'file' && item.entry.size !== null"
-                  class="shrink-0 text-[11px] text-dimmed"
+                  class="flex min-w-0 w-full items-center justify-start gap-2 text-left"
+                  :class="item.status ? 'text-muted' : ''"
                 >
-                  {{ formatLocalFileSize(item.entry.size) }}
+                  <span class="min-w-0 flex-1 truncate">{{ item.label }}</span>
+                  <UBadge
+                    v-if="item.entry?.isSymlink"
+                    color="neutral"
+                    variant="subtle"
+                    size="xs"
+                  >
+                    link
+                  </UBadge>
+                  <span
+                    v-if="item.entry?.kind === 'file' && item.entry.size !== null"
+                    class="shrink-0 text-[11px] text-dimmed"
+                  >
+                    {{ formatLocalFileSize(item.entry.size) }}
+                  </span>
+                  <span
+                    v-if="entryStatusLabel(item)"
+                    class="shrink-0 text-[11px] text-warning"
+                  >
+                    {{ entryStatusLabel(item) }}
+                  </span>
                 </span>
-                <span
-                  v-if="entryStatusLabel(item)"
-                  class="shrink-0 text-[11px] text-warning"
-                >
-                  {{ entryStatusLabel(item) }}
-                </span>
-              </span>
-            </template>
-          </UTree>
-        </UScrollArea>
+              </template>
+            </UTree>
+          </UScrollArea>
 
-        <div class="border-t border-default px-4 py-3 text-xs leading-5 text-muted">
-          Select a supported text or image file to open the existing preview. File changes are not available here.
-        </div>
+          <div class="border-t border-default px-4 py-3 text-xs leading-5 text-muted">
+            Read-only workspace files. File changes are not available here.
+          </div>
+        </aside>
+
+        <section
+          class="min-h-0 bg-elevated/10"
+          aria-label="Workspace file preview"
+        >
+          <LocalFilePreview
+            v-if="selectedEntry?.kind === 'file' && selectedEntry.accessible"
+            :workspace="workspace"
+            :path="selectedEntry.path"
+            eyebrow="Workspace file preview"
+          />
+          <div
+            v-else
+            class="flex h-full min-h-0 flex-col items-center justify-center gap-4 px-6 py-10 text-center"
+          >
+            <UIcon
+              name="i-lucide-file-search-2"
+              class="size-12 text-muted/45"
+              aria-hidden="true"
+            />
+            <p class="max-w-sm text-sm text-muted">
+              Select a file from the tree to preview it.
+            </p>
+          </div>
+        </section>
       </div>
     </template>
-  </USlideover>
+  </UModal>
 </template>

--- a/packages/client/app/composables/useWorkspaceFiles.ts
+++ b/packages/client/app/composables/useWorkspaceFiles.ts
@@ -306,20 +306,72 @@ export const useWorkspaceFiles = (
 
   const refreshCurrentDirectory = () => loadDirectory(snapshot.value.currentPath, { force: true })
 
+  const directoryAncestors = (path: string) => {
+    const segments = path ? path.split('/') : []
+    return segments.map((_, index) => segments.slice(0, index + 1).join('/'))
+  }
+
+  const parentDirectoryPath = (path: string) =>
+    path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : ''
+
   const setShowIgnored = async (showIgnored: boolean) => {
-    if (snapshot.value.showIgnored === showIgnored) {
+    const key = scopeKey.value
+    const targetSnapshot = ensureSnapshot(key)
+    if (targetSnapshot.showIgnored === showIgnored) {
       return
     }
 
-    snapshot.value.showIgnored = showIgnored
-    snapshot.value.generation += 1
-    snapshot.value.listings = {}
-    snapshot.value.loadingPaths = []
-    snapshot.value.errors = {}
-    snapshot.value.expandedPaths = []
-    snapshot.value.selectedPath = null
-    snapshot.value.currentPath = ''
+    const generation = targetSnapshot.generation + 1
+    const preservedExpandedPaths = [...targetSnapshot.expandedPaths]
+    const preservedCurrentPath = targetSnapshot.currentPath
+    const preservedSelectedPath = targetSnapshot.selectedPath
+
+    targetSnapshot.showIgnored = showIgnored
+    targetSnapshot.generation = generation
+    targetSnapshot.listings = {}
+    targetSnapshot.loadingPaths = []
+    targetSnapshot.errors = {}
     await loadDirectory('', { force: true })
+    if (scopeKey.value !== key || targetSnapshot.generation !== generation) {
+      return
+    }
+    if (!targetSnapshot.listings['']) {
+      targetSnapshot.expandedPaths = []
+      targetSnapshot.selectedPath = null
+      targetSnapshot.currentPath = ''
+      return
+    }
+
+    const pathsToReload = Array.from(new Set([
+      ...preservedExpandedPaths,
+      ...directoryAncestors(preservedCurrentPath),
+      ...directoryAncestors(parentDirectoryPath(preservedSelectedPath ?? ''))
+    ])).sort((left, right) => {
+      const depthDifference = left.split('/').length - right.split('/').length
+      return depthDifference || (left < right ? -1 : left > right ? 1 : 0)
+    })
+
+    for (const path of pathsToReload) {
+      if (scopeKey.value !== key || targetSnapshot.generation !== generation) {
+        return
+      }
+
+      const parentPath = parentDirectoryPath(path)
+      const entry = targetSnapshot.listings[parentPath]?.entries.find(item => item.path === path)
+      if (!entry || entry.kind !== 'directory' || !entry.accessible) {
+        removeDescendantState(path)
+        continue
+      }
+
+      await loadDirectory(path, { force: true })
+      if (scopeKey.value !== key || targetSnapshot.generation !== generation) {
+        return
+      }
+    }
+
+    if (targetSnapshot.selectedPath && !selectedEntry.value) {
+      targetSnapshot.selectedPath = null
+    }
   }
 
   return {

--- a/packages/client/app/composables/useWorkspaceFiles.ts
+++ b/packages/client/app/composables/useWorkspaceFiles.ts
@@ -2,6 +2,7 @@ import { useRuntimeConfig, useState } from '#imports'
 import { computed, type ComputedRef, type Ref } from 'vue'
 import type { WorkspaceLocalFileScope } from '../../shared/local-files'
 import {
+  fallbackWorkspacePathAfterRemoval,
   resolveWorkspaceDirectoryUrl,
   workspacePathBreadcrumbs,
   type WorkspaceDirectoryEntry,
@@ -118,6 +119,10 @@ export const useWorkspaceFiles = (
     ) {
       snapshot.value.selectedPath = null
     }
+    snapshot.value.currentPath = fallbackWorkspacePathAfterRemoval(
+      snapshot.value.currentPath,
+      directoryPath
+    )
   }
 
   const reconcileRemovedDirectories = (

--- a/packages/client/app/composables/useWorkspaceFiles.ts
+++ b/packages/client/app/composables/useWorkspaceFiles.ts
@@ -1,0 +1,334 @@
+import { useRuntimeConfig, useState } from '#imports'
+import { computed, type ComputedRef, type Ref } from 'vue'
+import type { WorkspaceLocalFileScope } from '../../shared/local-files'
+import {
+  resolveWorkspaceDirectoryUrl,
+  workspacePathBreadcrumbs,
+  type WorkspaceDirectoryEntry,
+  type WorkspaceDirectoryListing,
+  type WorkspaceDirectoryResponse
+} from '../../shared/workspace-files'
+
+export type WorkspaceFileTreeNode = {
+  key: string
+  label: string
+  icon?: string
+  disabled?: boolean
+  entry?: WorkspaceDirectoryEntry
+  status?: 'loading' | 'empty' | 'error' | 'truncated'
+  children?: WorkspaceFileTreeNode[]
+}
+
+type WorkspaceFilesSnapshot = {
+  generation: number
+  listings: Record<string, WorkspaceDirectoryListing>
+  loadingPaths: string[]
+  errors: Record<string, string>
+  expandedPaths: string[]
+  selectedPath: string | null
+  currentPath: string
+  showIgnored: boolean
+}
+
+const createSnapshot = (): WorkspaceFilesSnapshot => ({
+  generation: 0,
+  listings: {},
+  loadingPaths: [],
+  errors: {},
+  expandedPaths: [],
+  selectedPath: null,
+  currentPath: '',
+  showIgnored: false
+})
+
+const scopeKeyFor = (workspace: WorkspaceLocalFileScope) => `${workspace.kind}:${workspace.id}`
+
+const iconForEntry = (entry: WorkspaceDirectoryEntry) => {
+  if (!entry.accessible) {
+    return entry.isSymlink ? 'i-lucide-link-2-off' : 'i-lucide-file-warning'
+  }
+  if (entry.kind === 'directory') {
+    return entry.isSymlink ? 'i-lucide-folder-symlink' : 'i-lucide-folder'
+  }
+  if (entry.isSymlink) {
+    return 'i-lucide-file-symlink'
+  }
+  if (/\.(?:png|jpe?g|gif|webp|svg)$/iu.test(entry.name)) {
+    return 'i-lucide-image'
+  }
+  if (/\.(?:md|mdx)$/iu.test(entry.name)) {
+    return 'i-lucide-file-text'
+  }
+  if (/\.(?:js|jsx|ts|tsx|vue|css|scss|html|json|ya?ml|toml|rs|go|py|rb|java|kt|swift|sh)$/iu.test(entry.name)) {
+    return 'i-lucide-file-code-2'
+  }
+  return 'i-lucide-file'
+}
+
+const statusNode = (
+  directoryPath: string,
+  status: WorkspaceFileTreeNode['status'],
+  label: string
+): WorkspaceFileTreeNode => ({
+  key: `${directoryPath || 'root'}::__${status}`,
+  label,
+  status,
+  disabled: true,
+  icon: status === 'error'
+    ? 'i-lucide-triangle-alert'
+    : status === 'truncated'
+      ? 'i-lucide-list-end'
+      : status === 'loading'
+        ? 'i-lucide-loader-circle'
+        : 'i-lucide-folder-open'
+})
+
+export const useWorkspaceFiles = (
+  workspace: Ref<WorkspaceLocalFileScope> | ComputedRef<WorkspaceLocalFileScope>
+) => {
+  const runtimeConfig = useRuntimeConfig()
+  const snapshots = useState<Record<string, WorkspaceFilesSnapshot>>(
+    'codori-workspace-files',
+    () => ({})
+  )
+  const requestVersions = new Map<string, number>()
+  const scopeKey = computed(() => scopeKeyFor(workspace.value))
+
+  const ensureSnapshot = (key = scopeKey.value) => {
+    snapshots.value[key] ??= createSnapshot()
+    return snapshots.value[key]
+  }
+
+  const snapshot = computed(() => ensureSnapshot())
+
+  const removeDescendantState = (directoryPath: string) => {
+    const prefix = `${directoryPath}/`
+    for (const path of Object.keys(snapshot.value.listings)) {
+      if (path === directoryPath || path.startsWith(prefix)) {
+        delete snapshot.value.listings[path]
+        delete snapshot.value.errors[path]
+      }
+    }
+    snapshot.value.expandedPaths = snapshot.value.expandedPaths.filter(
+      path => path !== directoryPath && !path.startsWith(prefix)
+    )
+    if (
+      snapshot.value.selectedPath === directoryPath
+      || snapshot.value.selectedPath?.startsWith(prefix)
+    ) {
+      snapshot.value.selectedPath = null
+    }
+  }
+
+  const reconcileRemovedDirectories = (
+    previous: WorkspaceDirectoryListing | undefined,
+    next: WorkspaceDirectoryListing
+  ) => {
+    if (!previous) {
+      return
+    }
+
+    const nextEntries = new Map(next.entries.map(entry => [entry.path, entry]))
+    for (const entry of previous.entries) {
+      const nextEntry = nextEntries.get(entry.path)
+      if (!nextEntry) {
+        if (snapshot.value.selectedPath === entry.path) {
+          snapshot.value.selectedPath = null
+        }
+        if (entry.kind === 'directory') {
+          removeDescendantState(entry.path)
+        }
+        continue
+      }
+
+      if (
+        entry.kind === 'directory'
+        && (nextEntry.kind !== 'directory' || !nextEntry.accessible)
+      ) {
+        removeDescendantState(entry.path)
+      }
+    }
+  }
+
+  const loadDirectory = async (path: string, options: { force?: boolean } = {}) => {
+    const key = scopeKey.value
+    const targetSnapshot = ensureSnapshot(key)
+    if (targetSnapshot.listings[path] && !options.force) {
+      return targetSnapshot.listings[path]
+    }
+
+    const generation = targetSnapshot.generation
+    const requestKey = `${key}:${generation}:${path}`
+    const version = (requestVersions.get(requestKey) ?? 0) + 1
+    requestVersions.set(requestKey, version)
+    targetSnapshot.loadingPaths = Array.from(new Set([...targetSnapshot.loadingPaths, path]))
+    delete targetSnapshot.errors[path]
+    const requestedWorkspace = { ...workspace.value }
+
+    try {
+      const response = await $fetch<WorkspaceDirectoryResponse>(resolveWorkspaceDirectoryUrl({
+        workspace: requestedWorkspace,
+        path,
+        showIgnored: targetSnapshot.showIgnored,
+        configuredBase: String(runtimeConfig.public.serverBase ?? '')
+      }))
+
+      if (
+        scopeKey.value !== key
+        || requestVersions.get(requestKey) !== version
+        || ensureSnapshot(key).generation !== generation
+      ) {
+        return null
+      }
+
+      const activeSnapshot = ensureSnapshot(key)
+      reconcileRemovedDirectories(activeSnapshot.listings[path], response.directory)
+      activeSnapshot.listings[path] = response.directory
+      delete activeSnapshot.errors[path]
+      return response.directory
+    } catch (error) {
+      if (
+        scopeKey.value === key
+        && requestVersions.get(requestKey) === version
+        && ensureSnapshot(key).generation === generation
+      ) {
+        ensureSnapshot(key).errors[path] = error instanceof Error
+          ? error.message
+          : String(error)
+      }
+      return null
+    } finally {
+      if (
+        requestVersions.get(requestKey) === version
+        && ensureSnapshot(key).generation === generation
+      ) {
+        const activeSnapshot = ensureSnapshot(key)
+        activeSnapshot.loadingPaths = activeSnapshot.loadingPaths.filter(item => item !== path)
+      }
+    }
+  }
+
+  const childrenForDirectory = (directoryPath: string): WorkspaceFileTreeNode[] => {
+    if (snapshot.value.loadingPaths.includes(directoryPath)) {
+      return [statusNode(directoryPath, 'loading', 'Loading…')]
+    }
+
+    const error = snapshot.value.errors[directoryPath]
+    if (error) {
+      return [statusNode(directoryPath, 'error', error)]
+    }
+
+    const listing = snapshot.value.listings[directoryPath]
+    if (!listing) {
+      return [statusNode(directoryPath, 'loading', 'Expand to load')]
+    }
+
+    const nodes = listing.entries.map((entry): WorkspaceFileTreeNode => {
+      const node: WorkspaceFileTreeNode = {
+        key: entry.path,
+        label: entry.name,
+        entry,
+        icon: iconForEntry(entry),
+        disabled: !entry.accessible
+      }
+
+      if (entry.kind === 'directory' && entry.accessible) {
+        node.children = childrenForDirectory(entry.path)
+      }
+
+      return node
+    })
+
+    if (nodes.length === 0) {
+      nodes.push(statusNode(directoryPath, 'empty', 'This folder is empty.'))
+    }
+    if (listing.truncated) {
+      nodes.push(statusNode(
+        directoryPath,
+        'truncated',
+        `This directory is limited to ${listing.limit} entries.`
+      ))
+    }
+
+    return nodes
+  }
+
+  const treeItems = computed(() => childrenForDirectory(''))
+  const rootLoading = computed(() =>
+    snapshot.value.loadingPaths.includes('') && !snapshot.value.listings['']
+  )
+  const rootError = computed(() => snapshot.value.errors[''] ?? null)
+  const currentDirectoryError = computed(() =>
+    snapshot.value.currentPath
+      ? snapshot.value.errors[snapshot.value.currentPath] ?? null
+      : null
+  )
+  const breadcrumbs = computed(() => workspacePathBreadcrumbs(snapshot.value.currentPath))
+  const selectedEntry = computed(() => {
+    const selectedPath = snapshot.value.selectedPath
+    if (!selectedPath) {
+      return null
+    }
+    for (const listing of Object.values(snapshot.value.listings)) {
+      const entry = listing.entries.find(item => item.path === selectedPath)
+      if (entry) {
+        return entry
+      }
+    }
+    return null
+  })
+
+  const selectEntry = (entry: WorkspaceDirectoryEntry) => {
+    snapshot.value.selectedPath = entry.path
+    snapshot.value.currentPath = entry.kind === 'directory'
+      ? entry.path
+      : entry.path.includes('/')
+        ? entry.path.slice(0, entry.path.lastIndexOf('/'))
+        : ''
+  }
+
+  const navigateTo = (path: string) => {
+    snapshot.value.currentPath = path
+    snapshot.value.selectedPath = path || null
+    if (path) {
+      const segments = path.split('/')
+      snapshot.value.expandedPaths = Array.from(new Set([
+        ...snapshot.value.expandedPaths,
+        ...segments.map((_, index) => segments.slice(0, index + 1).join('/'))
+      ]))
+    }
+  }
+
+  const refreshCurrentDirectory = () => loadDirectory(snapshot.value.currentPath, { force: true })
+
+  const setShowIgnored = async (showIgnored: boolean) => {
+    if (snapshot.value.showIgnored === showIgnored) {
+      return
+    }
+
+    snapshot.value.showIgnored = showIgnored
+    snapshot.value.generation += 1
+    snapshot.value.listings = {}
+    snapshot.value.loadingPaths = []
+    snapshot.value.errors = {}
+    snapshot.value.expandedPaths = []
+    snapshot.value.selectedPath = null
+    snapshot.value.currentPath = ''
+    await loadDirectory('', { force: true })
+  }
+
+  return {
+    snapshot,
+    treeItems,
+    rootLoading,
+    rootError,
+    currentDirectoryError,
+    breadcrumbs,
+    selectedEntry,
+    loadDirectory,
+    selectEntry,
+    navigateTo,
+    refreshCurrentDirectory,
+    setShowIgnored
+  }
+}

--- a/packages/client/app/pages/projects/[...projectId]/index.vue
+++ b/packages/client/app/pages/projects/[...projectId]/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useRoute, useRouter } from '#imports'
 import { computed, onMounted } from 'vue'
+import WorkspaceFilesPanel from '../../../components/WorkspaceFilesPanel.vue'
 import { useProjects } from '../../../composables/useProjects'
 import { useThreadPanel } from '../../../composables/useThreadPanel'
 import WorkspaceTerminalToggle from '../../../components/WorkspaceTerminalToggle.vue'
@@ -47,6 +48,11 @@ onMounted(() => {
         >
           <template #right>
             <div class="flex items-center gap-2">
+              <WorkspaceFilesPanel
+                v-if="projectId"
+                :workspace="{ kind: 'project', id: projectId }"
+                :workspace-label="projectName"
+              />
               <UTooltip text="New thread">
                 <UButton
                   icon="i-lucide-plus"

--- a/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
+++ b/packages/client/app/pages/projects/[...projectId]/threads/[threadId].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useRoute, useRouter } from '#imports'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import WorkspaceFilesPanel from '../../../../components/WorkspaceFilesPanel.vue'
 import { useChatSession } from '../../../../composables/useChatSession'
 import { useProjects } from '../../../../composables/useProjects'
 import { useThreadSummaries } from '../../../../composables/useThreadSummaries'
@@ -271,6 +272,11 @@ watch(
           </template>
           <template #right>
             <div class="flex items-center gap-1.5 lg:gap-2">
+              <WorkspaceFilesPanel
+                v-if="projectId"
+                :workspace="{ kind: 'project', id: projectId }"
+                :workspace-label="projectName"
+              />
               <UTooltip text="New thread">
                 <UButton
                   icon="i-lucide-plus"

--- a/packages/client/server/api/codori/chats/[chatId]/files.get.ts
+++ b/packages/client/server/api/codori/chats/[chatId]/files.get.ts
@@ -1,0 +1,39 @@
+import {
+  createError,
+  defineEventHandler,
+  getQuery,
+  getRouterParam
+} from 'h3'
+import { encodeChatIdSegment } from '~~/shared/codori'
+import type { WorkspaceDirectoryResponse } from '~~/shared/workspace-files'
+import { proxyServerRequest } from '../../../../utils/server-proxy'
+
+export default defineEventHandler(async (event) => {
+  const chatId = getRouterParam(event, 'chatId')
+  if (!chatId) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Missing chat id.'
+    })
+  }
+
+  const query = getQuery(event)
+  const path = typeof query.path === 'string' ? query.path : ''
+  const params = new URLSearchParams({ path })
+  if (query.showIgnored === 'true') {
+    params.set('showIgnored', 'true')
+  }
+
+  try {
+    return await proxyServerRequest<WorkspaceDirectoryResponse>(
+      event,
+      `/api/chats/${encodeChatIdSegment(chatId)}/files?${params.toString()}`
+    )
+  } catch (error) {
+    const details = error as { statusCode?: number, statusMessage?: string }
+    throw createError({
+      statusCode: details.statusCode ?? 500,
+      statusMessage: details.statusMessage ?? 'Workspace directory listing failed.'
+    })
+  }
+})

--- a/packages/client/server/api/codori/projects/[projectId]/files.get.ts
+++ b/packages/client/server/api/codori/projects/[projectId]/files.get.ts
@@ -1,0 +1,39 @@
+import {
+  createError,
+  defineEventHandler,
+  getQuery,
+  getRouterParam
+} from 'h3'
+import { encodeProjectIdSegment } from '~~/shared/codori'
+import type { WorkspaceDirectoryResponse } from '~~/shared/workspace-files'
+import { proxyServerRequest } from '../../../../utils/server-proxy'
+
+export default defineEventHandler(async (event) => {
+  const projectId = getRouterParam(event, 'projectId')
+  if (!projectId) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Missing project id.'
+    })
+  }
+
+  const query = getQuery(event)
+  const path = typeof query.path === 'string' ? query.path : ''
+  const params = new URLSearchParams({ path })
+  if (query.showIgnored === 'true') {
+    params.set('showIgnored', 'true')
+  }
+
+  try {
+    return await proxyServerRequest<WorkspaceDirectoryResponse>(
+      event,
+      `/api/projects/${encodeProjectIdSegment(projectId)}/files?${params.toString()}`
+    )
+  } catch (error) {
+    const details = error as { statusCode?: number, statusMessage?: string }
+    throw createError({
+      statusCode: details.statusCode ?? 500,
+      statusMessage: details.statusMessage ?? 'Workspace directory listing failed.'
+    })
+  }
+})

--- a/packages/client/shared/workspace-files.ts
+++ b/packages/client/shared/workspace-files.ts
@@ -1,0 +1,66 @@
+import { encodeChatIdSegment, encodeProjectIdSegment } from './codori'
+import type { WorkspaceLocalFileScope } from './local-files'
+import { resolveApiUrl, shouldUseServerProxy } from './network'
+
+export type WorkspaceDirectoryEntryErrorCode =
+  | 'FORBIDDEN'
+  | 'NOT_FOUND'
+  | 'PERMISSION_DENIED'
+  | 'UNSUPPORTED'
+
+export type WorkspaceDirectoryEntry = {
+  name: string
+  path: string
+  kind: 'directory' | 'file' | 'other'
+  size: number | null
+  updatedAt: number | null
+  isSymlink: boolean
+  accessible: boolean
+  hidden: boolean
+  ignored: boolean
+  errorCode?: WorkspaceDirectoryEntryErrorCode
+}
+
+export type WorkspaceDirectoryListing = {
+  path: string
+  entries: WorkspaceDirectoryEntry[]
+  truncated: boolean
+  limit: number
+}
+
+export type WorkspaceDirectoryResponse = {
+  directory: WorkspaceDirectoryListing
+}
+
+export const resolveWorkspaceDirectoryUrl = (input: {
+  workspace: WorkspaceLocalFileScope
+  path: string
+  showIgnored: boolean
+  configuredBase?: string | null
+}) => {
+  const query = new URLSearchParams({ path: input.path })
+  if (input.showIgnored) {
+    query.set('showIgnored', 'true')
+  }
+
+  const requestPath = input.workspace.kind === 'chat'
+    ? `/chats/${encodeChatIdSegment(input.workspace.id)}/files?${query.toString()}`
+    : `/projects/${encodeProjectIdSegment(input.workspace.id)}/files?${query.toString()}`
+
+  if (shouldUseServerProxy(input.configuredBase)) {
+    return `/api/codori${requestPath}`
+  }
+
+  return resolveApiUrl(requestPath, input.configuredBase)
+}
+
+export const workspacePathBreadcrumbs = (path: string) => {
+  const segments = path ? path.split('/') : []
+  return [
+    { label: 'Workspace', path: '' },
+    ...segments.map((label, index) => ({
+      label,
+      path: segments.slice(0, index + 1).join('/')
+    }))
+  ]
+}

--- a/packages/client/shared/workspace-files.ts
+++ b/packages/client/shared/workspace-files.ts
@@ -64,3 +64,19 @@ export const workspacePathBreadcrumbs = (path: string) => {
     }))
   ]
 }
+
+export const fallbackWorkspacePathAfterRemoval = (
+  currentPath: string,
+  removedDirectoryPath: string
+) => {
+  if (
+    currentPath !== removedDirectoryPath
+    && !currentPath.startsWith(`${removedDirectoryPath}/`)
+  ) {
+    return currentPath
+  }
+
+  return removedDirectoryPath.includes('/')
+    ? removedDirectoryPath.slice(0, removedDirectoryPath.lastIndexOf('/'))
+    : ''
+}

--- a/packages/client/test/workspace-files-panel.test.ts
+++ b/packages/client/test/workspace-files-panel.test.ts
@@ -1,0 +1,392 @@
+/* eslint-disable vue/one-component-per-file */
+// @vitest-environment jsdom
+
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent, h, nextTick, type VNode } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import WorkspaceFilesPanel from '../app/components/WorkspaceFilesPanel.vue'
+import { useLocalFileViewer } from '../app/composables/useLocalFileViewer'
+import { useState } from '#imports'
+import type { WorkspaceFileTreeNode } from '../app/composables/useWorkspaceFiles'
+import type { WorkspaceLocalFileScope } from '../shared/local-files'
+
+const fetchMock = vi.fn()
+const clipboardWriteMock = vi.fn()
+
+const PassThroughStub = defineComponent({
+  setup(_, { slots }) {
+    return () => h('div', slots.default?.())
+  }
+})
+
+const ButtonStub = defineComponent({
+  inheritAttrs: false,
+  props: {
+    label: { type: String, default: '' },
+    disabled: { type: Boolean, default: false }
+  },
+  setup(props, { attrs, slots }) {
+    return () => h('button', {
+      ...attrs,
+      disabled: props.disabled
+    }, slots.default?.() ?? props.label)
+  }
+})
+
+const SlideoverStub = defineComponent({
+  props: {
+    open: { type: Boolean, default: false }
+  },
+  setup(props, { slots }) {
+    return () => props.open
+      ? h('div', { class: 'slideover-stub' }, [
+          slots.actions?.(),
+          slots.body?.(),
+          slots.footer?.()
+        ])
+      : null
+  }
+})
+
+const CheckboxStub = defineComponent({
+  props: {
+    modelValue: { type: Boolean, default: false },
+    label: { type: String, default: '' }
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () => h('label', [
+      h('input', {
+        type: 'checkbox',
+        checked: props.modelValue,
+        onChange: () => emit('update:modelValue', !props.modelValue)
+      }),
+      props.label
+    ])
+  }
+})
+
+const BreadcrumbStub = defineComponent({
+  props: {
+    items: { type: Array, default: () => [] }
+  },
+  setup(props, { slots }) {
+    return () => h('nav', (props.items as Array<Record<string, unknown>>).map(item =>
+      slots.item?.({ item })
+    ))
+  }
+})
+
+const TreeStub = defineComponent({
+  inheritAttrs: false,
+  props: {
+    items: { type: Array, default: () => [] },
+    expanded: { type: Array, default: () => [] },
+    onToggle: { type: Function, default: undefined },
+    onSelect: { type: Function, default: undefined }
+  },
+  setup(props, { attrs, slots }) {
+    const renderNodes = (nodes: WorkspaceFileTreeNode[]): VNode[] => nodes.map(node => {
+      const expanded = (props.expanded as string[]).includes(node.key)
+      const label = slots['item-label']?.({ item: node }) ?? node.label
+      const children: VNode[] = expanded && node.children
+        ? renderNodes(node.children)
+        : []
+
+      return h('div', { key: node.key }, [
+        h('button', {
+          'data-tree-path': node.key,
+          disabled: node.disabled,
+          onClick: () => {
+            if (node.entry?.kind === 'directory') {
+              props.onToggle?.({ detail: { isExpanded: expanded } }, node)
+              const updateExpanded = attrs['onUpdate:expanded'] as ((paths: string[]) => void) | undefined
+              updateExpanded?.(
+                expanded
+                  ? (props.expanded as string[]).filter(path => path !== node.key)
+                  : [...props.expanded as string[], node.key]
+              )
+            }
+            props.onSelect?.(new Event('select'), node)
+          }
+        }, label),
+        ...children
+      ])
+    })
+
+    return () => h('div', { class: 'tree-stub' }, renderNodes(props.items as WorkspaceFileTreeNode[]))
+  }
+})
+
+const AlertStub = defineComponent({
+  props: {
+    title: { type: String, default: '' },
+    description: { type: String, default: '' }
+  },
+  setup(props) {
+    return () => h('div', `${props.title} ${props.description}`)
+  }
+})
+
+const mountPanel = (workspace: WorkspaceLocalFileScope = { kind: 'project', id: 'demo' }) =>
+  mount(WorkspaceFilesPanel, {
+    props: {
+      workspace,
+      workspaceLabel: workspace.kind === 'project' ? 'demo' : 'Scratch chat'
+    },
+    global: {
+      stubs: {
+        UTooltip: PassThroughStub,
+        UButton: ButtonStub,
+        USlideover: SlideoverStub,
+        UCheckbox: CheckboxStub,
+        UBreadcrumb: BreadcrumbStub,
+        UScrollArea: PassThroughStub,
+        USkeleton: PassThroughStub,
+        UTree: TreeStub,
+        UAlert: AlertStub,
+        UBadge: PassThroughStub
+      }
+    }
+  })
+
+const directoryResponse = (
+  path: string,
+  entries: Array<Record<string, unknown>>,
+  truncated = false
+) => ({
+  directory: {
+    path,
+    entries,
+    truncated,
+    limit: 200
+  }
+})
+
+const entry = (input: Partial<Record<string, unknown>> & { name: string, path: string }) => ({
+  kind: 'file',
+  size: 5,
+  updatedAt: 1,
+  isSymlink: false,
+  accessible: true,
+  hidden: false,
+  ignored: false,
+  ...input
+})
+
+describe('WorkspaceFilesPanel', () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    clipboardWriteMock.mockReset()
+    vi.stubGlobal('$fetch', fetchMock)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: clipboardWriteMock }
+    })
+    useState<Record<string, unknown>>('codori-workspace-files', () => ({})).value = {}
+    const { state } = useLocalFileViewer()
+    state.value = {
+      open: false,
+      workspace: null,
+      projectId: null,
+      path: null,
+      line: null,
+      column: null
+    }
+  })
+
+  it('loads directories lazily and opens selected files in the existing viewer', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      const parsed = new URL(url, 'http://localhost')
+      const path = parsed.searchParams.get('path') ?? ''
+      return path === 'src'
+        ? Promise.resolve(directoryResponse('src', [entry({ name: 'app.ts', path: 'src/app.ts' })]))
+        : Promise.resolve(directoryResponse('', [
+            entry({ name: 'src', path: 'src', kind: 'directory', size: null }),
+            entry({ name: 'README.md', path: 'README.md' })
+          ]))
+    })
+
+    const wrapper = mountPanel()
+    await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(new URL(fetchMock.mock.calls[0]?.[0], 'http://localhost').searchParams.get('path')).toBe('')
+    expect(wrapper.find('[data-tree-path="src/app.ts"]').exists()).toBe(false)
+
+    await wrapper.get('[data-tree-path="src"]').trigger('click')
+    await flushPromises()
+    await nextTick()
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(new URL(fetchMock.mock.calls[1]?.[0], 'http://localhost').searchParams.get('path')).toBe('src')
+    const slideover = wrapper.findComponent(SlideoverStub)
+    await wrapper.get('[data-tree-path="src/app.ts"]').trigger('click')
+    await flushPromises()
+
+    const { state } = useLocalFileViewer()
+    expect(state.value.open).toBe(false)
+    slideover.vm.$emit('after:leave')
+    await flushPromises()
+    expect(state.value).toMatchObject({
+      open: true,
+      workspace: { kind: 'project', id: 'demo' },
+      path: 'src/app.ts'
+    })
+    expect(wrapper.find('.slideover-stub').exists()).toBe(false)
+  })
+
+  it('refreshes the active directory and copies its relative path', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      const path = new URL(url, 'http://localhost').searchParams.get('path') ?? ''
+      return Promise.resolve(path === 'src'
+        ? directoryResponse('src', [])
+        : directoryResponse('', [entry({ name: 'src', path: 'src', kind: 'directory', size: null })]))
+    })
+    clipboardWriteMock.mockResolvedValue(undefined)
+
+    const wrapper = mountPanel()
+    await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-tree-path="src"]').trigger('click')
+    await flushPromises()
+
+    await wrapper.get('[aria-label="Copy relative path"]').trigger('click')
+    await flushPromises()
+    expect(clipboardWriteMock).toHaveBeenCalledWith('src')
+    expect(wrapper.text()).toContain('Copied src')
+
+    await wrapper.get('[aria-label="Refresh current folder"]').trigger('click')
+    await flushPromises()
+    expect(fetchMock.mock.calls.filter(([url]) =>
+      new URL(url, 'http://localhost').searchParams.get('path') === 'src'
+    )).toHaveLength(2)
+  })
+
+  it('shows truncation and reloads with generated folders enabled', async () => {
+    fetchMock.mockResolvedValue(directoryResponse('', [
+      entry({ name: 'README.md', path: 'README.md' })
+    ], true))
+
+    const wrapper = mountPanel({ kind: 'chat', id: 'chat-test' })
+    await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('This directory is limited to 200 entries.')
+
+    await wrapper.get('input[type="checkbox"]').setValue(true)
+    await flushPromises()
+    const secondUrl = new URL(fetchMock.mock.calls[1]?.[0], 'http://localhost')
+    expect(secondUrl.pathname).toBe('/api/chats/chat-test/files')
+    expect(secondUrl.searchParams.get('showIgnored')).toBe('true')
+  })
+
+  it('keeps root errors visible and recoverable', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('Permission denied'))
+      .mockResolvedValueOnce(directoryResponse('', []))
+
+    const wrapper = mountPanel()
+    await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('Could not load workspace files')
+    expect(wrapper.text()).toContain('Permission denied')
+
+    const retry = wrapper.findAll('button').find(button => button.text() === 'Retry')
+    expect(retry).toBeDefined()
+    await retry?.trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('This folder is empty.')
+  })
+
+  it('shows a recoverable nested-directory error', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      const path = new URL(url, 'http://localhost').searchParams.get('path') ?? ''
+      if (path === 'src' && fetchMock.mock.calls.filter(([calledUrl]) =>
+        new URL(calledUrl, 'http://localhost').searchParams.get('path') === 'src'
+      ).length === 1) {
+        return Promise.reject(new Error('Folder disappeared'))
+      }
+      return Promise.resolve(path === 'src'
+        ? directoryResponse('src', [])
+        : directoryResponse('', [entry({ name: 'src', path: 'src', kind: 'directory', size: null })]))
+    })
+
+    const wrapper = mountPanel()
+    await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-tree-path="src"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('Could not load folder')
+    expect(wrapper.text()).toContain('Folder disappeared')
+
+    const retry = wrapper.findAll('button').find(button => button.text() === 'Retry folder')
+    expect(retry).toBeDefined()
+    await retry?.trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('This folder is empty.')
+  })
+
+  it('invalidates pending nested requests when the generated-folder policy changes', async () => {
+    let resolveOldRequest!: (value: ReturnType<typeof directoryResponse>) => void
+    const oldRequest = new Promise<ReturnType<typeof directoryResponse>>((resolve) => {
+      resolveOldRequest = resolve
+    })
+    fetchMock.mockImplementation((url: string) => {
+      const parsed = new URL(url, 'http://localhost')
+      const path = parsed.searchParams.get('path') ?? ''
+      if (path === 'src' && parsed.searchParams.get('showIgnored') !== 'true') {
+        return oldRequest
+      }
+      if (path === 'src') {
+        return Promise.resolve(directoryResponse('src', [entry({ name: 'fresh.ts', path: 'src/fresh.ts' })]))
+      }
+      return Promise.resolve(directoryResponse('', [
+        entry({ name: 'src', path: 'src', kind: 'directory', size: null })
+      ]))
+    })
+
+    const wrapper = mountPanel()
+    await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-tree-path="src"]').trigger('click')
+    await wrapper.get('input[type="checkbox"]').setValue(true)
+    await flushPromises()
+    resolveOldRequest(directoryResponse('src', [entry({ name: 'stale.ts', path: 'src/stale.ts' })]))
+    await flushPromises()
+    expect(wrapper.find('[data-tree-path="src/stale.ts"]').exists()).toBe(false)
+
+    await wrapper.get('[data-tree-path="src"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-tree-path="src/fresh.ts"]').exists()).toBe(true)
+  })
+
+  it('does not leak stale directory results across workspace switches', async () => {
+    let resolveProjectRequest!: (value: ReturnType<typeof directoryResponse>) => void
+    const projectRequest = new Promise<ReturnType<typeof directoryResponse>>((resolve) => {
+      resolveProjectRequest = resolve
+    })
+    fetchMock.mockImplementation((url: string) => {
+      const parsed = new URL(url, 'http://localhost')
+      return parsed.pathname.includes('/projects/')
+        ? projectRequest
+        : Promise.resolve(directoryResponse('', [entry({ name: 'chat.txt', path: 'chat.txt' })]))
+    })
+
+    const wrapper = mountPanel()
+    await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
+    await wrapper.setProps({
+      workspace: { kind: 'chat', id: 'chat-test' },
+      workspaceLabel: 'Scratch chat'
+    })
+    await nextTick()
+    await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-tree-path="chat.txt"]').exists()).toBe(true)
+
+    resolveProjectRequest(directoryResponse('', [entry({ name: 'project.txt', path: 'project.txt' })]))
+    await flushPromises()
+    expect(wrapper.find('[data-tree-path="chat.txt"]').exists()).toBe(true)
+    expect(wrapper.find('[data-tree-path="project.txt"]').exists()).toBe(false)
+  })
+})

--- a/packages/client/test/workspace-files-panel.test.ts
+++ b/packages/client/test/workspace-files-panel.test.ts
@@ -2,11 +2,14 @@
 // @vitest-environment jsdom
 
 import { flushPromises, mount } from '@vue/test-utils'
-import { defineComponent, h, nextTick, type VNode } from 'vue'
+import { defineComponent, h, nextTick, ref, type VNode } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import WorkspaceFilesPanel from '../app/components/WorkspaceFilesPanel.vue'
 import { useState } from '#imports'
-import type { WorkspaceFileTreeNode } from '../app/composables/useWorkspaceFiles'
+import {
+  useWorkspaceFiles,
+  type WorkspaceFileTreeNode
+} from '../app/composables/useWorkspaceFiles'
 import type { WorkspaceLocalFileScope } from '../shared/local-files'
 
 const fetchMock = vi.fn()
@@ -34,7 +37,8 @@ const ButtonStub = defineComponent({
 
 const ModalStub = defineComponent({
   props: {
-    open: { type: Boolean, default: false }
+    open: { type: Boolean, default: false },
+    description: { type: String, default: undefined }
   },
   setup(props, { slots }) {
     return () => props.open
@@ -69,24 +73,6 @@ const IconStub = defineComponent({
       ...attrs,
       'data-icon': props.name
     })
-  }
-})
-
-const CheckboxStub = defineComponent({
-  props: {
-    modelValue: { type: Boolean, default: false },
-    label: { type: String, default: '' }
-  },
-  emits: ['update:modelValue'],
-  setup(props, { emit }) {
-    return () => h('label', [
-      h('input', {
-        type: 'checkbox',
-        checked: props.modelValue,
-        onChange: () => emit('update:modelValue', !props.modelValue)
-      }),
-      props.label
-    ])
   }
 })
 
@@ -164,7 +150,6 @@ const mountPanel = (workspace: WorkspaceLocalFileScope = { kind: 'project', id: 
         UTooltip: PassThroughStub,
         UButton: ButtonStub,
         UModal: ModalStub,
-        UCheckbox: CheckboxStub,
         UBreadcrumb: BreadcrumbStub,
         UScrollArea: PassThroughStub,
         USkeleton: PassThroughStub,
@@ -273,6 +258,7 @@ describe('WorkspaceFilesPanel', () => {
     expect(wrapper.text()).toContain('Select a file from the tree to preview it.')
     expect(wrapper.find('[data-preview-path]').exists()).toBe(false)
     expect(wrapper.get('[data-icon="i-lucide-file-search-2"]').classes()).toContain('text-muted/45')
+    expect(wrapper.findComponent(ModalStub).props('description')).toBeUndefined()
   })
 
   it('refreshes the active directory and copies its relative path', async () => {
@@ -290,12 +276,16 @@ describe('WorkspaceFilesPanel', () => {
     await wrapper.get('[data-tree-path="src"]').trigger('click')
     await flushPromises()
 
-    await wrapper.get('[aria-label="Copy relative path"]').trigger('click')
+    const treeActions = wrapper.get('[aria-label="File tree actions"]')
+    expect(treeActions.find('[aria-label="Refresh current folder"]').exists()).toBe(true)
+    expect(treeActions.find('[aria-label="Copy relative path"]').exists()).toBe(true)
+
+    await treeActions.get('[aria-label="Copy relative path"]').trigger('click')
     await flushPromises()
     expect(clipboardWriteMock).toHaveBeenCalledWith('src')
     expect(wrapper.text()).toContain('Copied src')
 
-    await wrapper.get('[aria-label="Refresh current folder"]').trigger('click')
+    await treeActions.get('[aria-label="Refresh current folder"]').trigger('click')
     await flushPromises()
     expect(fetchMock.mock.calls.filter(([url]) =>
       new URL(url, 'http://localhost').searchParams.get('path') === 'src'
@@ -321,7 +311,7 @@ describe('WorkspaceFilesPanel', () => {
     expect(wrapper.text()).toContain('Could not copy the relative path.')
   })
 
-  it('shows truncation and reloads with generated folders enabled', async () => {
+  it('shows truncation without exposing generated-folder controls', async () => {
     fetchMock.mockResolvedValue(directoryResponse('', [
       entry({ name: 'README.md', path: 'README.md' })
     ], true))
@@ -330,12 +320,11 @@ describe('WorkspaceFilesPanel', () => {
     await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
     await flushPromises()
     expect(wrapper.text()).toContain('This directory is limited to 200 entries.')
-
-    await wrapper.get('input[type="checkbox"]').setValue(true)
-    await flushPromises()
-    const secondUrl = new URL(fetchMock.mock.calls[1]?.[0], 'http://localhost')
-    expect(secondUrl.pathname).toBe('/api/chats/chat-test/files')
-    expect(secondUrl.searchParams.get('showIgnored')).toBe('true')
+    expect(wrapper.text()).not.toContain('Show generated folders')
+    expect(wrapper.find('input[type="checkbox"]').exists()).toBe(false)
+    const initialUrl = new URL(fetchMock.mock.calls[0]?.[0], 'http://localhost')
+    expect(initialUrl.pathname).toBe('/api/chats/chat-test/files')
+    expect(initialUrl.searchParams.has('showIgnored')).toBe(false)
   })
 
   it('keeps root errors visible and recoverable', async () => {
@@ -403,20 +392,20 @@ describe('WorkspaceFilesPanel', () => {
       ]))
     })
 
-    const wrapper = mountPanel()
-    await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
-    await flushPromises()
-    await wrapper.get('[data-tree-path="src"]').trigger('click')
-    await wrapper.get('input[type="checkbox"]').setValue(true)
-    await flushPromises()
-    expect(wrapper.find('[data-tree-path="src/fresh.ts"]').exists()).toBe(true)
-    await wrapper.get('[aria-label="Copy relative path"]').trigger('click')
-    await flushPromises()
-    expect(clipboardWriteMock).toHaveBeenCalledWith('src')
+    const files = useWorkspaceFiles(ref<WorkspaceLocalFileScope>({ kind: 'project', id: 'demo' }))
+    await files.loadDirectory('')
+    const src = files.snapshot.value.listings['']?.entries[0]
+    expect(src).toBeDefined()
+    files.selectEntry(src!)
+    files.snapshot.value.expandedPaths = ['src']
+    const pendingOldRequest = files.loadDirectory('src')
+    await files.setShowIgnored(true)
+
+    expect(files.snapshot.value.listings.src?.entries.map(item => item.path)).toEqual(['src/fresh.ts'])
     resolveOldRequest(directoryResponse('src', [entry({ name: 'stale.ts', path: 'src/stale.ts' })]))
+    await pendingOldRequest
     await flushPromises()
-    expect(wrapper.find('[data-tree-path="src/stale.ts"]').exists()).toBe(false)
-    expect(wrapper.find('[data-tree-path="src/fresh.ts"]').exists()).toBe(true)
+    expect(files.snapshot.value.listings.src?.entries.map(item => item.path)).toEqual(['src/fresh.ts'])
   })
 
   it('does not restore filter state into a workspace selected during reload', async () => {
@@ -424,21 +413,6 @@ describe('WorkspaceFilesPanel', () => {
     const filteredRoot = new Promise<ReturnType<typeof directoryResponse>>((resolve) => {
       resolveFilteredRoot = resolve
     })
-    const snapshots = useState<Record<string, unknown>>('codori-workspace-files', () => ({}))
-    snapshots.value['chat:chat-test'] = {
-      generation: 1,
-      listings: {
-        '': directoryResponse('', [
-          entry({ name: 'src', path: 'src', kind: 'directory', size: null })
-        ]).directory
-      },
-      loadingPaths: [],
-      errors: {},
-      expandedPaths: [],
-      selectedPath: null,
-      currentPath: '',
-      showIgnored: false
-    }
     fetchMock.mockImplementation((url: string) => {
       const parsed = new URL(url, 'http://localhost')
       const path = parsed.searchParams.get('path') ?? ''
@@ -450,19 +424,20 @@ describe('WorkspaceFilesPanel', () => {
         : directoryResponse('', [entry({ name: 'src', path: 'src', kind: 'directory', size: null })]))
     })
 
-    const wrapper = mountPanel()
-    await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
-    await flushPromises()
-    await wrapper.get('[data-tree-path="src"]').trigger('click')
-    await flushPromises()
-    await wrapper.get('input[type="checkbox"]').setValue(true)
-    await wrapper.setProps({
-      workspace: { kind: 'chat', id: 'chat-test' },
-      workspaceLabel: 'Scratch chat'
-    })
+    const workspace = ref<WorkspaceLocalFileScope>({ kind: 'project', id: 'demo' })
+    const files = useWorkspaceFiles(workspace)
+    await files.loadDirectory('')
+    const src = files.snapshot.value.listings['']?.entries[0]
+    expect(src).toBeDefined()
+    files.selectEntry(src!)
+    files.snapshot.value.expandedPaths = ['src']
+    await files.loadDirectory('src')
+    const filterReload = files.setShowIgnored(true)
+    workspace.value = { kind: 'chat', id: 'chat-test' }
     resolveFilteredRoot(directoryResponse('', [
       entry({ name: 'src', path: 'src', kind: 'directory', size: null })
     ]))
+    await filterReload
     await flushPromises()
 
     expect(fetchMock.mock.calls.some(([url]) => {
@@ -488,23 +463,26 @@ describe('WorkspaceFilesPanel', () => {
         : directoryResponse('', [entry({ name: 'src', path: 'src', kind: 'directory', size: null })]))
     })
 
-    const wrapper = mountPanel()
-    await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
-    await flushPromises()
-    await wrapper.get('[data-tree-path="src"]').trigger('click')
-    await flushPromises()
-    await wrapper.get('input[type="checkbox"]').setValue(true)
-    await flushPromises()
-    expect(wrapper.text()).toContain('Could not load workspace files')
-    expect(wrapper.get('[aria-label="Copy relative path"]').attributes('disabled')).toBeDefined()
+    const files = useWorkspaceFiles(ref<WorkspaceLocalFileScope>({ kind: 'project', id: 'demo' }))
+    await files.loadDirectory('')
+    const src = files.snapshot.value.listings['']?.entries[0]
+    expect(src).toBeDefined()
+    files.selectEntry(src!)
+    files.snapshot.value.expandedPaths = ['src']
+    await files.loadDirectory('src')
 
-    const retry = wrapper.findAll('button').find(button => button.text() === 'Retry')
-    await retry?.trigger('click')
-    await flushPromises()
-    expect(wrapper.find('[data-tree-path="src/fresh.ts"]').exists()).toBe(false)
-    await wrapper.get('[data-tree-path="src"]').trigger('click')
-    await flushPromises()
-    expect(wrapper.find('[data-tree-path="src/fresh.ts"]').exists()).toBe(true)
+    await files.setShowIgnored(true)
+    expect(files.rootError.value).toBe('Root unavailable')
+    expect(files.snapshot.value.currentPath).toBe('')
+    expect(files.snapshot.value.selectedPath).toBeNull()
+
+    await files.loadDirectory('', { force: true })
+    expect(files.snapshot.value.listings.src).toBeUndefined()
+    const restoredSrc = files.snapshot.value.listings['']?.entries[0]
+    expect(restoredSrc).toBeDefined()
+    files.selectEntry(restoredSrc!)
+    await files.loadDirectory('src')
+    expect(files.snapshot.value.listings.src?.entries.map(item => item.path)).toEqual(['src/fresh.ts'])
   })
 
   it('does not leak stale directory results across workspace switches', async () => {

--- a/packages/client/test/workspace-files-panel.test.ts
+++ b/packages/client/test/workspace-files-panel.test.ts
@@ -5,7 +5,6 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { defineComponent, h, nextTick, type VNode } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import WorkspaceFilesPanel from '../app/components/WorkspaceFilesPanel.vue'
-import { useLocalFileViewer } from '../app/composables/useLocalFileViewer'
 import { useState } from '#imports'
 import type { WorkspaceFileTreeNode } from '../app/composables/useWorkspaceFiles'
 import type { WorkspaceLocalFileScope } from '../shared/local-files'
@@ -33,18 +32,43 @@ const ButtonStub = defineComponent({
   }
 })
 
-const SlideoverStub = defineComponent({
+const ModalStub = defineComponent({
   props: {
     open: { type: Boolean, default: false }
   },
   setup(props, { slots }) {
     return () => props.open
-      ? h('div', { class: 'slideover-stub' }, [
+      ? h('div', { class: 'modal-stub' }, [
           slots.actions?.(),
           slots.body?.(),
           slots.footer?.()
         ])
       : null
+  }
+})
+
+const LocalFilePreviewStub = defineComponent({
+  name: 'LocalFilePreview',
+  props: {
+    path: { type: String, required: true }
+  },
+  setup(props) {
+    return () => h('div', {
+      'data-preview-path': props.path
+    })
+  }
+})
+
+const IconStub = defineComponent({
+  inheritAttrs: false,
+  props: {
+    name: { type: String, required: true }
+  },
+  setup(props, { attrs }) {
+    return () => h('span', {
+      ...attrs,
+      'data-icon': props.name
+    })
   }
 })
 
@@ -139,14 +163,16 @@ const mountPanel = (workspace: WorkspaceLocalFileScope = { kind: 'project', id: 
       stubs: {
         UTooltip: PassThroughStub,
         UButton: ButtonStub,
-        USlideover: SlideoverStub,
+        UModal: ModalStub,
         UCheckbox: CheckboxStub,
         UBreadcrumb: BreadcrumbStub,
         UScrollArea: PassThroughStub,
         USkeleton: PassThroughStub,
         UTree: TreeStub,
         UAlert: AlertStub,
-        UBadge: PassThroughStub
+        UBadge: PassThroughStub,
+        UIcon: IconStub,
+        LocalFilePreview: LocalFilePreviewStub
       }
     }
   })
@@ -185,15 +211,6 @@ describe('WorkspaceFilesPanel', () => {
       value: { writeText: clipboardWriteMock }
     })
     useState<Record<string, unknown>>('codori-workspace-files', () => ({})).value = {}
-    const { state } = useLocalFileViewer()
-    state.value = {
-      open: false,
-      workspace: null,
-      projectId: null,
-      path: null,
-      line: null,
-      column: null
-    }
   })
 
   it('keeps tree rows and labels left aligned beside their icons', async () => {
@@ -211,7 +228,7 @@ describe('WorkspaceFilesPanel', () => {
     })
   })
 
-  it('loads directories lazily and opens selected files in the existing viewer', async () => {
+  it('loads directories lazily and previews selected files without closing the explorer', async () => {
     fetchMock.mockImplementation((url: string) => {
       const parsed = new URL(url, 'http://localhost')
       const path = parsed.searchParams.get('path') ?? ''
@@ -237,20 +254,25 @@ describe('WorkspaceFilesPanel', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(new URL(fetchMock.mock.calls[1]?.[0], 'http://localhost').searchParams.get('path')).toBe('src')
-    const slideover = wrapper.findComponent(SlideoverStub)
     await wrapper.get('[data-tree-path="src/app.ts"]').trigger('click')
     await flushPromises()
 
-    const { state } = useLocalFileViewer()
-    expect(state.value.open).toBe(false)
-    slideover.vm.$emit('after:leave')
+    expect(wrapper.find('.modal-stub').exists()).toBe(true)
+    expect(wrapper.get('[data-preview-path="src/app.ts"]').attributes('data-preview-path')).toBe('src/app.ts')
+  })
+
+  it('shows an empty preview prompt until a file is selected', async () => {
+    fetchMock.mockResolvedValue(directoryResponse('', [
+      entry({ name: 'README.md', path: 'README.md' })
+    ]))
+
+    const wrapper = mountPanel()
+    await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
     await flushPromises()
-    expect(state.value).toMatchObject({
-      open: true,
-      workspace: { kind: 'project', id: 'demo' },
-      path: 'src/app.ts'
-    })
-    expect(wrapper.find('.slideover-stub').exists()).toBe(false)
+
+    expect(wrapper.text()).toContain('Select a file from the tree to preview it.')
+    expect(wrapper.find('[data-preview-path]').exists()).toBe(false)
+    expect(wrapper.get('[data-icon="i-lucide-file-search-2"]').classes()).toContain('text-muted/45')
   })
 
   it('refreshes the active directory and copies its relative path', async () => {
@@ -293,8 +315,6 @@ describe('WorkspaceFilesPanel', () => {
     await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
     await flushPromises()
     await wrapper.get('[data-tree-path="README.md"]').trigger('click')
-    await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
-    await flushPromises()
     await wrapper.get('[aria-label="Copy relative path"]').trigger('click')
     await flushPromises()
 

--- a/packages/client/test/workspace-files-panel.test.ts
+++ b/packages/client/test/workspace-files-panel.test.ts
@@ -264,6 +264,27 @@ describe('WorkspaceFilesPanel', () => {
     )).toHaveLength(2)
   })
 
+  it('reports clipboard failure when the Clipboard API is unavailable', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: undefined
+    })
+    fetchMock.mockResolvedValue(directoryResponse('', [
+      entry({ name: 'README.md', path: 'README.md' })
+    ]))
+
+    const wrapper = mountPanel()
+    await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-tree-path="README.md"]').trigger('click')
+    await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[aria-label="Copy relative path"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Could not copy the relative path.')
+  })
+
   it('shows truncation and reloads with generated folders enabled', async () => {
     fetchMock.mockResolvedValue(directoryResponse('', [
       entry({ name: 'README.md', path: 'README.md' })
@@ -352,10 +373,99 @@ describe('WorkspaceFilesPanel', () => {
     await wrapper.get('[data-tree-path="src"]').trigger('click')
     await wrapper.get('input[type="checkbox"]').setValue(true)
     await flushPromises()
+    expect(wrapper.find('[data-tree-path="src/fresh.ts"]').exists()).toBe(true)
+    await wrapper.get('[aria-label="Copy relative path"]').trigger('click')
+    await flushPromises()
+    expect(clipboardWriteMock).toHaveBeenCalledWith('src')
     resolveOldRequest(directoryResponse('src', [entry({ name: 'stale.ts', path: 'src/stale.ts' })]))
     await flushPromises()
     expect(wrapper.find('[data-tree-path="src/stale.ts"]').exists()).toBe(false)
+    expect(wrapper.find('[data-tree-path="src/fresh.ts"]').exists()).toBe(true)
+  })
 
+  it('does not restore filter state into a workspace selected during reload', async () => {
+    let resolveFilteredRoot!: (value: ReturnType<typeof directoryResponse>) => void
+    const filteredRoot = new Promise<ReturnType<typeof directoryResponse>>((resolve) => {
+      resolveFilteredRoot = resolve
+    })
+    const snapshots = useState<Record<string, unknown>>('codori-workspace-files', () => ({}))
+    snapshots.value['chat:chat-test'] = {
+      generation: 1,
+      listings: {
+        '': directoryResponse('', [
+          entry({ name: 'src', path: 'src', kind: 'directory', size: null })
+        ]).directory
+      },
+      loadingPaths: [],
+      errors: {},
+      expandedPaths: [],
+      selectedPath: null,
+      currentPath: '',
+      showIgnored: false
+    }
+    fetchMock.mockImplementation((url: string) => {
+      const parsed = new URL(url, 'http://localhost')
+      const path = parsed.searchParams.get('path') ?? ''
+      if (parsed.pathname.includes('/projects/') && path === '' && parsed.searchParams.get('showIgnored') === 'true') {
+        return filteredRoot
+      }
+      return Promise.resolve(path === 'src'
+        ? directoryResponse('src', [])
+        : directoryResponse('', [entry({ name: 'src', path: 'src', kind: 'directory', size: null })]))
+    })
+
+    const wrapper = mountPanel()
+    await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-tree-path="src"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('input[type="checkbox"]').setValue(true)
+    await wrapper.setProps({
+      workspace: { kind: 'chat', id: 'chat-test' },
+      workspaceLabel: 'Scratch chat'
+    })
+    resolveFilteredRoot(directoryResponse('', [
+      entry({ name: 'src', path: 'src', kind: 'directory', size: null })
+    ]))
+    await flushPromises()
+
+    expect(fetchMock.mock.calls.some(([url]) => {
+      const parsed = new URL(url, 'http://localhost')
+      return parsed.pathname.includes('/chats/chat-test/files')
+        && parsed.searchParams.get('path') === 'src'
+    })).toBe(false)
+  })
+
+  it('resets stale navigation when a filter reload fails before retry', async () => {
+    let filteredRootRequests = 0
+    fetchMock.mockImplementation((url: string) => {
+      const parsed = new URL(url, 'http://localhost')
+      const path = parsed.searchParams.get('path') ?? ''
+      if (path === '' && parsed.searchParams.get('showIgnored') === 'true') {
+        filteredRootRequests += 1
+        if (filteredRootRequests === 1) {
+          return Promise.reject(new Error('Root unavailable'))
+        }
+      }
+      return Promise.resolve(path === 'src'
+        ? directoryResponse('src', [entry({ name: 'fresh.ts', path: 'src/fresh.ts' })])
+        : directoryResponse('', [entry({ name: 'src', path: 'src', kind: 'directory', size: null })]))
+    })
+
+    const wrapper = mountPanel()
+    await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('[data-tree-path="src"]').trigger('click')
+    await flushPromises()
+    await wrapper.get('input[type="checkbox"]').setValue(true)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Could not load workspace files')
+    expect(wrapper.get('[aria-label="Copy relative path"]').attributes('disabled')).toBeDefined()
+
+    const retry = wrapper.findAll('button').find(button => button.text() === 'Retry')
+    await retry?.trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-tree-path="src/fresh.ts"]').exists()).toBe(false)
     await wrapper.get('[data-tree-path="src"]').trigger('click')
     await flushPromises()
     expect(wrapper.find('[data-tree-path="src/fresh.ts"]').exists()).toBe(true)

--- a/packages/client/test/workspace-files-panel.test.ts
+++ b/packages/client/test/workspace-files-panel.test.ts
@@ -82,6 +82,7 @@ const TreeStub = defineComponent({
   props: {
     items: { type: Array, default: () => [] },
     expanded: { type: Array, default: () => [] },
+    ui: { type: Object, default: () => ({}) },
     onToggle: { type: Function, default: undefined },
     onSelect: { type: Function, default: undefined }
   },
@@ -193,6 +194,21 @@ describe('WorkspaceFilesPanel', () => {
       line: null,
       column: null
     }
+  })
+
+  it('keeps tree rows and labels left aligned beside their icons', async () => {
+    fetchMock.mockResolvedValue(directoryResponse('', [
+      entry({ name: 'README.md', path: 'README.md' })
+    ]))
+    const wrapper = mountPanel()
+    await wrapper.get('[aria-label="Browse workspace files"]').trigger('click')
+    await flushPromises()
+    const tree = wrapper.findComponent(TreeStub)
+
+    expect(tree.props('ui')).toMatchObject({
+      link: expect.stringContaining('justify-start'),
+      linkLabel: expect.stringContaining('text-left')
+    })
   })
 
   it('loads directories lazily and opens selected files in the existing viewer', async () => {

--- a/packages/client/test/workspace-files.test.ts
+++ b/packages/client/test/workspace-files.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  fallbackWorkspacePathAfterRemoval,
   resolveWorkspaceDirectoryUrl,
   workspacePathBreadcrumbs
 } from '../shared/workspace-files'
@@ -28,5 +29,11 @@ describe('workspace file helpers', () => {
       { label: 'components', path: 'src/components' },
       { label: 'tree', path: 'src/components/tree' }
     ])
+  })
+
+  it('falls back to the nearest surviving parent when a directory disappears', () => {
+    expect(fallbackWorkspacePathAfterRemoval('src/components/tree', 'src/components')).toBe('src')
+    expect(fallbackWorkspacePathAfterRemoval('src', 'src')).toBe('')
+    expect(fallbackWorkspacePathAfterRemoval('docs', 'src')).toBe('docs')
   })
 })

--- a/packages/client/test/workspace-files.test.ts
+++ b/packages/client/test/workspace-files.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveWorkspaceDirectoryUrl,
+  workspacePathBreadcrumbs
+} from '../shared/workspace-files'
+
+describe('workspace file helpers', () => {
+  it('builds project and chat directory URLs with root-relative paths', () => {
+    expect(resolveWorkspaceDirectoryUrl({
+      workspace: { kind: 'project', id: 'team/demo' },
+      path: 'src/components',
+      showIgnored: false,
+      configuredBase: 'https://codori.example.com'
+    })).toBe('/api/codori/projects/team%2Fdemo/files?path=src%2Fcomponents')
+
+    expect(resolveWorkspaceDirectoryUrl({
+      workspace: { kind: 'chat', id: 'chat one' },
+      path: '',
+      showIgnored: true,
+      configuredBase: null
+    })).toBe('http://127.0.0.1:4310/api/chats/chat%20one/files?path=&showIgnored=true')
+  })
+
+  it('creates cumulative breadcrumb paths without absolute host segments', () => {
+    expect(workspacePathBreadcrumbs('src/components/tree')).toEqual([
+      { label: 'Workspace', path: '' },
+      { label: 'src', path: 'src' },
+      { label: 'components', path: 'src/components' },
+      { label: 'tree', path: 'src/components/tree' }
+    ])
+  })
+})

--- a/packages/server/src/http-server.ts
+++ b/packages/server/src/http-server.ts
@@ -26,6 +26,11 @@ import { createGitBranch, listGitBranches, switchGitBranch } from './git.js'
 import { LocalFileViewError, readProjectLocalFile, type LocalFileReadResult } from './local-file-viewer.js'
 import { createRuntimeManager } from './process-manager.js'
 import {
+  listWorkspaceDirectory,
+  WorkspaceDirectoryError,
+  type WorkspaceDirectoryListing
+} from './workspace-file-explorer.js'
+import {
   createServiceUpdateController,
   type ServiceUpdateController,
   type ServiceUpdateStatus
@@ -118,6 +123,10 @@ type ProjectGitBranchMutationRequest = {
 
 type ProjectLocalFileResponse = {
   file: LocalFileReadResult
+}
+
+type WorkspaceDirectoryResponse = {
+  directory: WorkspaceDirectoryListing
 }
 
 export type HttpServerOptions = {
@@ -849,6 +858,42 @@ export const createHttpServer = async (
     }
   )
 
+  app.get<{ Params: { chatId: string }, Querystring: { path?: string, showIgnored?: string } }>(
+    '/api/chats/:chatId/files',
+    async (request, reply): Promise<WorkspaceDirectoryResponse | { error: { code: string, message: string } }> => {
+      if (!manager.getChatStatus) {
+        throw new CodoriError('INVALID_CONFIG', 'Chat lookup is not available.')
+      }
+
+      const chatId = getChatIdFromRequest(request.params.chatId)
+      const requestedPath = typeof request.query.path === 'string'
+        ? request.query.path
+        : ''
+      const chat = await resolveValue(manager.getChatStatus(chatId))
+      await touchChatActivity(manager, chatId)
+
+      try {
+        const directory = await listWorkspaceDirectory(chat.chatPath, requestedPath, {
+          showIgnored: request.query.showIgnored === 'true'
+        })
+        reply.header('cache-control', 'no-store')
+        return { directory }
+      } catch (error) {
+        if (error instanceof WorkspaceDirectoryError) {
+          reply.status(error.code === 'NOT_FOUND' || error.code === 'NOT_A_DIRECTORY' ? 404 : 403)
+          return {
+            error: {
+              code: error.code,
+              message: error.message
+            }
+          }
+        }
+
+        throw error
+      }
+    }
+  )
+
   app.get<{ Params: { chatId: string }, Querystring: { path?: string } }>(
     '/api/chats/:chatId/local-file',
     async (request, reply): Promise<ProjectLocalFileResponse | { error: { code: string, message: string } }> => {
@@ -1208,6 +1253,38 @@ export const createHttpServer = async (
       reply.header('content-disposition', `inline; filename="${basename(resolvedPath).replace(/"/g, '')}"`)
 
       return await readFile(resolvedPath)
+    }
+  )
+
+  app.get<{ Params: { projectId: string }, Querystring: { path?: string, showIgnored?: string } }>(
+    '/api/projects/:projectId/files',
+    async (request, reply): Promise<WorkspaceDirectoryResponse | { error: { code: string, message: string } }> => {
+      const projectId = getProjectIdFromRequest(request.params.projectId)
+      const requestedPath = typeof request.query.path === 'string'
+        ? request.query.path
+        : ''
+      const project = await resolveValue(manager.getProjectStatus(projectId))
+      await touchProjectActivity(manager, projectId)
+
+      try {
+        const directory = await listWorkspaceDirectory(project.projectPath, requestedPath, {
+          showIgnored: request.query.showIgnored === 'true'
+        })
+        reply.header('cache-control', 'no-store')
+        return { directory }
+      } catch (error) {
+        if (error instanceof WorkspaceDirectoryError) {
+          reply.status(error.code === 'NOT_FOUND' || error.code === 'NOT_A_DIRECTORY' ? 404 : 403)
+          return {
+            error: {
+              code: error.code,
+              message: error.message
+            }
+          }
+        }
+
+        throw error
+      }
     }
   )
 

--- a/packages/server/src/local-file-viewer.ts
+++ b/packages/server/src/local-file-viewer.ts
@@ -52,7 +52,7 @@ const hasBinaryContent = (buffer: Buffer) => {
 }
 
 const readFileWithinLimit = async (fileHandle: Awaited<ReturnType<typeof open>>) => {
-  const buffer = Buffer.allocUnsafe(MAX_LOCAL_FILE_VIEW_BYTES + 1)
+  const buffer = Buffer.alloc(MAX_LOCAL_FILE_VIEW_BYTES + 1)
   let offset = 0
 
   while (offset < buffer.length) {
@@ -157,7 +157,7 @@ export const readProjectLocalFile = async (
 
   const fileHandle = await open(
     resolvedTargetPath,
-    fsConstants.O_RDONLY | fsConstants.O_NONBLOCK
+    fsConstants.O_RDONLY | (fsConstants.O_NONBLOCK || 0)
   ).catch(() => null)
   if (!fileHandle) {
     throw new LocalFileViewError('NOT_FOUND', 'Local file not found.')

--- a/packages/server/src/local-file-viewer.ts
+++ b/packages/server/src/local-file-viewer.ts
@@ -1,7 +1,9 @@
-import { basename, relative, resolve } from 'node:path'
-import { readFile, realpath, stat } from 'node:fs/promises'
+import { basename, isAbsolute, relative, resolve } from 'node:path'
+import { constants as fsConstants } from 'node:fs'
+import { open, realpath } from 'node:fs/promises'
 import { lookup as lookupMimeType } from 'mime-types'
 import { isPathInsideDirectory } from './attachment-store.js'
+import { normalizeWorkspaceRelativePath, WorkspaceDirectoryError } from './workspace-file-explorer.js'
 
 export const MAX_LOCAL_FILE_VIEW_BYTES = 1024 * 1024
 
@@ -47,6 +49,26 @@ const hasBinaryContent = (buffer: Buffer) => {
   }
 
   return false
+}
+
+const readFileWithinLimit = async (fileHandle: Awaited<ReturnType<typeof open>>) => {
+  const buffer = Buffer.allocUnsafe(MAX_LOCAL_FILE_VIEW_BYTES + 1)
+  let offset = 0
+
+  while (offset < buffer.length) {
+    const { bytesRead } = await fileHandle.read(
+      buffer,
+      offset,
+      buffer.length - offset,
+      null
+    )
+    if (bytesRead === 0) {
+      break
+    }
+    offset += bytesRead
+  }
+
+  return buffer.subarray(0, offset)
 }
 
 const SUPPORTED_IMAGE_MEDIA_TYPES = new Set([
@@ -105,7 +127,22 @@ export const readProjectLocalFile = async (
   requestedPath: string
 ): Promise<LocalFileReadResult> => {
   const resolvedProjectRoot = await realpath(resolve(projectRoot))
-  const resolvedRequestPath = resolve(requestedPath)
+  let resolvedRequestPath: string
+  if (isAbsolute(requestedPath)) {
+    resolvedRequestPath = resolve(requestedPath)
+  } else {
+    try {
+      const relativePath = normalizeWorkspaceRelativePath(requestedPath)
+      resolvedRequestPath = relativePath
+        ? resolve(resolvedProjectRoot, ...relativePath.split('/'))
+        : resolvedProjectRoot
+    } catch (error) {
+      if (error instanceof WorkspaceDirectoryError) {
+        throw new LocalFileViewError('FORBIDDEN', 'Local file access is limited to the active project root.')
+      }
+      throw error
+    }
+  }
 
   let resolvedTargetPath: string
   try {
@@ -118,23 +155,39 @@ export const readProjectLocalFile = async (
     throw new LocalFileViewError('FORBIDDEN', 'Local file access is limited to the active project root.')
   }
 
-  const fileStat = await stat(resolvedTargetPath).catch(() => null)
-  if (!fileStat) {
+  const fileHandle = await open(
+    resolvedTargetPath,
+    fsConstants.O_RDONLY | fsConstants.O_NONBLOCK
+  ).catch(() => null)
+  if (!fileHandle) {
     throw new LocalFileViewError('NOT_FOUND', 'Local file not found.')
   }
 
-  if (!fileStat.isFile()) {
-    throw new LocalFileViewError('NOT_A_FILE', 'Only regular files can be previewed.')
-  }
+  let fileStat: Awaited<ReturnType<typeof fileHandle.stat>>
+  let buffer: Buffer
+  try {
+    fileStat = await fileHandle.stat()
+    if (!fileStat.isFile()) {
+      throw new LocalFileViewError('NOT_A_FILE', 'Only regular files can be previewed.')
+    }
 
-  if (fileStat.size > MAX_LOCAL_FILE_VIEW_BYTES) {
-    throw new LocalFileViewError(
-      'TOO_LARGE',
-      `Local file preview is limited to ${Math.floor(MAX_LOCAL_FILE_VIEW_BYTES / 1024)} KB.`
-    )
-  }
+    if (fileStat.size > MAX_LOCAL_FILE_VIEW_BYTES) {
+      throw new LocalFileViewError(
+        'TOO_LARGE',
+        `Local file preview is limited to ${Math.floor(MAX_LOCAL_FILE_VIEW_BYTES / 1024)} KB.`
+      )
+    }
 
-  const buffer = await readFile(resolvedTargetPath)
+    buffer = await readFileWithinLimit(fileHandle)
+    if (buffer.length > MAX_LOCAL_FILE_VIEW_BYTES) {
+      throw new LocalFileViewError(
+        'TOO_LARGE',
+        `Local file preview is limited to ${Math.floor(MAX_LOCAL_FILE_VIEW_BYTES / 1024)} KB.`
+      )
+    }
+  } finally {
+    await fileHandle.close()
+  }
   const baseFile = {
     path: resolvedTargetPath,
     relativePath: relative(resolvedProjectRoot, resolvedTargetPath),

--- a/packages/server/src/workspace-file-explorer.ts
+++ b/packages/server/src/workspace-file-explorer.ts
@@ -124,7 +124,7 @@ const inspectDirectoryEntry = async (input: {
     ? `${input.directoryPath}/${input.name}`
     : input.name
   const hidden = input.name.startsWith('.')
-  const ignored = IGNORED_PROJECT_DIRECTORY_NAMES.has(input.name)
+  const ignoredName = IGNORED_PROJECT_DIRECTORY_NAMES.has(input.name)
 
   let entryLstat: Awaited<ReturnType<typeof lstat>>
   try {
@@ -139,7 +139,7 @@ const inspectDirectoryEntry = async (input: {
       isSymlink: false,
       accessible: false,
       hidden,
-      ignored,
+      ignored: false,
       errorCode: toEntryErrorCode(error)
     }
   }
@@ -155,7 +155,7 @@ const inspectDirectoryEntry = async (input: {
       isSymlink,
       accessible: false,
       hidden,
-      ignored,
+      ignored: false,
       errorCode: 'UNSUPPORTED'
     }
   }
@@ -175,7 +175,7 @@ const inspectDirectoryEntry = async (input: {
         isSymlink: true,
         accessible: false,
         hidden,
-        ignored,
+        ignored: false,
         errorCode: toEntryErrorCode(error)
       }
     }
@@ -190,7 +190,7 @@ const inspectDirectoryEntry = async (input: {
         isSymlink: true,
         accessible: false,
         hidden,
-        ignored,
+        ignored: false,
         errorCode: 'FORBIDDEN'
       }
     }
@@ -209,7 +209,7 @@ const inspectDirectoryEntry = async (input: {
       isSymlink,
       accessible: false,
       hidden,
-      ignored,
+      ignored: false,
       errorCode: toEntryErrorCode(error)
     }
   }
@@ -224,7 +224,7 @@ const inspectDirectoryEntry = async (input: {
     isSymlink,
     accessible: kind === 'directory' || kind === 'file',
     hidden,
-    ignored
+    ignored: kind === 'directory' && ignoredName
   }
 }
 

--- a/packages/server/src/workspace-file-explorer.ts
+++ b/packages/server/src/workspace-file-explorer.ts
@@ -1,0 +1,331 @@
+import { lstat, opendir, realpath, stat } from 'node:fs/promises'
+import { isAbsolute, resolve } from 'node:path'
+import { isPathInsideDirectory } from './attachment-store.js'
+import { IGNORED_PROJECT_DIRECTORY_NAMES } from './project-scanner.js'
+
+export const MAX_WORKSPACE_DIRECTORY_ENTRIES = 200
+
+export type WorkspaceDirectoryEntryErrorCode =
+  | 'FORBIDDEN'
+  | 'NOT_FOUND'
+  | 'PERMISSION_DENIED'
+  | 'UNSUPPORTED'
+
+export type WorkspaceDirectoryEntry = {
+  name: string
+  path: string
+  kind: 'directory' | 'file' | 'other'
+  size: number | null
+  updatedAt: number | null
+  isSymlink: boolean
+  accessible: boolean
+  hidden: boolean
+  ignored: boolean
+  errorCode?: WorkspaceDirectoryEntryErrorCode
+}
+
+export type WorkspaceDirectoryListing = {
+  path: string
+  entries: WorkspaceDirectoryEntry[]
+  truncated: boolean
+  limit: number
+}
+
+export class WorkspaceDirectoryError extends Error {
+  readonly code: 'FORBIDDEN' | 'NOT_FOUND' | 'NOT_A_DIRECTORY' | 'PERMISSION_DENIED'
+
+  constructor(
+    code: WorkspaceDirectoryError['code'],
+    message: string
+  ) {
+    super(message)
+    this.name = 'WorkspaceDirectoryError'
+    this.code = code
+  }
+}
+
+const WINDOWS_ABSOLUTE_PATH_RE = /^[A-Za-z]:[\\/]/u
+
+export const normalizeWorkspaceRelativePath = (requestedPath: string) => {
+  if (requestedPath === '') {
+    return ''
+  }
+
+  if (
+    requestedPath.includes('\0')
+    || requestedPath.includes('\\')
+    || requestedPath.startsWith('/')
+    || WINDOWS_ABSOLUTE_PATH_RE.test(requestedPath)
+    || isAbsolute(requestedPath)
+  ) {
+    throw new WorkspaceDirectoryError(
+      'FORBIDDEN',
+      'Workspace directory paths must be root-relative.'
+    )
+  }
+
+  const segments = requestedPath.split('/')
+  if (segments.some(segment => segment === '' || segment === '.' || segment === '..')) {
+    throw new WorkspaceDirectoryError(
+      'FORBIDDEN',
+      'Workspace directory traversal is not allowed.'
+    )
+  }
+
+  return segments.join('/')
+}
+
+const toEntryErrorCode = (error: unknown): WorkspaceDirectoryEntryErrorCode => {
+  const code = (error as NodeJS.ErrnoException).code
+  if (code === 'EACCES' || code === 'EPERM') {
+    return 'PERMISSION_DENIED'
+  }
+  if (code === 'ENOENT' || code === 'ENOTDIR' || code === 'ELOOP') {
+    return 'NOT_FOUND'
+  }
+  return 'UNSUPPORTED'
+}
+
+const toDirectoryError = (error: unknown): WorkspaceDirectoryError => {
+  if (error instanceof WorkspaceDirectoryError) {
+    return error
+  }
+
+  const code = (error as NodeJS.ErrnoException).code
+  if (code === 'EACCES' || code === 'EPERM') {
+    return new WorkspaceDirectoryError('PERMISSION_DENIED', 'Workspace directory is not readable.')
+  }
+
+  if (code === 'ENOENT' || code === 'ENOTDIR' || code === 'ELOOP') {
+    return new WorkspaceDirectoryError('NOT_FOUND', 'Workspace directory not found.')
+  }
+
+  throw error
+}
+
+const classifyEntry = (entryStat: Awaited<ReturnType<typeof stat>>) => {
+  if (entryStat.isDirectory()) {
+    return 'directory' as const
+  }
+  if (entryStat.isFile()) {
+    return 'file' as const
+  }
+  return 'other' as const
+}
+
+const inspectDirectoryEntry = async (input: {
+  root: string
+  directory: string
+  directoryPath: string
+  name: string
+}): Promise<WorkspaceDirectoryEntry> => {
+  const entryPath = resolve(input.directory, input.name)
+  const relativePath = input.directoryPath
+    ? `${input.directoryPath}/${input.name}`
+    : input.name
+  const hidden = input.name.startsWith('.')
+  const ignored = IGNORED_PROJECT_DIRECTORY_NAMES.has(input.name)
+
+  let entryLstat: Awaited<ReturnType<typeof lstat>>
+  try {
+    entryLstat = await lstat(entryPath)
+  } catch (error) {
+    return {
+      name: input.name,
+      path: relativePath,
+      kind: 'other',
+      size: null,
+      updatedAt: null,
+      isSymlink: false,
+      accessible: false,
+      hidden,
+      ignored,
+      errorCode: toEntryErrorCode(error)
+    }
+  }
+
+  const isSymlink = entryLstat.isSymbolicLink()
+  if (input.name.includes('\\')) {
+    return {
+      name: input.name,
+      path: relativePath,
+      kind: 'other',
+      size: null,
+      updatedAt: entryLstat.mtimeMs,
+      isSymlink,
+      accessible: false,
+      hidden,
+      ignored,
+      errorCode: 'UNSUPPORTED'
+    }
+  }
+
+  let resolvedEntryPath = entryPath
+
+  if (isSymlink) {
+    try {
+      resolvedEntryPath = await realpath(entryPath)
+    } catch (error) {
+      return {
+        name: input.name,
+        path: relativePath,
+        kind: 'other',
+        size: null,
+        updatedAt: entryLstat.mtimeMs,
+        isSymlink: true,
+        accessible: false,
+        hidden,
+        ignored,
+        errorCode: toEntryErrorCode(error)
+      }
+    }
+
+    if (!isPathInsideDirectory(resolvedEntryPath, input.root)) {
+      return {
+        name: input.name,
+        path: relativePath,
+        kind: 'other',
+        size: null,
+        updatedAt: entryLstat.mtimeMs,
+        isSymlink: true,
+        accessible: false,
+        hidden,
+        ignored,
+        errorCode: 'FORBIDDEN'
+      }
+    }
+  }
+
+  let entryStat: Awaited<ReturnType<typeof stat>>
+  try {
+    entryStat = isSymlink ? await stat(resolvedEntryPath) : entryLstat
+  } catch (error) {
+    return {
+      name: input.name,
+      path: relativePath,
+      kind: 'other',
+      size: null,
+      updatedAt: entryLstat.mtimeMs,
+      isSymlink,
+      accessible: false,
+      hidden,
+      ignored,
+      errorCode: toEntryErrorCode(error)
+    }
+  }
+
+  const kind = classifyEntry(entryStat)
+  return {
+    name: input.name,
+    path: relativePath,
+    kind,
+    size: kind === 'file' ? entryStat.size : null,
+    updatedAt: entryStat.mtimeMs,
+    isSymlink,
+    accessible: kind === 'directory' || kind === 'file',
+    hidden,
+    ignored
+  }
+}
+
+const compareEntries = (left: WorkspaceDirectoryEntry, right: WorkspaceDirectoryEntry) => {
+  const leftDirectory = left.kind === 'directory' && left.accessible
+  const rightDirectory = right.kind === 'directory' && right.accessible
+  if (leftDirectory !== rightDirectory) {
+    return leftDirectory ? -1 : 1
+  }
+
+  if (left.name < right.name) {
+    return -1
+  }
+  if (left.name > right.name) {
+    return 1
+  }
+  return 0
+}
+
+export const listWorkspaceDirectory = async (
+  workspaceRoot: string,
+  requestedPath: string,
+  options: { showIgnored?: boolean } = {}
+): Promise<WorkspaceDirectoryListing> => {
+  const directoryPath = normalizeWorkspaceRelativePath(requestedPath)
+
+  let resolvedRoot: string
+  try {
+    resolvedRoot = await realpath(resolve(workspaceRoot))
+  } catch (error) {
+    throw toDirectoryError(error)
+  }
+
+  const requestedTarget = directoryPath
+    ? resolve(resolvedRoot, ...directoryPath.split('/'))
+    : resolvedRoot
+
+  let resolvedDirectory: string
+  try {
+    resolvedDirectory = await realpath(requestedTarget)
+  } catch (error) {
+    throw toDirectoryError(error)
+  }
+
+  if (!isPathInsideDirectory(resolvedDirectory, resolvedRoot)) {
+    throw new WorkspaceDirectoryError(
+      'FORBIDDEN',
+      'Workspace directory access is limited to the active workspace root.'
+    )
+  }
+
+  let directoryStat: Awaited<ReturnType<typeof stat>>
+  try {
+    directoryStat = await stat(resolvedDirectory)
+  } catch (error) {
+    throw toDirectoryError(error)
+  }
+
+  if (!directoryStat.isDirectory()) {
+    throw new WorkspaceDirectoryError('NOT_A_DIRECTORY', 'Workspace path is not a directory.')
+  }
+
+  let directoryHandle: Awaited<ReturnType<typeof opendir>>
+  try {
+    directoryHandle = await opendir(resolvedDirectory)
+  } catch (error) {
+    throw toDirectoryError(error)
+  }
+
+  const entries: WorkspaceDirectoryEntry[] = []
+  let truncated = false
+
+  try {
+    for await (const directoryEntry of directoryHandle) {
+      const entry = await inspectDirectoryEntry({
+        root: resolvedRoot,
+        directory: resolvedDirectory,
+        directoryPath,
+        name: directoryEntry.name
+      })
+      if (entry.kind === 'directory' && entry.ignored && !options.showIgnored) {
+        continue
+      }
+
+      if (entries.length >= MAX_WORKSPACE_DIRECTORY_ENTRIES) {
+        truncated = true
+        break
+      }
+
+      entries.push(entry)
+    }
+  } catch (error) {
+    throw toDirectoryError(error)
+  }
+
+  entries.sort(compareEntries)
+
+  return {
+    path: directoryPath,
+    entries,
+    truncated,
+    limit: MAX_WORKSPACE_DIRECTORY_ENTRIES
+  }
+}

--- a/packages/server/test/http-server.test.ts
+++ b/packages/server/test/http-server.test.ts
@@ -9,6 +9,7 @@ import WebSocket, { WebSocketServer } from 'ws'
 import { resolveProjectAttachmentsDir } from '../src/attachment-store.js'
 import { CodoriError } from '../src/errors.js'
 import { createHttpServer, startHttpServer, type RuntimeManagerLike } from '../src/http-server.js'
+import { MAX_LOCAL_FILE_VIEW_BYTES } from '../src/local-file-viewer.js'
 import type { ServiceUpdateController } from '../src/service-update.js'
 import type {
   ChatSessionStatusRecord,
@@ -1401,5 +1402,157 @@ describe('createHttpServer', () => {
         message: 'Binary files are not supported by the local file viewer.'
       }
     })
+  })
+
+  it('rejects oversized local files without reading beyond the preview bound', async () => {
+    const projectPath = mkdtempSync(join(os.tmpdir(), 'codori-local-file-'))
+    tempDirs.push(projectPath)
+    writeFileSync(join(projectPath, 'large.txt'), Buffer.alloc(MAX_LOCAL_FILE_VIEW_BYTES + 1, 0x61))
+    const app = await createHttpServer(createManager({
+      getProjectStatus: () => ({
+        ...createProjectRecord(),
+        projectPath
+      })
+    }))
+    startedApps.push(app)
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/projects/demo/local-file?path=large.txt'
+    })
+
+    expect(response.statusCode).toBe(415)
+    expect(response.json()).toMatchObject({
+      error: { code: 'TOO_LARGE' }
+    })
+  })
+
+  it('rejects named pipes without blocking the preview worker', async () => {
+    if (process.platform === 'win32') {
+      return
+    }
+
+    const projectPath = mkdtempSync(join(os.tmpdir(), 'codori-local-file-'))
+    tempDirs.push(projectPath)
+    execFileSync('mkfifo', [join(projectPath, 'preview.pipe')])
+    const app = await createHttpServer(createManager({
+      getProjectStatus: () => ({
+        ...createProjectRecord(),
+        projectPath
+      })
+    }))
+    startedApps.push(app)
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/projects/demo/local-file?path=preview.pipe'
+    })
+
+    expect(response.statusCode).toBe(404)
+    expect(response.json()).toMatchObject({
+      error: { code: 'NOT_A_FILE' }
+    })
+  })
+
+  it('lists bounded root-relative project directories without exposing absolute paths', async () => {
+    const projectPath = mkdtempSync(join(os.tmpdir(), 'codori-project-files-'))
+    tempDirs.push(projectPath)
+    mkdirSync(join(projectPath, 'src'))
+    mkdirSync(join(projectPath, 'node_modules'))
+    writeFileSync(join(projectPath, 'README.md'), '# Demo\n', 'utf8')
+
+    const app = await createHttpServer(createManager({
+      getProjectStatus: () => ({
+        ...createProjectRecord(),
+        projectPath
+      })
+    }))
+    startedApps.push(app)
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/projects/demo/files'
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.headers['cache-control']).toBe('no-store')
+    expect(response.json()).toMatchObject({
+      directory: {
+        path: '',
+        truncated: false,
+        limit: 200,
+        entries: [
+          { name: 'src', path: 'src', kind: 'directory' },
+          { name: 'README.md', path: 'README.md', kind: 'file' }
+        ]
+      }
+    })
+    expect(JSON.stringify(response.json())).not.toContain(projectPath)
+  })
+
+  it('provides matching nested directory listing and relative preview routes for chats', async () => {
+    const chatPath = mkdtempSync(join(os.tmpdir(), 'codori-chat-files-'))
+    tempDirs.push(chatPath)
+    mkdirSync(join(chatPath, 'notes'))
+    writeFileSync(join(chatPath, 'notes', 'today.md'), '# Today\n', 'utf8')
+
+    const app = await createHttpServer(createManager({
+      getChatStatus: () => ({
+        ...createChatRecord(),
+        chatPath
+      })
+    }))
+    startedApps.push(app)
+
+    const listingResponse = await app.inject({
+      method: 'GET',
+      url: '/api/chats/chat-test/files?path=notes'
+    })
+    expect(listingResponse.statusCode).toBe(200)
+    expect(listingResponse.json()).toMatchObject({
+      directory: {
+        path: 'notes',
+        entries: [
+          { name: 'today.md', path: 'notes/today.md', kind: 'file' }
+        ]
+      }
+    })
+
+    const previewResponse = await app.inject({
+      method: 'GET',
+      url: '/api/chats/chat-test/local-file?path=notes%2Ftoday.md'
+    })
+    expect(previewResponse.statusCode).toBe(200)
+    expect(previewResponse.json()).toMatchObject({
+      file: {
+        kind: 'text',
+        relativePath: 'notes/today.md',
+        text: '# Today\n'
+      }
+    })
+  })
+
+  it('rejects traversal and absolute injection in project directory routes', async () => {
+    const projectPath = mkdtempSync(join(os.tmpdir(), 'codori-project-files-'))
+    tempDirs.push(projectPath)
+    const app = await createHttpServer(createManager({
+      getProjectStatus: () => ({
+        ...createProjectRecord(),
+        projectPath
+      })
+    }))
+    startedApps.push(app)
+
+    for (const path of ['../outside', '/tmp/outside']) {
+      const response = await app.inject({
+        method: 'GET',
+        url: `/api/projects/demo/files?path=${encodeURIComponent(path)}`
+      })
+
+      expect(response.statusCode).toBe(403)
+      expect(response.json()).toMatchObject({
+        error: { code: 'FORBIDDEN' }
+      })
+    }
   })
 })

--- a/packages/server/test/workspace-file-explorer.test.ts
+++ b/packages/server/test/workspace-file-explorer.test.ts
@@ -1,0 +1,175 @@
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import { join, sep } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  listWorkspaceDirectory,
+  MAX_WORKSPACE_DIRECTORY_ENTRIES
+} from '../src/workspace-file-explorer.js'
+
+const tempPaths: string[] = []
+
+const createTempDirectory = (prefix: string) => {
+  const directory = mkdtempSync(join(os.tmpdir(), prefix))
+  tempPaths.push(directory)
+  return directory
+}
+
+afterEach(() => {
+  for (const path of tempPaths.splice(0)) {
+    rmSync(path, { recursive: true, force: true })
+  }
+})
+
+describe('listWorkspaceDirectory', () => {
+  it('lists direct children with stable directory-first ordering and useful dotfiles', async () => {
+    const root = createTempDirectory('codori-workspace-files-')
+    mkdirSync(join(root, 'src'))
+    mkdirSync(join(root, '.github'))
+    mkdirSync(join(root, 'node_modules'))
+    writeFileSync(join(root, 'zeta.txt'), 'zeta\n', 'utf8')
+    writeFileSync(join(root, 'Alpha.txt'), 'alpha\n', 'utf8')
+    writeFileSync(join(root, '.env.example'), 'KEY=value\n', 'utf8')
+    writeFileSync(join(root, 'dist'), 'release marker\n', 'utf8')
+
+    const listing = await listWorkspaceDirectory(root, '')
+
+    expect(listing.path).toBe('')
+    expect(listing.truncated).toBe(false)
+    expect(listing.limit).toBe(MAX_WORKSPACE_DIRECTORY_ENTRIES)
+    expect(listing.entries.map(entry => entry.name)).toEqual([
+      '.github',
+      'src',
+      '.env.example',
+      'Alpha.txt',
+      'dist',
+      'zeta.txt'
+    ])
+    expect(listing.entries.find(entry => entry.name === 'Alpha.txt')).toMatchObject({
+      path: 'Alpha.txt',
+      kind: 'file',
+      size: 6,
+      accessible: true,
+      hidden: false,
+      ignored: false
+    })
+  })
+
+  it('reveals ignored heavy directories only when requested', async () => {
+    const root = createTempDirectory('codori-workspace-files-')
+    mkdirSync(join(root, 'node_modules'))
+    mkdirSync(join(root, 'dist'))
+
+    expect((await listWorkspaceDirectory(root, '')).entries).toEqual([])
+
+    const listing = await listWorkspaceDirectory(root, '', { showIgnored: true })
+    expect(listing.entries.map(entry => entry.name)).toEqual(['dist', 'node_modules'])
+    expect(listing.entries.every(entry => entry.ignored)).toBe(true)
+  })
+
+  it('loads nested directories lazily through normalized relative paths', async () => {
+    const root = createTempDirectory('codori-workspace-files-')
+    mkdirSync(join(root, 'src', 'nested'), { recursive: true })
+    writeFileSync(join(root, 'src', 'nested', '한글.md'), '# 안녕\n', 'utf8')
+
+    const listing = await listWorkspaceDirectory(root, 'src/nested')
+
+    expect(listing.path).toBe('src/nested')
+    expect(listing.entries).toEqual([
+      expect.objectContaining({
+        name: '한글.md',
+        path: 'src/nested/한글.md',
+        kind: 'file',
+        accessible: true
+      })
+    ])
+  })
+
+  it.each([
+    '../outside',
+    'src/../outside',
+    './src',
+    '/tmp/outside',
+    'C:/outside',
+    'src\\nested'
+  ])('rejects non-normalized or absolute paths: %s', async (requestedPath) => {
+    const root = createTempDirectory('codori-workspace-files-')
+
+    await expect(listWorkspaceDirectory(root, requestedPath)).rejects.toMatchObject({
+      code: 'FORBIDDEN'
+    })
+  })
+
+  it('keeps broken and outside symlinks visible but inaccessible', async () => {
+    const root = createTempDirectory('codori-workspace-files-')
+    const outside = createTempDirectory('codori-workspace-outside-')
+    mkdirSync(join(root, 'inside'))
+    writeFileSync(join(root, 'inside', 'ok.txt'), 'ok\n', 'utf8')
+    writeFileSync(join(outside, 'secret.txt'), 'secret\n', 'utf8')
+    symlinkSync(join(root, 'inside'), join(root, 'inside-link'))
+    symlinkSync(join(outside, 'secret.txt'), join(root, 'outside-link'))
+    symlinkSync(join(root, 'missing'), join(root, 'broken-link'))
+
+    const listing = await listWorkspaceDirectory(root, '')
+
+    expect(listing.entries.find(entry => entry.name === 'inside-link')).toMatchObject({
+      kind: 'directory',
+      isSymlink: true,
+      accessible: true
+    })
+    expect(listing.entries.find(entry => entry.name === 'outside-link')).toMatchObject({
+      kind: 'other',
+      isSymlink: true,
+      accessible: false,
+      errorCode: 'FORBIDDEN'
+    })
+    expect(listing.entries.find(entry => entry.name === 'broken-link')).toMatchObject({
+      kind: 'other',
+      isSymlink: true,
+      accessible: false,
+      errorCode: 'NOT_FOUND'
+    })
+
+    await expect(listWorkspaceDirectory(root, 'outside-link')).rejects.toMatchObject({
+      code: 'FORBIDDEN'
+    })
+  })
+
+  it('marks non-portable backslash names as inaccessible on POSIX', async () => {
+    if (sep === '\\') {
+      return
+    }
+
+    const root = createTempDirectory('codori-workspace-files-')
+    writeFileSync(join(root, 'back\\slash.txt'), 'content\n', 'utf8')
+
+    expect((await listWorkspaceDirectory(root, '')).entries).toEqual([
+      expect.objectContaining({
+        name: 'back\\slash.txt',
+        accessible: false,
+        errorCode: 'UNSUPPORTED'
+      })
+    ])
+  })
+
+  it('enforces a fixed bound and reports truncation', async () => {
+    const root = createTempDirectory('codori-workspace-files-')
+    for (let index = 0; index <= MAX_WORKSPACE_DIRECTORY_ENTRIES; index += 1) {
+      writeFileSync(join(root, `file-${String(index).padStart(3, '0')}.txt`), '', 'utf8')
+    }
+
+    const listing = await listWorkspaceDirectory(root, '')
+
+    expect(listing.entries).toHaveLength(MAX_WORKSPACE_DIRECTORY_ENTRIES)
+    expect(listing.truncated).toBe(true)
+  })
+
+  it('rejects files used as directory targets', async () => {
+    const root = createTempDirectory('codori-workspace-files-')
+    writeFileSync(join(root, 'README.md'), '# Demo\n', 'utf8')
+
+    await expect(listWorkspaceDirectory(root, 'README.md')).rejects.toMatchObject({
+      code: 'NOT_A_DIRECTORY'
+    })
+  })
+})

--- a/packages/server/test/workspace-file-explorer.test.ts
+++ b/packages/server/test/workspace-file-explorer.test.ts
@@ -53,6 +53,10 @@ describe('listWorkspaceDirectory', () => {
       hidden: false,
       ignored: false
     })
+    expect(listing.entries.find(entry => entry.name === 'dist')).toMatchObject({
+      kind: 'file',
+      ignored: false
+    })
   })
 
   it('reveals ignored heavy directories only when requested', async () => {


### PR DESCRIPTION
## Summary

- add dedicated project and projectless-chat directory routes that accept workspace-relative paths, canonicalize every request, reject traversal and symlink escape, and cap each lazy listing at 200 entries
- extend the existing local-file preview to accept relative explorer paths while preserving absolute transcript-link compatibility, with bounded nonblocking descriptor reads
- add a responsive Nuxt UI fullscreen workspace explorer with a left-aligned lazy file tree, an in-modal right-side file preview, a clear empty preview state, and project/projectless-chat top action-bar entry points
- keep the explorer open while files are selected, reuse the extracted preview renderer in the existing fullscreen transcript file viewer, and preserve read-only behavior throughout
- document the read-only behavior, hidden/generated-directory policy, and workspace-root boundary

## Commits

- `943d246` (`feat: add bounded workspace file directory API`)
- `660a895` (`feat: add workspace file explorer UI`)
- `37daccf` (`docs: document workspace file explorer`)
- `5e09a2c` (`fix: harden workspace explorer edge cases`)
- `6fe3ff5` (`fix: address workspace explorer review feedback`)
- `93a0db5` (`fix: left align workspace file tree labels`)
- `b43de85` (`feat: add split workspace file preview`)
- `7a6ad72` (`refactor: move workspace files to top actions`)
- `261c481` (`refactor: simplify workspace file tree controls`)

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (46 client files / 327 tests; 12 server files / 108 tests)
- `pnpm build`
- real Chrome smoke test against the built server: a single top action-bar trigger, fullscreen left/right split geometry, empty preview guidance, computed left-aligned tree labels, README and package.json selection without closing the explorer, real JSON preview rendering, and zero console errors

## Review follow-up

- `6fe3ff5` adds explicit Clipboard API and Windows open-flag guards, uses zero-filled bounded preview buffers, and preserves validated explorer navigation across generated-folder filter reloads with scope/generation race protection
- all six review threads were assessed, answered, and resolved; natural locale sorting and unbounded `Promise.all` collection were intentionally declined because they conflict with the stable locale-independent ordering and bounded-listing contracts
- focused follow-up validation: 15 client tests and 49 server tests, plus client/server typecheck and lint; the full test/build validation above was rerun after the review fixes

## UX follow-up

- `93a0db5` aligns tree rows and labels directly after their leading icons
- `b43de85` extracts the shared local-file preview and replaces the explorer slideover/handoff with a fullscreen responsive split modal
- `7a6ad72` moves project and projectless-chat explorer entry points from the prompt footer into their top action bars
- `261c481` removes the modal subtitle and generated-folder checkbox, then places refresh and relative-path copy in an accessible fixed action group beneath the file tree

## Main integration

- the feature commits are rebased directly onto PR #83's merge commit `43d5a82`, so `origin/main` is a direct ancestor and the feature branch has no integration merge commit
- the rebase conflict in the shared workspace shell was resolved by preserving both features: the file explorer remains in the top action bars while the workspace terminal remains in its PR #83 locations
- the rebased result is tree-identical to the previously validated integration commit, and full lint, typecheck, test, and production build validation was rerun afterward

## Risks and known gaps

- Device pairing/authentication (#77) and Tailscale Serve (#78) are intentionally deferred. This PR targets local or user-managed private-network operation; those issues remain related future hardening.
- Every request revalidates the canonical workspace boundary. Portable Node path APIs cannot fully eliminate a malicious concurrent symlink-swap race without `openat`/`O_NOFOLLOW`-style component traversal; preview reads reduce exposure through nonblocking descriptor checks and a strict sentinel bound.
- Large directory responses are intentionally capped rather than paginated. Returned entries are sorted consistently within the bounded response, and truncation is explicit in the UI.
- The explorer is strictly read-only: it adds no create, edit, rename, move, copy, delete, upload-to-path, trash, or restore operations.

Closes #80
